### PR TITLE
Simplify digest memory allocation

### DIFF
--- a/SymCryptEngine/src/sc_ossl_digests.c
+++ b/SymCryptEngine/src/sc_ossl_digests.c
@@ -10,32 +10,34 @@
 extern "C" {
 #endif
 
+static int sc_ossl_digest_nids[] = {
+    NID_md5,
+    NID_sha1,
+    NID_sha256,
+    NID_sha384,
+    NID_sha512
+};
+
 /* MD5 */
-typedef struct _SC_OSSL_MD_MD5_STATE {
-    PSYMCRYPT_MD5_STATE state;
-} SC_OSSL_MD_MD5_STATE, *PSC_OSSL_MD_MD5_STATE;
 static int sc_ossl_digest_md5_init(EVP_MD_CTX *ctx);
 static int sc_ossl_digest_md5_update(EVP_MD_CTX *ctx, const void *data, size_t count);
 static int sc_ossl_digest_md5_final(EVP_MD_CTX *ctx, unsigned char *md);
 static int sc_ossl_digest_md5_copy(EVP_MD_CTX *to, const EVP_MD_CTX *from);
-static int sc_ossl_digest_md5_cleanup(EVP_MD_CTX *ctx);
 static EVP_MD *_hidden_md5_md = NULL;
 static const EVP_MD *sc_ossl_digest_md5(void)
 {
     SC_OSSL_LOG_DEBUG(NULL);
     if (_hidden_md5_md == NULL) {
         EVP_MD *md;
-
         if ((md = EVP_MD_meth_new(NID_md5, NID_md5WithRSAEncryption)) == NULL
             || !EVP_MD_meth_set_result_size(md, MD5_DIGEST_LENGTH)
             || !EVP_MD_meth_set_input_blocksize(md, MD5_CBLOCK)
-            || !EVP_MD_meth_set_app_datasize(md, sizeof(EVP_MD *) + sizeof(SC_OSSL_MD_MD5_STATE))
+            || !EVP_MD_meth_set_app_datasize(md, sizeof(SYMCRYPT_MD5_STATE))
             || !EVP_MD_meth_set_flags(md, 0)
             || !EVP_MD_meth_set_init(md, sc_ossl_digest_md5_init)
             || !EVP_MD_meth_set_update(md, sc_ossl_digest_md5_update)
             || !EVP_MD_meth_set_final(md, sc_ossl_digest_md5_final)
             || !EVP_MD_meth_set_copy(md, sc_ossl_digest_md5_copy)
-            || !EVP_MD_meth_set_cleanup(md, sc_ossl_digest_md5_cleanup)
             )
         {
             EVP_MD_meth_free(md);
@@ -47,31 +49,26 @@ static const EVP_MD *sc_ossl_digest_md5(void)
 }
 
 /* SHA1 */
-typedef struct _SC_OSSL_MD_SHA1_STATE {
-    PSYMCRYPT_SHA1_STATE state;
-} SC_OSSL_MD_SHA1_STATE, *PSC_OSSL_MD_SHA1_STATE;
 static int sc_ossl_digest_sha1_init(EVP_MD_CTX *ctx);
 static int sc_ossl_digest_sha1_update(EVP_MD_CTX *ctx, const void *data, size_t count);
 static int sc_ossl_digest_sha1_final(EVP_MD_CTX *ctx, unsigned char *md);
 static int sc_ossl_digest_sha1_copy(EVP_MD_CTX *to, const EVP_MD_CTX *from);
-static int sc_ossl_digest_sha1_cleanup(EVP_MD_CTX *ctx);
 static EVP_MD *_hidden_sha1_md = NULL;
 static const EVP_MD *sc_ossl_digest_sha1(void)
 {
     SC_OSSL_LOG_DEBUG(NULL);
-    if (_hidden_sha1_md == NULL) {
+    if( _hidden_sha1_md == NULL )
+    {
         EVP_MD *md;
-
-        if ((md = EVP_MD_meth_new(NID_sha1, NID_sha1WithRSAEncryption)) == NULL
+        if( (md = EVP_MD_meth_new(NID_sha1, NID_sha1WithRSAEncryption)) == NULL
             || !EVP_MD_meth_set_result_size(md, SHA_DIGEST_LENGTH)
             || !EVP_MD_meth_set_input_blocksize(md, SHA_CBLOCK)
-            || !EVP_MD_meth_set_app_datasize(md, sizeof(EVP_MD *) + sizeof(SC_OSSL_MD_SHA1_STATE))
+            || !EVP_MD_meth_set_app_datasize(md, sizeof(SYMCRYPT_SHA1_STATE))
             || !EVP_MD_meth_set_flags(md, EVP_MD_FLAG_DIGALGID_ABSENT)
             || !EVP_MD_meth_set_init(md, sc_ossl_digest_sha1_init)
             || !EVP_MD_meth_set_update(md, sc_ossl_digest_sha1_update)
             || !EVP_MD_meth_set_final(md, sc_ossl_digest_sha1_final)
             || !EVP_MD_meth_set_copy(md, sc_ossl_digest_sha1_copy)
-            || !EVP_MD_meth_set_cleanup(md, sc_ossl_digest_sha1_cleanup)
             )
         {
             EVP_MD_meth_free(md);
@@ -83,30 +80,26 @@ static const EVP_MD *sc_ossl_digest_sha1(void)
 }
 
 /* SHA256 */
-typedef struct _SC_OSSL_MD_SHA256_STATE {
-    PSYMCRYPT_SHA256_STATE state;
-} SC_OSSL_MD_SHA256_STATE, *PSC_OSSL_MD_SHA256_STATE;
 static int sc_ossl_digest_sha256_init(EVP_MD_CTX *ctx);
 static int sc_ossl_digest_sha256_update(EVP_MD_CTX *ctx, const void *data, size_t count);
 static int sc_ossl_digest_sha256_final(EVP_MD_CTX *ctx, unsigned char *md);
 static int sc_ossl_digest_sha256_copy(EVP_MD_CTX *to, const EVP_MD_CTX *from);
-static int sc_ossl_digest_sha256_cleanup(EVP_MD_CTX *ctx);
 static EVP_MD *_hidden_sha256_md = NULL;
 static const EVP_MD *sc_ossl_digest_sha256(void)
 {
     SC_OSSL_LOG_DEBUG(NULL);
-    if (_hidden_sha256_md == NULL) {
+    if( _hidden_sha256_md == NULL )
+    {
         EVP_MD *md;
-        if ((md = EVP_MD_meth_new(NID_sha256, NID_sha256WithRSAEncryption)) == NULL
+        if( (md = EVP_MD_meth_new(NID_sha256, NID_sha256WithRSAEncryption)) == NULL
             || !EVP_MD_meth_set_result_size(md, SHA256_DIGEST_LENGTH)
             || !EVP_MD_meth_set_input_blocksize(md, SHA256_CBLOCK)
-            || !EVP_MD_meth_set_app_datasize(md, sizeof(EVP_MD *) + sizeof(SC_OSSL_MD_SHA256_STATE))
+            || !EVP_MD_meth_set_app_datasize(md, sizeof(SYMCRYPT_SHA256_STATE))
             || !EVP_MD_meth_set_flags(md, EVP_MD_FLAG_DIGALGID_ABSENT)
             || !EVP_MD_meth_set_init(md, sc_ossl_digest_sha256_init)
             || !EVP_MD_meth_set_update(md, sc_ossl_digest_sha256_update)
             || !EVP_MD_meth_set_final(md, sc_ossl_digest_sha256_final)
             || !EVP_MD_meth_set_copy(md, sc_ossl_digest_sha256_copy)
-            || !EVP_MD_meth_set_cleanup(md, sc_ossl_digest_sha256_cleanup)
             )
         {
             EVP_MD_meth_free(md);
@@ -118,31 +111,26 @@ static const EVP_MD *sc_ossl_digest_sha256(void)
 }
 
 /* SHA384 */
-typedef struct _SC_OSSL_MD_SHA384_STATE {
-    PSYMCRYPT_SHA384_STATE state;
-} SC_OSSL_MD_SHA384_STATE, *PSC_OSSL_MD_SHA384_STATE;
 static int sc_ossl_digest_sha384_init(EVP_MD_CTX *ctx);
 static int sc_ossl_digest_sha384_update(EVP_MD_CTX *ctx, const void *data, size_t count);
 static int sc_ossl_digest_sha384_final(EVP_MD_CTX *ctx, unsigned char *md);
 static int sc_ossl_digest_sha384_copy(EVP_MD_CTX *to, const EVP_MD_CTX *from);
-static int sc_ossl_digest_sha384_cleanup(EVP_MD_CTX *ctx);
 static EVP_MD *_hidden_sha384_md = NULL;
 static const EVP_MD *sc_ossl_digest_sha384(void)
 {
     SC_OSSL_LOG_DEBUG(NULL);
-    if (_hidden_sha384_md == NULL) {
+    if( _hidden_sha384_md == NULL )
+    {
         EVP_MD *md;
-
-        if ((md = EVP_MD_meth_new(NID_sha384, NID_sha384WithRSAEncryption)) == NULL
+        if( (md = EVP_MD_meth_new(NID_sha384, NID_sha384WithRSAEncryption)) == NULL
             || !EVP_MD_meth_set_result_size(md, SHA384_DIGEST_LENGTH)
             || !EVP_MD_meth_set_input_blocksize(md, SHA512_CBLOCK)
-            || !EVP_MD_meth_set_app_datasize(md, sizeof(EVP_MD *) + sizeof(SC_OSSL_MD_SHA384_STATE))
+            || !EVP_MD_meth_set_app_datasize(md, sizeof(SYMCRYPT_SHA384_STATE))
             || !EVP_MD_meth_set_flags(md, EVP_MD_FLAG_DIGALGID_ABSENT)
             || !EVP_MD_meth_set_init(md, sc_ossl_digest_sha384_init)
             || !EVP_MD_meth_set_update(md, sc_ossl_digest_sha384_update)
             || !EVP_MD_meth_set_final(md, sc_ossl_digest_sha384_final)
             || !EVP_MD_meth_set_copy(md, sc_ossl_digest_sha384_copy)
-            || !EVP_MD_meth_set_cleanup(md, sc_ossl_digest_sha384_cleanup)
             )
         {
             EVP_MD_meth_free(md);
@@ -154,31 +142,26 @@ static const EVP_MD *sc_ossl_digest_sha384(void)
 }
 
 /* SHA512 */
-typedef struct _SC_OSSL_MD_SHA512_STATE {
-    PSYMCRYPT_SHA512_STATE state;
-} SC_OSSL_MD_SHA512_STATE, *PSC_OSSL_MD_SHA512_STATE;
 static int sc_ossl_digest_sha512_init(EVP_MD_CTX *ctx);
 static int sc_ossl_digest_sha512_update(EVP_MD_CTX *ctx, const void *data, size_t count);
 static int sc_ossl_digest_sha512_final(EVP_MD_CTX *ctx, unsigned char *md);
 static int sc_ossl_digest_sha512_copy(EVP_MD_CTX *to, const EVP_MD_CTX *from);
-static int sc_ossl_digest_sha512_cleanup(EVP_MD_CTX *ctx);
 static EVP_MD *_hidden_sha512_md = NULL;
 static const EVP_MD *sc_ossl_digest_sha512(void)
 {
     SC_OSSL_LOG_DEBUG(NULL);
-    if (_hidden_sha512_md == NULL) {
+    if( _hidden_sha512_md == NULL )
+    {
         EVP_MD *md;
-
-        if ((md = EVP_MD_meth_new(NID_sha512, NID_sha512WithRSAEncryption)) == NULL
+        if( (md = EVP_MD_meth_new(NID_sha512, NID_sha512WithRSAEncryption)) == NULL
             || !EVP_MD_meth_set_result_size(md, SHA512_DIGEST_LENGTH)
             || !EVP_MD_meth_set_input_blocksize(md, SHA512_CBLOCK)
-            || !EVP_MD_meth_set_app_datasize(md, sizeof(EVP_MD *) + sizeof(SC_OSSL_MD_SHA512_STATE))
+            || !EVP_MD_meth_set_app_datasize(md, sizeof(SYMCRYPT_SHA512_STATE))
             || !EVP_MD_meth_set_flags(md, EVP_MD_FLAG_DIGALGID_ABSENT)
             || !EVP_MD_meth_set_init(md, sc_ossl_digest_sha512_init)
             || !EVP_MD_meth_set_update(md, sc_ossl_digest_sha512_update)
             || !EVP_MD_meth_set_final(md, sc_ossl_digest_sha512_final)
             || !EVP_MD_meth_set_copy(md, sc_ossl_digest_sha512_copy)
-            || !EVP_MD_meth_set_cleanup(md, sc_ossl_digest_sha512_cleanup)
             )
         {
             EVP_MD_meth_free(md);
@@ -188,6 +171,7 @@ static const EVP_MD *sc_ossl_digest_sha512(void)
     }
     return _hidden_sha512_md;
 }
+
 void sc_ossl_destroy_digests(void)
 {
     SC_OSSL_LOG_DEBUG(NULL);
@@ -202,43 +186,23 @@ void sc_ossl_destroy_digests(void)
     EVP_MD_meth_free(_hidden_sha512_md);
     _hidden_sha512_md = NULL;
 }
-static int sc_ossl_digest_nids(const int **nids)
-{
-    SC_OSSL_LOG_DEBUG(NULL);
-    static int sc_ossl_digest_nids[6] = { 0, 0, 0, 0, 0, 0 };
-    static int pos = 0;
-    static int init = 0;
-
-    if (!init) {
-        const EVP_MD *md;
-        if ((md = sc_ossl_digest_md5()) != NULL)
-            sc_ossl_digest_nids[pos++] = EVP_MD_type(md);
-        if ((md = sc_ossl_digest_sha1()) != NULL)
-            sc_ossl_digest_nids[pos++] = EVP_MD_type(md);
-        if ((md = sc_ossl_digest_sha256()) != NULL)
-            sc_ossl_digest_nids[pos++] = EVP_MD_type(md);
-        if ((md = sc_ossl_digest_sha384()) != NULL)
-            sc_ossl_digest_nids[pos++] = EVP_MD_type(md);
-        if ((md = sc_ossl_digest_sha512()) != NULL)
-            sc_ossl_digest_nids[pos++] = EVP_MD_type(md);
-        sc_ossl_digest_nids[pos] = 0;
-        init = 1;
-    }
-    *nids = sc_ossl_digest_nids;
-    return pos;
-}
 
 int sc_ossl_digests(ENGINE *e, const EVP_MD **digest,
                           const int **nids, int nid)
 {
     SC_OSSL_LOG_DEBUG(NULL);
     int ok = 1;
-    if (!digest) {
+    if( !digest )
+    {
         /* We are returning a list of supported nids */
-        return sc_ossl_digest_nids(nids);
+        *nids = sc_ossl_digest_nids;
+        return (sizeof(sc_ossl_digest_nids))
+               / sizeof(sc_ossl_digest_nids[0]);
     }
+
     /* We are being asked for a specific digest */
-    switch (nid) {
+    switch (nid)
+    {
     case NID_md5:
         *digest = sc_ossl_digest_md5();
         break;
@@ -268,17 +232,14 @@ int sc_ossl_digests(ENGINE *e, const EVP_MD **digest,
 static int sc_ossl_digest_md5_init(EVP_MD_CTX *ctx)
 {
     SC_OSSL_LOG_DEBUG(NULL);
-    PSC_OSSL_MD_MD5_STATE md_state = (PSC_OSSL_MD_MD5_STATE)EVP_MD_CTX_md_data(ctx);
-    if (md_state == NULL) {
+    PSYMCRYPT_MD5_STATE state = (PSYMCRYPT_MD5_STATE)EVP_MD_CTX_md_data(ctx);
+    if( state == NULL )
+    {
         SC_OSSL_LOG_ERROR("No MD Data Present");
         return 0;
     }
-    md_state->state = (PSYMCRYPT_MD5_STATE)OPENSSL_zalloc(sizeof(SYMCRYPT_MD5_STATE));
-    if (md_state->state == NULL) {
-        SC_OSSL_LOG_ERROR("Memory Allocation Error");
-        return 0;
-    }
-    SymCryptMd5Init(md_state->state);
+
+    SymCryptMd5Init(state);
     return 1;
 }
 
@@ -286,59 +247,48 @@ static int sc_ossl_digest_md5_update(EVP_MD_CTX *ctx, const void *data,
                              size_t count)
 {
     SC_OSSL_LOG_DEBUG("Count: %d", count);
-    PSC_OSSL_MD_MD5_STATE md_state = (PSC_OSSL_MD_MD5_STATE)EVP_MD_CTX_md_data(ctx);
-    if (md_state == NULL || md_state->state == NULL) {
+    PSYMCRYPT_MD5_STATE state = (PSYMCRYPT_MD5_STATE)EVP_MD_CTX_md_data(ctx);
+    if( state == NULL )
+    {
         SC_OSSL_LOG_ERROR("No MD Data Present");
         return 0;
     }
-    SymCryptMd5Append(md_state->state, data, count);
+
+    SymCryptMd5Append(state, data, count);
     return 1;
 }
 
 static int sc_ossl_digest_md5_final(EVP_MD_CTX *ctx, unsigned char *md)
 {
     SC_OSSL_LOG_DEBUG(NULL);
-    PSC_OSSL_MD_MD5_STATE md_state = (PSC_OSSL_MD_MD5_STATE)EVP_MD_CTX_md_data(ctx);
-    if (md_state == NULL || md_state->state == NULL) {
+    PSYMCRYPT_MD5_STATE state = (PSYMCRYPT_MD5_STATE)EVP_MD_CTX_md_data(ctx);
+    if( state == NULL )
+    {
         SC_OSSL_LOG_ERROR("No MD Data Present");
         return 0;
     }
-    SymCryptMd5Result(md_state->state, md);
+
+    SymCryptMd5Result(state, md);
     return 1;
 }
 
 static int sc_ossl_digest_md5_copy(EVP_MD_CTX *to, const EVP_MD_CTX *from)
 {
     SC_OSSL_LOG_DEBUG(NULL);
-    PSC_OSSL_MD_MD5_STATE md_state_to = (PSC_OSSL_MD_MD5_STATE)EVP_MD_CTX_md_data(to);
-    PSC_OSSL_MD_MD5_STATE md_state_from = (PSC_OSSL_MD_MD5_STATE)EVP_MD_CTX_md_data(from);
-    if (md_state_from == NULL)  {
+    PSYMCRYPT_MD5_STATE state_to = (PSYMCRYPT_MD5_STATE)EVP_MD_CTX_md_data(to);
+    PSYMCRYPT_MD5_STATE state_from = (PSYMCRYPT_MD5_STATE)EVP_MD_CTX_md_data(from);
+    if( state_to == NULL )
+    {
+        SC_OSSL_LOG_DEBUG("No MD 'to' Present");
+        return 1;
+    }
+    if( state_from == NULL )
+    {
         SC_OSSL_LOG_DEBUG("No MD 'from' Present");
         return 1;
     }
-    if (md_state_from->state == NULL)  {
-        SC_OSSL_LOG_DEBUG("No MD Symcrypt State Present in 'from'");
-        return 1;
-    }
 
-    md_state_to->state = (PSYMCRYPT_MD5_STATE)OPENSSL_zalloc(sizeof(SYMCRYPT_MD5_STATE));
-    if (md_state_to->state == NULL) {
-        SC_OSSL_LOG_ERROR("Memory Allocation Error");
-        return 0;
-    }
-
-    SymCryptMd5StateCopy(md_state_from->state, md_state_to->state);
-    return 1;
-}
-
-static int sc_ossl_digest_md5_cleanup(EVP_MD_CTX *ctx)
-{
-    SC_OSSL_LOG_DEBUG(NULL);
-    PSC_OSSL_MD_MD5_STATE md_state = (PSC_OSSL_MD_MD5_STATE)EVP_MD_CTX_md_data(ctx);
-    if (md_state != NULL && md_state->state != NULL) {
-        OPENSSL_free(md_state->state);
-        md_state->state = NULL;
-    }
+    SymCryptMd5StateCopy(state_from, state_to);
     return 1;
 }
 
@@ -348,17 +298,14 @@ static int sc_ossl_digest_md5_cleanup(EVP_MD_CTX *ctx)
 static int sc_ossl_digest_sha1_init(EVP_MD_CTX *ctx)
 {
     SC_OSSL_LOG_DEBUG(NULL);
-    PSC_OSSL_MD_SHA1_STATE md_state = (PSC_OSSL_MD_SHA1_STATE)EVP_MD_CTX_md_data(ctx);
-    if (md_state == NULL) {
+    PSYMCRYPT_SHA1_STATE state = (PSYMCRYPT_SHA1_STATE)EVP_MD_CTX_md_data(ctx);
+    if( state == NULL )
+    {
         SC_OSSL_LOG_ERROR("No MD Data Present");
         return 0;
     }
-    md_state->state = (PSYMCRYPT_SHA1_STATE)OPENSSL_zalloc(sizeof(SYMCRYPT_SHA1_STATE));
-    if (md_state->state == NULL) {
-        SC_OSSL_LOG_ERROR("Memory Allocation Error");
-        return 0;
-    }
-    SymCryptSha1Init(md_state->state);
+
+    SymCryptSha1Init(state);
     return 1;
 }
 
@@ -366,59 +313,48 @@ static int sc_ossl_digest_sha1_update(EVP_MD_CTX *ctx, const void *data,
                               size_t count)
 {
     SC_OSSL_LOG_DEBUG("Count: %d", count);
-    PSC_OSSL_MD_SHA1_STATE md_state = (PSC_OSSL_MD_SHA1_STATE)EVP_MD_CTX_md_data(ctx);
-    if (md_state == NULL || md_state->state == NULL) {
+    PSYMCRYPT_SHA1_STATE state = (PSYMCRYPT_SHA1_STATE)EVP_MD_CTX_md_data(ctx);
+    if( state == NULL )
+    {
         SC_OSSL_LOG_ERROR("No MD Data Present");
         return 0;
     }
-    SymCryptSha1Append(md_state->state, data, count);
+
+    SymCryptSha1Append(state, data, count);
     return 1;
 }
 
 static int sc_ossl_digest_sha1_final(EVP_MD_CTX *ctx, unsigned char *md)
 {
     SC_OSSL_LOG_DEBUG(NULL);
-    PSC_OSSL_MD_SHA1_STATE md_state = (PSC_OSSL_MD_SHA1_STATE)EVP_MD_CTX_md_data(ctx);
-    if (md_state == NULL || md_state->state == NULL) {
+    PSYMCRYPT_SHA1_STATE state = (PSYMCRYPT_SHA1_STATE)EVP_MD_CTX_md_data(ctx);
+    if( state == NULL )
+    {
         SC_OSSL_LOG_ERROR("No MD Data Present");
         return 0;
     }
-    SymCryptSha1Result(md_state->state, md);
+
+    SymCryptSha1Result(state, md);
     return 1;
 }
 
 static int sc_ossl_digest_sha1_copy(EVP_MD_CTX *to, const EVP_MD_CTX *from)
 {
     SC_OSSL_LOG_DEBUG(NULL);
-    PSC_OSSL_MD_SHA1_STATE md_state_to = (PSC_OSSL_MD_SHA1_STATE)EVP_MD_CTX_md_data(to);
-    PSC_OSSL_MD_SHA1_STATE md_state_from = (PSC_OSSL_MD_SHA1_STATE)EVP_MD_CTX_md_data(from);
-    if (md_state_from == NULL)  {
+    PSYMCRYPT_SHA1_STATE state_to = (PSYMCRYPT_SHA1_STATE)EVP_MD_CTX_md_data(to);
+    PSYMCRYPT_SHA1_STATE state_from = (PSYMCRYPT_SHA1_STATE)EVP_MD_CTX_md_data(from);
+    if( state_to == NULL )
+    {
+        SC_OSSL_LOG_DEBUG("No MD 'to' Present");
+        return 1;
+    }
+    if( state_from == NULL )
+    {
         SC_OSSL_LOG_DEBUG("No MD 'from' Present");
         return 1;
     }
-    if (md_state_from->state == NULL)  {
-        SC_OSSL_LOG_DEBUG("No MD Symcrypt State Present in 'from'");
-        return 1;
-    }
 
-    md_state_to->state = (PSYMCRYPT_SHA1_STATE)OPENSSL_zalloc(sizeof(SYMCRYPT_SHA1_STATE));
-    if (md_state_to->state == NULL) {
-        SC_OSSL_LOG_ERROR("Memory Allocation Error");
-        return 0;
-    }
-
-    SymCryptSha1StateCopy(md_state_from->state, md_state_to->state);
-    return 1;
-}
-
-static int sc_ossl_digest_sha1_cleanup(EVP_MD_CTX *ctx)
-{
-    SC_OSSL_LOG_DEBUG(NULL);
-    PSC_OSSL_MD_SHA1_STATE md_state = (PSC_OSSL_MD_SHA1_STATE)EVP_MD_CTX_md_data(ctx);
-    if (md_state != NULL && md_state->state != NULL) {
-        OPENSSL_free(md_state->state);
-        md_state->state = NULL;
-    }
+    SymCryptSha1StateCopy(state_from, state_to);
     return 1;
 }
 
@@ -429,17 +365,14 @@ static int sc_ossl_digest_sha1_cleanup(EVP_MD_CTX *ctx)
 static int sc_ossl_digest_sha256_init(EVP_MD_CTX *ctx)
 {
     SC_OSSL_LOG_DEBUG(NULL);
-    PSC_OSSL_MD_SHA256_STATE md_state = (PSC_OSSL_MD_SHA256_STATE)EVP_MD_CTX_md_data(ctx);
-    if (md_state == NULL) {
+    PSYMCRYPT_SHA256_STATE state = (PSYMCRYPT_SHA256_STATE)EVP_MD_CTX_md_data(ctx);
+    if( state == NULL )
+    {
         SC_OSSL_LOG_ERROR("No MD Data Present");
         return 0;
     }
-    md_state->state = (PSYMCRYPT_SHA256_STATE)OPENSSL_zalloc(sizeof(SYMCRYPT_SHA256_STATE));
-    if (md_state->state == NULL) {
-        SC_OSSL_LOG_ERROR("Memory Allocation Error");
-        return 0;
-    }
-    SymCryptSha256Init(md_state->state);
+
+    SymCryptSha256Init(state);
     return 1;
 }
 
@@ -447,59 +380,48 @@ static int sc_ossl_digest_sha256_update(EVP_MD_CTX *ctx, const void *data,
                                 size_t count)
 {
     SC_OSSL_LOG_DEBUG("Count: %d", count);
-    PSC_OSSL_MD_SHA256_STATE md_state = (PSC_OSSL_MD_SHA256_STATE)EVP_MD_CTX_md_data(ctx);
-    if (md_state == NULL || md_state->state == NULL) {
+    PSYMCRYPT_SHA256_STATE state = (PSYMCRYPT_SHA256_STATE)EVP_MD_CTX_md_data(ctx);
+    if( state == NULL )
+    {
         SC_OSSL_LOG_ERROR("No MD Data Present");
         return 0;
     }
-    SymCryptSha256Append(md_state->state, data, count);
+
+    SymCryptSha256Append(state, data, count);
     return 1;
 }
 
 static int sc_ossl_digest_sha256_final(EVP_MD_CTX *ctx, unsigned char *md)
 {
     SC_OSSL_LOG_DEBUG(NULL);
-    PSC_OSSL_MD_SHA256_STATE md_state = (PSC_OSSL_MD_SHA256_STATE)EVP_MD_CTX_md_data(ctx);
-    if (md_state == NULL || md_state->state == NULL) {
+    PSYMCRYPT_SHA256_STATE state = (PSYMCRYPT_SHA256_STATE)EVP_MD_CTX_md_data(ctx);
+    if( state == NULL )
+    {
         SC_OSSL_LOG_ERROR("No MD Data Present");
         return 0;
     }
-    SymCryptSha256Result(md_state->state, md);
+
+    SymCryptSha256Result(state, md);
     return 1;
 }
 
 static int sc_ossl_digest_sha256_copy(EVP_MD_CTX *to, const EVP_MD_CTX *from)
 {
     SC_OSSL_LOG_DEBUG(NULL);
-    PSC_OSSL_MD_SHA256_STATE md_state_to = (PSC_OSSL_MD_SHA256_STATE)EVP_MD_CTX_md_data(to);
-    PSC_OSSL_MD_SHA256_STATE md_state_from = (PSC_OSSL_MD_SHA256_STATE)EVP_MD_CTX_md_data(from);
-    if (md_state_from == NULL)  {
+    PSYMCRYPT_SHA256_STATE state_to = (PSYMCRYPT_SHA256_STATE)EVP_MD_CTX_md_data(to);
+    PSYMCRYPT_SHA256_STATE state_from = (PSYMCRYPT_SHA256_STATE)EVP_MD_CTX_md_data(from);
+    if( state_to == NULL )
+    {
+        SC_OSSL_LOG_DEBUG("No MD 'to' Present");
+        return 1;
+    }
+    if( state_from == NULL )
+    {
         SC_OSSL_LOG_DEBUG("No MD 'from' Present");
         return 1;
     }
-    if (md_state_from->state == NULL)  {
-        SC_OSSL_LOG_DEBUG("No MD Symcrypt State Present in 'from'");
-        return 1;
-    }
 
-    md_state_to->state = (PSYMCRYPT_SHA256_STATE)OPENSSL_zalloc(sizeof(SYMCRYPT_SHA256_STATE));
-    if (md_state_to->state == NULL) {
-        SC_OSSL_LOG_ERROR("Memory Allocation Error");
-        return 0;
-    }
-
-    SymCryptSha256StateCopy(md_state_from->state, md_state_to->state);
-    return 1;
-}
-
-static int sc_ossl_digest_sha256_cleanup(EVP_MD_CTX *ctx)
-{
-    SC_OSSL_LOG_DEBUG(NULL);
-    PSC_OSSL_MD_SHA256_STATE md_state = (PSC_OSSL_MD_SHA256_STATE)EVP_MD_CTX_md_data(ctx);
-    if (md_state != NULL && md_state->state != NULL) {
-        OPENSSL_free(md_state->state);
-        md_state->state = NULL;
-    }
+    SymCryptSha256StateCopy(state_from, state_to);
     return 1;
 }
 
@@ -509,17 +431,14 @@ static int sc_ossl_digest_sha256_cleanup(EVP_MD_CTX *ctx)
 static int sc_ossl_digest_sha384_init(EVP_MD_CTX *ctx)
 {
     SC_OSSL_LOG_DEBUG(NULL);
-    PSC_OSSL_MD_SHA384_STATE md_state = (PSC_OSSL_MD_SHA384_STATE)EVP_MD_CTX_md_data(ctx);
-    if (md_state == NULL) {
+    PSYMCRYPT_SHA384_STATE state = (PSYMCRYPT_SHA384_STATE)EVP_MD_CTX_md_data(ctx);
+    if( state == NULL )
+    {
         SC_OSSL_LOG_ERROR("No MD Data Present");
         return 0;
     }
-    md_state->state = (PSYMCRYPT_SHA384_STATE)OPENSSL_zalloc(sizeof(SYMCRYPT_SHA384_STATE));
-    if (md_state->state == NULL) {
-        SC_OSSL_LOG_ERROR("Memory Allocation Error");
-        return 0;
-    }
-    SymCryptSha384Init(md_state->state);
+
+    SymCryptSha384Init(state);
     return 1;
 }
 
@@ -527,62 +446,50 @@ static int sc_ossl_digest_sha384_update(EVP_MD_CTX *ctx, const void *data,
                                 size_t count)
 {
     SC_OSSL_LOG_DEBUG("Count: %d", count);
-    PSC_OSSL_MD_SHA384_STATE md_state = (PSC_OSSL_MD_SHA384_STATE)EVP_MD_CTX_md_data(ctx);
-    if (md_state == NULL || md_state->state == NULL) {
+    PSYMCRYPT_SHA384_STATE state = (PSYMCRYPT_SHA384_STATE)EVP_MD_CTX_md_data(ctx);
+    if( state == NULL )
+    {
         SC_OSSL_LOG_ERROR("No MD Data Present");
         return 0;
     }
-    SymCryptSha384Append(md_state->state, data, count);
+
+    SymCryptSha384Append(state, data, count);
     return 1;
 }
 
 static int sc_ossl_digest_sha384_final(EVP_MD_CTX *ctx, unsigned char *md)
 {
     SC_OSSL_LOG_DEBUG(NULL);
-    PSC_OSSL_MD_SHA384_STATE md_state = (PSC_OSSL_MD_SHA384_STATE)EVP_MD_CTX_md_data(ctx);
-    if (md_state == NULL || md_state->state == NULL) {
+    PSYMCRYPT_SHA384_STATE state = (PSYMCRYPT_SHA384_STATE)EVP_MD_CTX_md_data(ctx);
+    if( state == NULL )
+    {
         SC_OSSL_LOG_ERROR("No MD Data Present");
         return 0;
     }
-    SymCryptSha384Result(md_state->state, md);
+
+    SymCryptSha384Result(state, md);
     return 1;
 }
 
 static int sc_ossl_digest_sha384_copy(EVP_MD_CTX *to, const EVP_MD_CTX *from)
 {
     SC_OSSL_LOG_DEBUG(NULL);
-    PSC_OSSL_MD_SHA384_STATE md_state_to = (PSC_OSSL_MD_SHA384_STATE)EVP_MD_CTX_md_data(to);
-    PSC_OSSL_MD_SHA384_STATE md_state_from = (PSC_OSSL_MD_SHA384_STATE)EVP_MD_CTX_md_data(from);
-    if (md_state_from == NULL)  {
+    PSYMCRYPT_SHA384_STATE state_to = (PSYMCRYPT_SHA384_STATE)EVP_MD_CTX_md_data(to);
+    PSYMCRYPT_SHA384_STATE state_from = (PSYMCRYPT_SHA384_STATE)EVP_MD_CTX_md_data(from);
+    if( state_to == NULL )
+    {
+        SC_OSSL_LOG_DEBUG("No MD 'to' Present");
+        return 1;
+    }
+    if( state_from == NULL )
+    {
         SC_OSSL_LOG_DEBUG("No MD 'from' Present");
         return 1;
     }
-    if (md_state_from->state == NULL)  {
-        SC_OSSL_LOG_DEBUG("No MD Symcrypt State Present in 'from'");
-        return 1;
-    }
 
-    md_state_to->state = (PSYMCRYPT_SHA384_STATE)OPENSSL_zalloc(sizeof(SYMCRYPT_SHA384_STATE));
-    if (md_state_to->state == NULL) {
-        SC_OSSL_LOG_ERROR("Memory Allocation Error");
-        return 0;
-    }
-
-    SymCryptSha384StateCopy(md_state_from->state, md_state_to->state);
+    SymCryptSha384StateCopy(state_from, state_to);
     return 1;
 }
-
-static int sc_ossl_digest_sha384_cleanup(EVP_MD_CTX *ctx)
-{
-    SC_OSSL_LOG_DEBUG(NULL);
-    PSC_OSSL_MD_SHA384_STATE md_state = (PSC_OSSL_MD_SHA384_STATE)EVP_MD_CTX_md_data(ctx);
-    if (md_state != NULL && md_state->state != NULL) {
-        OPENSSL_free(md_state->state);
-        md_state->state = NULL;
-    }
-    return 1;
-}
-
 
 /*
  * SHA512 implementation.
@@ -590,17 +497,14 @@ static int sc_ossl_digest_sha384_cleanup(EVP_MD_CTX *ctx)
 static int sc_ossl_digest_sha512_init(EVP_MD_CTX *ctx)
 {
     SC_OSSL_LOG_DEBUG(NULL);
-    PSC_OSSL_MD_SHA512_STATE md_state = (PSC_OSSL_MD_SHA512_STATE)EVP_MD_CTX_md_data(ctx);
-    if (md_state == NULL) {
+    PSYMCRYPT_SHA512_STATE state = (PSYMCRYPT_SHA512_STATE)EVP_MD_CTX_md_data(ctx);
+    if( state == NULL )
+    {
         SC_OSSL_LOG_ERROR("No MD Data Present");
         return 0;
     }
-    md_state->state = (PSYMCRYPT_SHA512_STATE)OPENSSL_zalloc(sizeof(SYMCRYPT_SHA512_STATE));
-    if (md_state->state == NULL) {
-        SC_OSSL_LOG_ERROR("Memory Allocation Error");
-        return 0;
-    }
-    SymCryptSha512Init(md_state->state);
+
+    SymCryptSha512Init(state);
     return 1;
 }
 
@@ -608,59 +512,48 @@ static int sc_ossl_digest_sha512_update(EVP_MD_CTX *ctx, const void *data,
                                 size_t count)
 {
     SC_OSSL_LOG_DEBUG("Count: %d", count);
-    PSC_OSSL_MD_SHA512_STATE md_state = (PSC_OSSL_MD_SHA512_STATE)EVP_MD_CTX_md_data(ctx);
-    if (md_state == NULL || md_state->state == NULL) {
+    PSYMCRYPT_SHA512_STATE state = (PSYMCRYPT_SHA512_STATE)EVP_MD_CTX_md_data(ctx);
+    if( state == NULL )
+    {
         SC_OSSL_LOG_ERROR("No MD Data Present");
         return 0;
     }
-    SymCryptSha512Append(md_state->state, data, count);
+
+    SymCryptSha512Append(state, data, count);
     return 1;
 }
 
 static int sc_ossl_digest_sha512_final(EVP_MD_CTX *ctx, unsigned char *md)
 {
     SC_OSSL_LOG_DEBUG(NULL);
-    PSC_OSSL_MD_SHA512_STATE md_state = (PSC_OSSL_MD_SHA512_STATE)EVP_MD_CTX_md_data(ctx);
-    if (md_state == NULL || md_state->state == NULL) {
+    PSYMCRYPT_SHA512_STATE state = (PSYMCRYPT_SHA512_STATE)EVP_MD_CTX_md_data(ctx);
+    if( state == NULL )
+    {
         SC_OSSL_LOG_ERROR("No MD Data Present");
         return 0;
     }
-    SymCryptSha512Result(md_state->state, md);
+
+    SymCryptSha512Result(state, md);
     return 1;
 }
 
 static int sc_ossl_digest_sha512_copy(EVP_MD_CTX *to, const EVP_MD_CTX *from)
 {
     SC_OSSL_LOG_DEBUG(NULL);
-    PSC_OSSL_MD_SHA512_STATE md_state_to = (PSC_OSSL_MD_SHA512_STATE)EVP_MD_CTX_md_data(to);
-    PSC_OSSL_MD_SHA512_STATE md_state_from = (PSC_OSSL_MD_SHA512_STATE)EVP_MD_CTX_md_data(from);
-    if (md_state_from == NULL)  {
+    PSYMCRYPT_SHA512_STATE state_to = (PSYMCRYPT_SHA512_STATE)EVP_MD_CTX_md_data(to);
+    PSYMCRYPT_SHA512_STATE state_from = (PSYMCRYPT_SHA512_STATE)EVP_MD_CTX_md_data(from);
+    if( state_to == NULL )
+    {
+        SC_OSSL_LOG_DEBUG("No MD 'to' Present");
+        return 1;
+    }
+    if( state_from == NULL )
+    {
         SC_OSSL_LOG_DEBUG("No MD 'from' Present");
         return 1;
     }
-    if (md_state_from->state == NULL)  {
-        SC_OSSL_LOG_DEBUG("No MD Symcrypt State Present in 'from'");
-        return 1;
-    }
 
-    md_state_to->state = (PSYMCRYPT_SHA512_STATE)OPENSSL_zalloc(sizeof(SYMCRYPT_SHA512_STATE));
-    if (md_state_to->state == NULL) {
-        SC_OSSL_LOG_ERROR("Memory Allocation Error");
-        return 0;
-    }
-
-    SymCryptSha512StateCopy(md_state_from->state, md_state_to->state);
-    return 1;
-}
-
-static int sc_ossl_digest_sha512_cleanup(EVP_MD_CTX *ctx)
-{
-    SC_OSSL_LOG_DEBUG(NULL);
-    PSC_OSSL_MD_SHA512_STATE md_state = (PSC_OSSL_MD_SHA512_STATE)EVP_MD_CTX_md_data(ctx);
-    if (md_state != NULL && md_state->state != NULL) {
-        OPENSSL_free(md_state->state);
-        md_state->state = NULL;
-    }
+    SymCryptSha512StateCopy(state_from, state_to);
     return 1;
 }
 

--- a/SymCryptEngine/src/sc_ossl_ecc.c
+++ b/SymCryptEngine/src/sc_ossl_ecc.c
@@ -1186,7 +1186,11 @@ int sc_ossl_eckey_compute_key(unsigned char **psec,
     res = *pseclen;
 
 cleanup:
-    // Always free the temporary BIGNUMs and BN_CTX
+    // Always free the temporary pkPublic, BIGNUMs and BN_CTX
+    if( pkPublic )
+    {
+        SymCryptEckeyFree(pkPublic);
+    }
     if( ec_pub_x != NULL )
     {
         BN_free(ec_pub_x);
@@ -1203,10 +1207,6 @@ cleanup:
     return res;
 
 err:
-    if( pkPublic )
-    {
-        SymCryptEckeyFree(pkPublic);
-    }
     if( *psec )
     {
         OPENSSL_free(*psec);

--- a/SymCryptEngine/src/sc_ossl_rsa.c
+++ b/SymCryptEngine/src/sc_ossl_rsa.c
@@ -26,6 +26,11 @@ typedef int (*PFN_RSA_meth_pub_dec)(int flen, const unsigned char* from,
 typedef int (*PFN_RSA_meth_priv_dec)(int flen, const unsigned char *from,
                         unsigned char *to, RSA *rsa, int padding);
 
+// The minimum PKCS1 padding is 11 bytes
+#define SC_OSSL_MIN_PKCS1_PADDING (11)
+// The minimum OAEP padding is 2*hashlen + 2, and the minimum hashlen is SHA1 - with 20B hash => minimum 42B of padding
+#define SC_OSSL_MIN_OAEP_PADDING (42)
+
 int sc_ossl_rsa_pub_enc(int flen, const unsigned char* from,
     unsigned char* to, RSA* rsa,
     int padding)
@@ -63,7 +68,7 @@ int sc_ossl_rsa_pub_enc(int flen, const unsigned char* from,
     {
     case RSA_PKCS1_PADDING:
         SC_OSSL_LOG_DEBUG("SymCryptRsaPkcs1Encrypt");
-        if( flen > cbModulus - 11 )
+        if( flen > cbModulus - SC_OSSL_MIN_PKCS1_PADDING )
         {
             goto err;
         }
@@ -85,7 +90,7 @@ int sc_ossl_rsa_pub_enc(int flen, const unsigned char* from,
         break;
     case RSA_PKCS1_OAEP_PADDING:
         SC_OSSL_LOG_DEBUG("SymCryptRsaOaepEncrypt");
-        if( flen > cbModulus - 42 )
+        if( flen > cbModulus - SC_OSSL_MIN_OAEP_PADDING )
         {
             goto err;
         }
@@ -223,7 +228,7 @@ int sc_ossl_rsa_priv_dec(int flen, const unsigned char* from,
                        SYMCRYPT_NUMBER_FORMAT_MSB_FIRST,
                        0,
                        to,
-                       cbModulus - 11,
+                       cbModulus - SC_OSSL_MIN_PKCS1_PADDING,
                        &cbResult);
         SC_OSSL_LOG_DEBUG("cbResult: %ld", cbResult);
         if( SymError != SYMCRYPT_NO_ERROR )
@@ -244,7 +249,7 @@ int sc_ossl_rsa_priv_dec(int flen, const unsigned char* from,
                        0,
                        0,
                        to,
-                       cbModulus - 42,
+                       cbModulus - SC_OSSL_MIN_OAEP_PADDING,
                        &cbResult);
         SC_OSSL_LOG_DEBUG("cbResult: %ld", cbResult);
         if( SymError != SYMCRYPT_NO_ERROR )

--- a/SymCryptEngine/src/sc_ossl_rsa.c
+++ b/SymCryptEngine/src/sc_ossl_rsa.c
@@ -32,7 +32,7 @@ int sc_ossl_rsa_pub_enc(int flen, const unsigned char* from,
 {
     SC_OSSL_LOG_DEBUG(NULL);
     SYMCRYPT_ERROR SymError = SYMCRYPT_NO_ERROR;
-    BN_ULONG cbModuls = 0;
+    BN_ULONG cbModulus = 0;
     BN_ULONG cbResult = 0;
     const RSA_METHOD *ossl_rsa_meth = NULL;
     PFN_RSA_meth_pub_enc pfn_rsa_meth_pub_enc = NULL;
@@ -51,21 +51,30 @@ int sc_ossl_rsa_pub_enc(int flen, const unsigned char* from,
         }
     }
 
-    cbModuls= SymCryptRsakeySizeofModulus(keyCtx->key);
-    SC_OSSL_LOG_DEBUG("from: %X, flen: %d, cbModuls: %ld", from, flen, cbModuls);
+    cbModulus= SymCryptRsakeySizeofModulus(keyCtx->key);
+    SC_OSSL_LOG_DEBUG("from: %X, flen: %d, cbModulus: %ld", from, flen, cbModulus);
+
+    if( from == NULL )
+    {
+        goto err;
+    }
 
     switch( padding )
     {
     case RSA_PKCS1_PADDING:
         SC_OSSL_LOG_DEBUG("SymCryptRsaPkcs1Encrypt");
+        if( flen > cbModulus - 11 )
+        {
+            goto err;
+        }
         SymError = SymCryptRsaPkcs1Encrypt(
                        keyCtx->key,
                        from,
-                       flen > cbModuls ? cbModuls : flen,
+                       flen,
                        0,
                        SYMCRYPT_NUMBER_FORMAT_MSB_FIRST,
                        to,
-                       cbModuls,
+                       cbModulus,
                        &cbResult);
         SC_OSSL_LOG_DEBUG("cbResult: %ld", cbResult);
         if( SymError != SYMCRYPT_NO_ERROR )
@@ -76,17 +85,21 @@ int sc_ossl_rsa_pub_enc(int flen, const unsigned char* from,
         break;
     case RSA_PKCS1_OAEP_PADDING:
         SC_OSSL_LOG_DEBUG("SymCryptRsaOaepEncrypt");
+        if( flen > cbModulus - 42 )
+        {
+            goto err;
+        }
         SymError = SymCryptRsaOaepEncrypt(
                        keyCtx->key,
                        from,
-                       flen > cbModuls ? cbModuls : flen,
+                       flen,
                        SymCryptSha1Algorithm,
                        NULL,
                        0,
                        0,
                        SYMCRYPT_NUMBER_FORMAT_MSB_FIRST,
                        to,
-                       cbModuls,
+                       cbModulus,
                        &cbResult);
         SC_OSSL_LOG_DEBUG("cbResult: %ld", cbResult);
         if( SymError != SYMCRYPT_NO_ERROR )
@@ -97,15 +110,19 @@ int sc_ossl_rsa_pub_enc(int flen, const unsigned char* from,
         break;
     case RSA_NO_PADDING:
         SC_OSSL_LOG_DEBUG("SymCryptRsaRawEncrypt");
+        if( flen != cbModulus )
+        {
+            goto err;
+        }
         SymError = SymCryptRsaRawEncrypt(
                        keyCtx->key,
                        from,
-                       flen > cbModuls ? cbModuls : flen,
+                       flen,
                        SYMCRYPT_NUMBER_FORMAT_MSB_FIRST,
                        0,
                        to,
-                       cbModuls);
-        cbResult = cbModuls;
+                       cbModulus);
+        cbResult = cbModulus;
         SC_OSSL_LOG_DEBUG("cbResult: %ld", cbResult);
         if( SymError != SYMCRYPT_NO_ERROR )
         {
@@ -160,7 +177,7 @@ int sc_ossl_rsa_priv_dec(int flen, const unsigned char* from,
 {
     SC_OSSL_LOG_DEBUG(NULL);
     SYMCRYPT_ERROR SymError = SYMCRYPT_NO_ERROR;
-    BN_ULONG cbModuls = 0;
+    BN_ULONG cbModulus = 0;
     BN_ULONG cbResult = 0;
     const RSA_METHOD *ossl_rsa_meth = NULL;
     PFN_RSA_meth_priv_dec pfn_rsa_meth_priv_dec = NULL;
@@ -180,13 +197,17 @@ int sc_ossl_rsa_priv_dec(int flen, const unsigned char* from,
     }
 
     SC_OSSL_LOG_DEBUG("SymCryptRsakeySizeofModulus");
-    cbModuls= SymCryptRsakeySizeofModulus(keyCtx->key);
-    cbResult = cbModuls;
+    cbModulus= SymCryptRsakeySizeofModulus(keyCtx->key);
+    cbResult = cbModulus;
 
-    SC_OSSL_LOG_DEBUG("from: %X, flen: %d, cbModuls: %ld, to: %X", from, flen, cbModuls, to);
+    SC_OSSL_LOG_DEBUG("from: %X, flen: %d, cbModulus: %ld, to: %X", from, flen, cbModulus, to);
     SC_OSSL_LOG_DEBUG("SymCryptRsakeyHasPrivateKey %d", SymCryptRsakeyHasPrivateKey(keyCtx->key));
 
     if( from == NULL )
+    {
+        goto err;
+    }
+    if( flen > cbModulus )
     {
         goto err;
     }
@@ -202,7 +223,7 @@ int sc_ossl_rsa_priv_dec(int flen, const unsigned char* from,
                        SYMCRYPT_NUMBER_FORMAT_MSB_FIRST,
                        0,
                        to,
-                       flen > cbModuls ? cbModuls : flen,
+                       cbModulus - 11,
                        &cbResult);
         SC_OSSL_LOG_DEBUG("cbResult: %ld", cbResult);
         if( SymError != SYMCRYPT_NO_ERROR )
@@ -216,14 +237,14 @@ int sc_ossl_rsa_priv_dec(int flen, const unsigned char* from,
         SymError = SymCryptRsaOaepDecrypt(
                        keyCtx->key,
                        from,
-                       flen > cbModuls ? cbModuls : flen,
+                       flen,
                        SYMCRYPT_NUMBER_FORMAT_MSB_FIRST,
                        SymCryptSha1Algorithm,
                        NULL,
                        0,
                        0,
                        to,
-                       flen > cbModuls ? cbModuls : flen,
+                       cbModulus - 42,
                        &cbResult);
         SC_OSSL_LOG_DEBUG("cbResult: %ld", cbResult);
         if( SymError != SYMCRYPT_NO_ERROR )
@@ -237,12 +258,12 @@ int sc_ossl_rsa_priv_dec(int flen, const unsigned char* from,
         SymError = SymCryptRsaRawDecrypt(
                        keyCtx->key,
                        from,
-                       flen > cbModuls ? cbModuls : flen,
+                       flen,
                        SYMCRYPT_NUMBER_FORMAT_MSB_FIRST,
                        0,
                        to,
-                       cbModuls);
-        cbResult = cbModuls;
+                       cbModulus);
+        cbResult = cbModulus;
         if( SymError != SYMCRYPT_NO_ERROR )
         {
             SC_OSSL_LOG_SYMERROR_ERROR("SymCryptRsaRawDecrypt failed", SymError);
@@ -332,7 +353,7 @@ int sc_ossl_rsa_sign(int type, const unsigned char* m,
     const RSA* rsa)
 {
     SC_OSSL_LOG_DEBUG(NULL);
-    BN_ULONG cbModuls = 0;
+    BN_ULONG cbModulus = 0;
     size_t cbResult = 0;
     SYMCRYPT_ERROR SymError = SYMCRYPT_NO_ERROR;
     SC_OSSL_RSA_KEY_CONTEXT *keyCtx = RSA_get_ex_data(rsa, rsa_sc_ossl_idx);
@@ -350,8 +371,8 @@ int sc_ossl_rsa_sign(int type, const unsigned char* m,
         }
     }
 
-    cbModuls = SymCryptRsakeySizeofModulus(keyCtx->key);
-    cbResult = cbModuls;
+    cbModulus = SymCryptRsakeySizeofModulus(keyCtx->key);
+    cbResult = cbModulus;
     SC_OSSL_LOG_DEBUG("m_length= %d", m_length);
     if( siglen != NULL )
     {
@@ -377,13 +398,13 @@ int sc_ossl_rsa_sign(int type, const unsigned char* m,
         SymError = SymCryptRsaPkcs1Sign(
                        keyCtx->key,
                        m,
-                       m_length > cbModuls ? cbModuls : m_length,
+                       m_length > cbModulus ? cbModulus : m_length,
                        NULL,
                        0,
                        SYMCRYPT_FLAG_RSA_PKCS1_NO_ASN1,
                        SYMCRYPT_NUMBER_FORMAT_MSB_FIRST,
                        sigret,
-                       siglen != NULL ? (*siglen > cbModuls ? cbModuls : *siglen) : 0,
+                       siglen != NULL ? (*siglen > cbModulus ? cbModulus : *siglen) : 0,
                        &cbResult);
 
         if( SymError != SYMCRYPT_NO_ERROR )
@@ -403,13 +424,13 @@ int sc_ossl_rsa_sign(int type, const unsigned char* m,
         SymError = SymCryptRsaPkcs1Sign(
                        keyCtx->key,
                        m,
-                       m_length > cbModuls ? cbModuls : m_length,
+                       m_length > cbModulus ? cbModulus : m_length,
                        SymCryptMd5OidList,
                        SYMCRYPT_MD5_OID_COUNT,
                        0,
                        SYMCRYPT_NUMBER_FORMAT_MSB_FIRST,
                        sigret,
-                       siglen != NULL ? (*siglen > cbModuls ? cbModuls : *siglen) : 0,
+                       siglen != NULL ? (*siglen > cbModulus ? cbModulus : *siglen) : 0,
                        &cbResult);
 
         if( SymError != SYMCRYPT_NO_ERROR )
@@ -429,13 +450,13 @@ int sc_ossl_rsa_sign(int type, const unsigned char* m,
         SymError = SymCryptRsaPkcs1Sign(
                        keyCtx->key,
                        m,
-                       m_length > cbModuls ? cbModuls : m_length,
+                       m_length > cbModulus ? cbModulus : m_length,
                        SymCryptSha1OidList,
                        SYMCRYPT_SHA1_OID_COUNT,
                        0,
                        SYMCRYPT_NUMBER_FORMAT_MSB_FIRST,
                        sigret,
-                       siglen != NULL ? (*siglen > cbModuls ? cbModuls : *siglen) : 0,
+                       siglen != NULL ? (*siglen > cbModulus ? cbModulus : *siglen) : 0,
                        &cbResult);
 
         if( SymError != SYMCRYPT_NO_ERROR )
@@ -454,13 +475,13 @@ int sc_ossl_rsa_sign(int type, const unsigned char* m,
         SymError = SymCryptRsaPkcs1Sign(
                        keyCtx->key,
                        m,
-                       m_length > cbModuls ? cbModuls : m_length,
+                       m_length > cbModulus ? cbModulus : m_length,
                        SymCryptSha256OidList,
                        SYMCRYPT_SHA256_OID_COUNT,
                        0,
                        SYMCRYPT_NUMBER_FORMAT_MSB_FIRST,
                        sigret,
-                       siglen != NULL ? (*siglen > cbModuls ? cbModuls : *siglen) : 0,
+                       siglen != NULL ? (*siglen > cbModulus ? cbModulus : *siglen) : 0,
                        &cbResult);
 
         if( SymError != SYMCRYPT_NO_ERROR )
@@ -480,13 +501,13 @@ int sc_ossl_rsa_sign(int type, const unsigned char* m,
         SymError = SymCryptRsaPkcs1Sign(
                        keyCtx->key,
                        m,
-                       m_length > cbModuls ? cbModuls : m_length,
+                       m_length > cbModulus ? cbModulus : m_length,
                        SymCryptSha384OidList,
                        SYMCRYPT_SHA384_OID_COUNT,
                        0,
                        SYMCRYPT_NUMBER_FORMAT_MSB_FIRST,
                        sigret,
-                       siglen != NULL ? (*siglen > cbModuls ? cbModuls : *siglen) : 0,
+                       siglen != NULL ? (*siglen > cbModulus ? cbModulus : *siglen) : 0,
                        &cbResult);
 
         if( SymError != SYMCRYPT_NO_ERROR )
@@ -505,13 +526,13 @@ int sc_ossl_rsa_sign(int type, const unsigned char* m,
         SymError = SymCryptRsaPkcs1Sign(
                        keyCtx->key,
                        m,
-                       m_length > cbModuls ? cbModuls : m_length,
+                       m_length > cbModulus ? cbModulus : m_length,
                        SymCryptSha512OidList,
                        SYMCRYPT_SHA512_OID_COUNT,
                        0,
                        SYMCRYPT_NUMBER_FORMAT_MSB_FIRST,
                        sigret,
-                       siglen != NULL ? (*siglen > cbModuls ? cbModuls : *siglen) : 0,
+                       siglen != NULL ? (*siglen > cbModulus ? cbModulus : *siglen) : 0,
                        &cbResult);
 
         if( SymError != SYMCRYPT_NO_ERROR )
@@ -550,7 +571,7 @@ int sc_ossl_rsa_verify(int dtype, const unsigned char* m,
     unsigned int siglen, const RSA* rsa)
 {
     SC_OSSL_LOG_DEBUG(NULL);
-    BN_ULONG cbModuls = 0;
+    BN_ULONG cbModulus = 0;
     size_t cbResult = 0;
     SYMCRYPT_ERROR SymError = SYMCRYPT_NO_ERROR;
     SC_OSSL_RSA_KEY_CONTEXT *keyCtx = RSA_get_ex_data(rsa, rsa_sc_ossl_idx);
@@ -570,8 +591,8 @@ int sc_ossl_rsa_verify(int dtype, const unsigned char* m,
         }
     }
 
-    cbModuls = SymCryptRsakeySizeofModulus(keyCtx->key);
-    cbResult = cbModuls;
+    cbModulus = SymCryptRsakeySizeofModulus(keyCtx->key);
+    cbResult = cbModulus;
     switch( dtype )
     {
     case NID_md5_sha1:
@@ -586,7 +607,7 @@ int sc_ossl_rsa_verify(int dtype, const unsigned char* m,
         SymError = SymCryptRsaPkcs1Verify(
                        keyCtx->key,
                        m,
-                       m_length > cbModuls ? cbModuls : m_length,
+                       m_length > cbModulus ? cbModulus : m_length,
                        sigbuf,
                        siglen,
                        SYMCRYPT_NUMBER_FORMAT_MSB_FIRST,
@@ -611,7 +632,7 @@ int sc_ossl_rsa_verify(int dtype, const unsigned char* m,
         SymError = SymCryptRsaPkcs1Verify(
                        keyCtx->key,
                        m,
-                       m_length > cbModuls ? cbModuls : m_length,
+                       m_length > cbModulus ? cbModulus : m_length,
                        sigbuf,
                        siglen,
                        SYMCRYPT_NUMBER_FORMAT_MSB_FIRST,
@@ -636,7 +657,7 @@ int sc_ossl_rsa_verify(int dtype, const unsigned char* m,
         SymError = SymCryptRsaPkcs1Verify(
                        keyCtx->key,
                        m,
-                       m_length > cbModuls ? cbModuls : m_length,
+                       m_length > cbModulus ? cbModulus : m_length,
                        sigbuf,
                        siglen,
                        SYMCRYPT_NUMBER_FORMAT_MSB_FIRST,
@@ -660,7 +681,7 @@ int sc_ossl_rsa_verify(int dtype, const unsigned char* m,
         SymError = SymCryptRsaPkcs1Verify(
                        keyCtx->key,
                        m,
-                       m_length > cbModuls ? cbModuls : m_length,
+                       m_length > cbModulus ? cbModulus : m_length,
                        sigbuf,
                        siglen,
                        SYMCRYPT_NUMBER_FORMAT_MSB_FIRST,
@@ -683,7 +704,7 @@ int sc_ossl_rsa_verify(int dtype, const unsigned char* m,
         SymError = SymCryptRsaPkcs1Verify(
                        keyCtx->key,
                        m,
-                       m_length > cbModuls ? cbModuls : m_length,
+                       m_length > cbModulus ? cbModulus : m_length,
                        sigbuf,
                        siglen,
                        SYMCRYPT_NUMBER_FORMAT_MSB_FIRST,
@@ -707,7 +728,7 @@ int sc_ossl_rsa_verify(int dtype, const unsigned char* m,
         SymError = SymCryptRsaPkcs1Verify(
                        keyCtx->key,
                        m,
-                       m_length > cbModuls ? cbModuls : m_length,
+                       m_length > cbModulus ? cbModulus : m_length,
                        sigbuf,
                        siglen,
                        SYMCRYPT_NUMBER_FORMAT_MSB_FIRST,

--- a/SymCryptEngine/src/sc_ossl_rsapss.c
+++ b/SymCryptEngine/src/sc_ossl_rsapss.c
@@ -16,7 +16,7 @@ extern "C" {
 int sc_ossl_rsapss_sign(EVP_PKEY_CTX *ctx, unsigned char *sig, size_t *siglen, const unsigned char *tbs, size_t tbslen)
 {
     SC_OSSL_LOG_DEBUG(NULL);
-    BN_ULONG cbModuls = 0;
+    BN_ULONG cbModulus = 0;
     EVP_PKEY* pkey = NULL;
     RSA* rsa = NULL;
     size_t cbResult = 0;
@@ -81,8 +81,8 @@ int sc_ossl_rsapss_sign(EVP_PKEY_CTX *ctx, unsigned char *sig, size_t *siglen, c
         return -2;
     }
 
-    cbModuls = SymCryptRsakeySizeofModulus(localKeyCtx.key);
-    cbResult = cbModuls;
+    cbModulus = SymCryptRsakeySizeofModulus(localKeyCtx.key);
+    cbResult = cbModulus;
     SC_OSSL_LOG_DEBUG("tbslen= %d", tbslen);
     if( siglen != NULL )
     {
@@ -240,7 +240,7 @@ err:
 int sc_ossl_rsapss_verify(EVP_PKEY_CTX *ctx, const unsigned char *sig, size_t siglen, const unsigned char *tbs, size_t tbslen)
 {
     SC_OSSL_LOG_DEBUG(NULL);
-    BN_ULONG cbModuls = 0;
+    BN_ULONG cbModulus = 0;
     EVP_PKEY* pkey = NULL;
     RSA* rsa = NULL;
     size_t cbResult = 0;
@@ -311,8 +311,6 @@ int sc_ossl_rsapss_verify(EVP_PKEY_CTX *ctx, const unsigned char *sig, size_t si
         return -2;
     }
 
-    cbModuls = SymCryptRsakeySizeofModulus(localKeyCtx.key);
-    cbResult = cbModuls;
     SC_OSSL_LOG_DEBUG("tbslen= %d", tbslen);
     if( sig == NULL )
     {
@@ -320,8 +318,8 @@ int sc_ossl_rsapss_verify(EVP_PKEY_CTX *ctx, const unsigned char *sig, size_t si
         goto err;
     }
 
-    cbModuls = SymCryptRsakeySizeofModulus(localKeyCtx.key);
-    cbResult = cbModuls;
+    cbModulus = SymCryptRsakeySizeofModulus(localKeyCtx.key);
+    cbResult = cbModulus;
     switch( dtype )
     {
     case NID_md5:


### PR DESCRIPTION
+ Hopefully handing allocation/freeing of SymCrypt digest state entirely
  to OpenSSL should avoid leaks in HMAC which Ming-Wei observes but I
  have not been able to reproduce
  + Reduces complexity and lines of code anyway, so seems like a step in
    the right direction
+ Free allocated public key on successful ECDH
+ Error in the engine when flen provided to RSA is too big, rather than
  changing the value to read a prefix of the provided buffer
  + Also explicitly write to the amount of memory that is specified in
    the RSA documentation:
    https://www.openssl.org/docs/man1.1.1/man3/RSA_private_decrypt.html