### PR TITLE
[build]: Fix the loading symcryengine issue

### DIFF
--- a/SymCryptEngine/dynamic/CMakeLists.txt
+++ b/SymCryptEngine/dynamic/CMakeLists.txt
@@ -43,7 +43,7 @@ set_target_properties(sc_ossl_dynamic PROPERTIES OUTPUT_NAME "symcryptengine")
 
 target_link_directories(sc_ossl_dynamic PUBLIC ${CMAKE_SOURCE_DIR})
 target_link_libraries(sc_ossl_dynamic PUBLIC symcrypt)
-target_link_libraries(sc_ossl_dynamic PUBLIC crypto)
+target_link_libraries(sc_ossl_dynamic PUBLIC ${OPENSSL_CRYPTO_LIBRARY})
 
 install(TARGETS sc_ossl_dynamic
     LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}

--- a/SymCryptEngine/dynamic/CMakeLists.txt
+++ b/SymCryptEngine/dynamic/CMakeLists.txt
@@ -43,6 +43,7 @@ set_target_properties(sc_ossl_dynamic PROPERTIES OUTPUT_NAME "symcryptengine")
 
 target_link_directories(sc_ossl_dynamic PUBLIC ${CMAKE_SOURCE_DIR})
 target_link_libraries(sc_ossl_dynamic PUBLIC symcrypt)
+target_link_libraries(sc_ossl_dynamic PUBLIC crypto)
 
 install(TARGETS sc_ossl_dynamic
     LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}


### PR DESCRIPTION
Failed to load the libsymcryptengine caused by the crypto not loaded in python3. The ssl module will not call into the symcrypt without any display error.
The error message is  "undefined symbol: RSA_meth_get_pub_dec" during the debug.

The debug as below, the lib crypto is not loaded:

ENGINE_ctrl_cmd_string (e=0x55f821dc7370, cmd_name=0x7fdd7f6ae128 "LOAD", arg=0x0, cmd_optional=0) at ../crypto/engine/eng_ctrl.c:231
231     ../crypto/engine/eng_ctrl.c: No such file or directory.
(gdb) p *e
$1 = {id = 0x7fdd7f6ae1b0 "dynamic", name = 0x7fdd7f6ae1b8 "Dynamic engine loading support", rsa_meth = 0x0, dsa_meth = 0x0, dh_meth = 0x0, ec_meth = 0x0, rand_meth = 0x0, ciphers = 0x0, digests = 0x0, pkey_meths = 0x0, pkey_asn1_meths = 0x0, 
  destroy = 0x0, init = 0x7fdd7f589201 <dynamic_init>, finish = 0x7fdd7f589210 <dynamic_finish>, ctrl = 0x7fdd7f58921f <dynamic_ctrl>, load_privkey = 0x0, load_pubkey = 0x0, load_ssl_client_cert = 0x0, 
  cmd_defns = 0x7fdd7f722e60 <dynamic_cmd_defns>, flags = 4, struct_ref = 1, funct_ref = 0, ex_data = {sk = 0x55f821dc74d0}, prev = 0x0, next = 0x0}
(gdb) p num
$2 = 206

dynamic_ctrl (e=0x55f821dc7370, cmd=206, i=0, p=0x0, f=0x0) at ../crypto/engine/eng_dyn.c:291
291     ../crypto/engine/eng_dyn.c: No such file or directory.
(gdb) p *ctx
Cannot access memory at address 0x0
(gdb) n
294     in ../crypto/engine/eng_dyn.c
(gdb) p *ctx
$4 = {dynamic_dso = 0x0, v_check = 0x0, bind_engine = 0x0, DYNAMIC_LIBNAME = 0x55f821dc7170 "/usr/lib/x86_64-linux-gnu/libsymcryptengine.so", no_vcheck = 0, engine_id = 0x0, list_add_value = 2, DYNAMIC_F1 = 0x7fdd7f6ae3d2 "v_check", 
  DYNAMIC_F2 = 0x7fdd7f6ae3da "bind_engine", dir_load = 1, dirs = 0x55f821dc74a0}
(gdb) n

(gdb) p result->errstring
$16 = 0x0
(gdb) n
170     in dlerror.c
(gdb) n
174     in dlerror.c
(gdb) n
176     in dlerror.c
(gdb) p result->errstring
$17 = 0x56175d41be30 "undefined symbol: RSA_meth_get_pub_dec"
(gdb) info sharedlibrary
From                To                  Syms Read   Shared Object Library
0x00007fdda2f68090  0x00007fdda2f871a0  Yes         /lib64/ld-linux-x86-64.so.2
0x00007fdda2f43580  0x00007fdda2f520a1  Yes         /lib/x86_64-linux-gnu/libpthread.so.0
0x00007fdda2f37130  0x00007fdda2f38045  Yes         /lib/x86_64-linux-gnu/libdl.so.2
0x00007fdda2f32210  0x00007fdda2f32b98  Yes         /lib/x86_64-linux-gnu/libutil.so.1
0x00007fdda2dfc200  0x00007fdda2e95c98  Yes         /lib/x86_64-linux-gnu/libm.so.6
0x00007fdda2c4d320  0x00007fdda2d966b9  Yes         /lib/x86_64-linux-gnu/libc.so.6
0x00007fdda29e5550  0x00007fdda29e77d5  Yes         /home/xumia/test/cpython/build/lib.linux-x86_64-3.9-pydebug/readline.cpython-39d-x86_64-linux-gnu.so
0x00007fdda299b9f0  0x00007fdda29c59f5  Yes (*)     /lib/x86_64-linux-gnu/libreadline.so.8
0x00007fdda2963990  0x00007fdda29700b8  Yes (*)     /lib/x86_64-linux-gnu/libtinfo.so.6
0x00007fdda290e0f0  0x00007fdda290f43d  Yes         /home/xumia/test/cpython/build/lib.linux-x86_64-3.9-pydebug/_heapq.cpython-39d-x86_64-linux-gnu.so
0x00007fdda28ab2a0  0x00007fdda28b788a  Yes         /home/xumia/test/cpython/build/lib.linux-x86_64-3.9-pydebug/_ssl.cpython-39d-x86_64-linux-gnu.so
0x00007fdda2804450  0x00007fdda2870c33  Yes         /usr/lib/x86_64-linux-gnu/libssl.so.1.1
0x00007fdda24f9000  0x00007fdda2716cbf  Yes         /usr/lib/x86_64-linux-gnu/libcrypto.so.1.1
0x00007fdda24537e0  0x00007fdda245da37  Yes         /home/xumia/test/cpython/build/lib.linux-x86_64-3.9-pydebug/_socket.cpython-39d-x86_64-linux-gnu.so
(*): Shared library is missing debugging information.
(gdb) 