### PR TITLE
Fixes for some memory leaks

### DIFF
--- a/SymCryptEngine/src/sc_ossl_ecc.h
+++ b/SymCryptEngine/src/sc_ossl_ecc.h
@@ -16,9 +16,9 @@ typedef int (*PFN_eckey_set_group)(EC_KEY *key, const EC_GROUP *grp);
 typedef int (*PFN_eckey_set_private)(EC_KEY *key, const BIGNUM *priv_key);
 typedef int (*PFN_eckey_set_public)(EC_KEY *key, const EC_POINT *pub_key);
 
-int sc_ossl_eckey_init(EC_KEY *key);
+// int sc_ossl_eckey_init(EC_KEY *key);
 void sc_ossl_eckey_finish(EC_KEY *key);
-// int sc_ossl_eckey_copy(EC_KEY *dest, const EC_KEY *src);
+// int sc_ossl_eckey_copy(EC_KEY *dst, const EC_KEY *src);
 // int sc_ossl_eckey_set_group(EC_KEY *key, const EC_GROUP *grp);
 // int sc_ossl_eckey_set_private(EC_KEY *key, const BIGNUM *priv_key);
 // int sc_ossl_eckey_set_public(EC_KEY *key, const EC_POINT *pub_key);

--- a/SymCryptEngine/src/sc_ossl_rsa.c
+++ b/SymCryptEngine/src/sc_ossl_rsa.c
@@ -1274,8 +1274,15 @@ int sc_ossl_rsa_finish(RSA *rsa)
 {
     SC_OSSL_LOG_DEBUG(NULL);
     SC_OSSL_RSA_KEY_CONTEXT *keyCtx = RSA_get_ex_data(rsa, rsa_sc_ossl_idx);
-    sc_ossl_rsa_free_key_context(keyCtx);
-    RSA_set_ex_data(rsa, rsa_sc_ossl_idx, NULL);
+    if( keyCtx )
+    {
+        if( keyCtx->initialized == 1 )
+        {
+            sc_ossl_rsa_free_key_context(keyCtx);
+        }
+        OPENSSL_free(keyCtx);
+        RSA_set_ex_data(rsa, rsa_sc_ossl_idx, NULL);
+    }
     return 1;
 }
 


### PR DESCRIPTION
+ In sc_ossl_rsa_finish free exdata if it is non-NULL
  + And do not dereference exdata if it is NULL
+ In ECC, do not initialize exdata until we know we will definitely be
  using it (and not falling back to default implementation)
  + Rather than using the curve to determine whether to free exdata
    members, use the initialized field
  + Always free the exdata if it is non-NULL
+ Also in ECDSA, handle DER encoded ECDSA signatures for P192 and P224