### PR TITLE
Introduce cmake-toolchain files for Linux AMD64 and ARM64

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,17 +1,27 @@
-cmake_minimum_required(VERSION 2.8)
+cmake_minimum_required(VERSION 3.13.0)
 
-project(OpenSSL_FIPS)
+project(scossl)
 
 include_directories(~/SymCrypt/inc)
 
-# add_compile_options(-fsanitize=address)
-# add_compile_options(-fsanitize=leak)
-# add_compile_options(-fsanitize=undefined)
-# add_compile_options(-fno-sanitize-recover=all)
-# add_link_options(-fsanitize=address)
-# add_link_options(-fsanitize=leak)
-# add_link_options(-fsanitize=undefined)
-# add_link_options(-fno-sanitize-recover=all)
+# In Sanitize version, enable sanitizers
+if (CMAKE_BUILD_TYPE MATCHES Sanitize)
+    add_compile_options(-fsanitize=address)
+    add_compile_options(-fsanitize=leak)
+    add_compile_options(-fsanitize=undefined)
+    add_compile_options(-fno-sanitize-recover=all)
+    add_link_options(-fsanitize=address)
+    add_link_options(-fsanitize=leak)
+    add_link_options(-fsanitize=undefined)
+    add_link_options(-fno-sanitize-recover=all)
+endif()
+
+if(CMAKE_BUILD_TYPE MATCHES Release)
+    message("Release mode")
+else()
+    message("Debug mode")
+    add_compile_options(-DDBG=1)
+endif()
 
 add_subdirectory (SymCryptEngine/static)
 add_subdirectory (SymCryptEngine/dynamic)

--- a/README.md
+++ b/README.md
@@ -20,15 +20,15 @@ The known cases where the Engine will currently fail rather than fallback to the
 Follow Linux build instructions from SymCrypt repository [SymCrypt](https://github.com/Microsoft/SymCrypt) to build the Linux SymCrypt module.
 
 ```
-cp <SymCryptRepo>/bin/module/<arch>/LinuxUserMode/libsymcrypt.so ./
-cmake . -DOPENSSL_ROOT_DIR=<OpensslInstallDirectory>
+cp <SymCryptRepo>/bin/module/<arch>/LinuxUserMode/<module_name>/libsymcrypt.so ./
+mkdir bin; cd bin
+cmake .. -DOPENSSL_ROOT_DIR=<OpensslInstallDirectory> -DCMAKE_TOOLCHAIN_FILE=../cmake-toolchain/LinuxUserMode-<arch>.cmake
 cmake --build .
 ```
 
 ## Run Samples
 ```
-cd SslPlay
-./SslPlay
+./SslPlay/SslPlay
 ```
 
 ## Contributing

--- a/SslPlay/CMakeLists.txt
+++ b/SslPlay/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8)
+cmake_minimum_required(VERSION 3.13.0)
 
 project(SslPlay)
 
@@ -13,5 +13,5 @@ add_executable (SslPlay
 target_link_directories(SslPlay PUBLIC ${CMAKE_BINARY_DIR} ${CMAKE_INSTALL_LIBDIR})
 target_include_directories(SslPlay PUBLIC ${CMAKE_SOURCE_DIR}/SymCryptEngine/inc)
 
-target_link_libraries(SslPlay LINK_PUBLIC $<TARGET_FILE:sc_ossl_dynamic> ${OPENSSL_CRYPTO_LIBRARY})
+target_link_libraries(SslPlay LINK_PUBLIC $<TARGET_FILE:scossl_dynamic> ${OPENSSL_CRYPTO_LIBRARY})
 #target_link_libraries(SslPlay ${OPENSSL_CRYPTO_LIBRARY})

--- a/SymCryptEngine/dynamic/CMakeLists.txt
+++ b/SymCryptEngine/dynamic/CMakeLists.txt
@@ -1,6 +1,6 @@
-cmake_minimum_required(VERSION 2.8)
+cmake_minimum_required(VERSION 3.13.0)
 
-project(sc_ossl_engine_dynamic)
+project(scossl_engine_dynamic)
 
 set(DEFAULT_BUILD_TYPE "Release")
 
@@ -11,12 +11,7 @@ set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++1y -Wall -Wextra -Wno-unused-par
 find_package(OpenSSL REQUIRED)
 include_directories(${OPENSSL_INCLUDE_DIR})
 
-# Define _AMD64_ to set up the correct SymCrypt macros, e.g. SYMCRYPT_CPU_AMD64
-add_compile_options(-D_AMD64_)
-add_compile_options(-DDBG)
-add_compile_options(-O3)
-
-add_library(sc_ossl_dynamic SHARED
+add_library(scossl_dynamic SHARED
     ../src/sc_ossl.c
     ../src/sc_ossl_ciphers.c
     ../src/sc_ossl_dh.c
@@ -32,20 +27,20 @@ add_library(sc_ossl_dynamic SHARED
     ../src/sc_ossl_helpers.c
 )
 
-set_target_properties(sc_ossl_dynamic PROPERTIES PUBLIC_HEADER ../inc/sc_ossl.h)
-# target_link_libraries(sc_ossl_dynamic ${OPENSSL_CRYPTO_LIBRARY})
-target_include_directories(sc_ossl_dynamic PUBLIC ../inc)
-target_include_directories(sc_ossl_dynamic PRIVATE ../src)
-target_include_directories (sc_ossl_dynamic PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
+set_target_properties(scossl_dynamic PROPERTIES PUBLIC_HEADER ../inc/sc_ossl.h)
+# target_link_libraries(scossl_dynamic ${OPENSSL_CRYPTO_LIBRARY})
+target_include_directories(scossl_dynamic PUBLIC ../inc)
+target_include_directories(scossl_dynamic PRIVATE ../src)
+target_include_directories (scossl_dynamic PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
 
-# set_target_properties(sc_ossl_dynamic PROPERTIES PREFIX "")
-set_target_properties(sc_ossl_dynamic PROPERTIES OUTPUT_NAME "symcryptengine")
+# set_target_properties(scossl_dynamic PROPERTIES PREFIX "")
+set_target_properties(scossl_dynamic PROPERTIES OUTPUT_NAME "symcryptengine")
 
-target_link_directories(sc_ossl_dynamic PUBLIC ${CMAKE_SOURCE_DIR})
-target_link_libraries(sc_ossl_dynamic PUBLIC symcrypt)
-target_link_libraries(sc_ossl_dynamic PUBLIC ${OPENSSL_CRYPTO_LIBRARY})
+target_link_directories(scossl_dynamic PUBLIC ${CMAKE_SOURCE_DIR})
+target_link_libraries(scossl_dynamic PUBLIC symcrypt)
+target_link_libraries(scossl_dynamic PUBLIC ${OPENSSL_CRYPTO_LIBRARY})
 
-install(TARGETS sc_ossl_dynamic
+install(TARGETS scossl_dynamic
     LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
     PUBLIC_HEADER DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
 

--- a/SymCryptEngine/src/sc_ossl_helpers.c
+++ b/SymCryptEngine/src/sc_ossl_helpers.c
@@ -64,7 +64,7 @@ static void _close_trace_log_filename(FILE *fp)
     return;
 }
 
-void _sc_ossl_log(
+void _scossl_log(
     int trace_level,
     const char *func,
     const char *format, ...)
@@ -111,7 +111,7 @@ void _sc_ossl_log(
     return;
 }
 
-void _sc_ossl_log_bytes(
+void _scossl_log_bytes(
     int trace_level,
     const char *func,
     char *description,
@@ -123,14 +123,14 @@ void _sc_ossl_log_bytes(
         return;
     }
     FILE *fp = NULL;
-    _sc_ossl_log(trace_level, func, description);
+    _scossl_log(trace_level, func, description);
     fp = _open_trace_log_filename();
     BIO_dump_fp(fp, s, len);
     _close_trace_log_filename(fp);
     return;
 }
 
-void _sc_ossl_log_bignum(
+void _scossl_log_bignum(
     int trace_level,
     const char *func,
     char *description,
@@ -167,12 +167,12 @@ void _sc_ossl_log_bignum(
         return;
     }
 
-    _sc_ossl_log_bytes(trace_level, func, description, (const char*) string, length);
+    _scossl_log_bytes(trace_level, func, description, (const char*) string, length);
     OPENSSL_free(string);
     return;
 }
 
-void _sc_ossl_log_SYMCRYPT_ERROR(
+void _scossl_log_SYMCRYPT_ERROR(
     int trace_level,
     const char *func,
     char *description,
@@ -181,67 +181,67 @@ void _sc_ossl_log_SYMCRYPT_ERROR(
     switch( symError  )
     {
         case SYMCRYPT_NO_ERROR:
-            _sc_ossl_log(trace_level, func, "%s - SYMCRYPT_NO_ERROR (%d)", description, symError);
+            _scossl_log(trace_level, func, "%s - SYMCRYPT_NO_ERROR (%d)", description, symError);
             break;
         case SYMCRYPT_UNUSED:
-            _sc_ossl_log(trace_level, func, "%s - SYMCRYPT_UNUSED (%d)", description, symError);
+            _scossl_log(trace_level, func, "%s - SYMCRYPT_UNUSED (%d)", description, symError);
             break;
         case SYMCRYPT_WRONG_KEY_SIZE:
-            _sc_ossl_log(trace_level, func, "%s - SYMCRYPT_WRONG_KEY_SIZE (%d)", description, symError);
+            _scossl_log(trace_level, func, "%s - SYMCRYPT_WRONG_KEY_SIZE (%d)", description, symError);
             break;
         case SYMCRYPT_WRONG_BLOCK_SIZE:
-            _sc_ossl_log(trace_level, func, "%s - SYMCRYPT_WRONG_BLOCK_SIZE (%d)", description, symError);
+            _scossl_log(trace_level, func, "%s - SYMCRYPT_WRONG_BLOCK_SIZE (%d)", description, symError);
             break;
         case SYMCRYPT_WRONG_DATA_SIZE:
-            _sc_ossl_log(trace_level, func, "%s - SYMCRYPT_WRONG_DATA_SIZE (%d)", description, symError);
+            _scossl_log(trace_level, func, "%s - SYMCRYPT_WRONG_DATA_SIZE (%d)", description, symError);
             break;
         case SYMCRYPT_WRONG_NONCE_SIZE:
-            _sc_ossl_log(trace_level, func, "%s - SYMCRYPT_WRONG_NONCE_SIZE (%d)", description, symError);
+            _scossl_log(trace_level, func, "%s - SYMCRYPT_WRONG_NONCE_SIZE (%d)", description, symError);
             break;
         case SYMCRYPT_WRONG_TAG_SIZE:
-            _sc_ossl_log(trace_level, func, "%s - SYMCRYPT_WRONG_TAG_SIZE (%d)", description, symError);
+            _scossl_log(trace_level, func, "%s - SYMCRYPT_WRONG_TAG_SIZE (%d)", description, symError);
             break;
         case SYMCRYPT_WRONG_ITERATION_COUNT:
-            _sc_ossl_log(trace_level, func, "%s - SYMCRYPT_WRONG_ITERATION_COUNT (%d)", description, symError);
+            _scossl_log(trace_level, func, "%s - SYMCRYPT_WRONG_ITERATION_COUNT (%d)", description, symError);
             break;
         case SYMCRYPT_AUTHENTICATION_FAILURE:
-            _sc_ossl_log(trace_level, func, "%s - SYMCRYPT_AUTHENTICATION_FAILURE (%d)", description, symError);
+            _scossl_log(trace_level, func, "%s - SYMCRYPT_AUTHENTICATION_FAILURE (%d)", description, symError);
             break;
         case SYMCRYPT_EXTERNAL_FAILURE:
-            _sc_ossl_log(trace_level, func, "%s - SYMCRYPT_EXTERNAL_FAILURE (%d)", description, symError);
+            _scossl_log(trace_level, func, "%s - SYMCRYPT_EXTERNAL_FAILURE (%d)", description, symError);
             break;
         case SYMCRYPT_FIPS_FAILURE:
-            _sc_ossl_log(trace_level, func, "%s - SYMCRYPT_FIPS_FAILURE (%d)", description, symError);
+            _scossl_log(trace_level, func, "%s - SYMCRYPT_FIPS_FAILURE (%d)", description, symError);
             break;
         case SYMCRYPT_HARDWARE_FAILURE:
-            _sc_ossl_log(trace_level, func, "%s - SYMCRYPT_HARDWARE_FAILURE (%d)", description, symError);
+            _scossl_log(trace_level, func, "%s - SYMCRYPT_HARDWARE_FAILURE (%d)", description, symError);
             break;
         case SYMCRYPT_NOT_IMPLEMENTED:
-            _sc_ossl_log(trace_level, func, "%s - SYMCRYPT_NOT_IMPLEMENTED (%d)", description, symError);
+            _scossl_log(trace_level, func, "%s - SYMCRYPT_NOT_IMPLEMENTED (%d)", description, symError);
             break;
         case SYMCRYPT_INVALID_BLOB:
-            _sc_ossl_log(trace_level, func, "%s - SYMCRYPT_INVALID_BLOB (%d)", description, symError);
+            _scossl_log(trace_level, func, "%s - SYMCRYPT_INVALID_BLOB (%d)", description, symError);
             break;
         case SYMCRYPT_BUFFER_TOO_SMALL:
-            _sc_ossl_log(trace_level, func, "%s - SYMCRYPT_BUFFER_TOO_SMALL (%d)", description, symError);
+            _scossl_log(trace_level, func, "%s - SYMCRYPT_BUFFER_TOO_SMALL (%d)", description, symError);
             break;
         case SYMCRYPT_INVALID_ARGUMENT:
-            _sc_ossl_log(trace_level, func, "%s - SYMCRYPT_INVALID_ARGUMENT (%d)", description, symError);
+            _scossl_log(trace_level, func, "%s - SYMCRYPT_INVALID_ARGUMENT (%d)", description, symError);
             break;
         case SYMCRYPT_MEMORY_ALLOCATION_FAILURE:
-            _sc_ossl_log(trace_level, func, "%s - SYMCRYPT_MEMORY_ALLOCATION_FAILURE (%d)", description, symError);
+            _scossl_log(trace_level, func, "%s - SYMCRYPT_MEMORY_ALLOCATION_FAILURE (%d)", description, symError);
             break;
         case SYMCRYPT_SIGNATURE_VERIFICATION_FAILURE:
-            _sc_ossl_log(trace_level, func, "%s - SYMCRYPT_SIGNATURE_VERIFICATION_FAILURE (%d)", description, symError);
+            _scossl_log(trace_level, func, "%s - SYMCRYPT_SIGNATURE_VERIFICATION_FAILURE (%d)", description, symError);
             break;
         case SYMCRYPT_INCOMPATIBLE_FORMAT:
-            _sc_ossl_log(trace_level, func, "%s - SYMCRYPT_INCOMPATIBLE_FORMAT (%d)", description, symError);
+            _scossl_log(trace_level, func, "%s - SYMCRYPT_INCOMPATIBLE_FORMAT (%d)", description, symError);
             break;
         case SYMCRYPT_VALUE_TOO_LARGE:
-            _sc_ossl_log(trace_level, func, "%s - SYMCRYPT_VALUE_TOO_LARGE (%d)", description, symError);
+            _scossl_log(trace_level, func, "%s - SYMCRYPT_VALUE_TOO_LARGE (%d)", description, symError);
             break;
         default:
-            _sc_ossl_log(trace_level, func, "%s - UNKNOWN SYMCRYPT_ERROR (%d)", description, symError);
+            _scossl_log(trace_level, func, "%s - UNKNOWN SYMCRYPT_ERROR (%d)", description, symError);
             break;
     }
 }

--- a/SymCryptEngine/src/sc_ossl_helpers.h
+++ b/SymCryptEngine/src/sc_ossl_helpers.h
@@ -17,68 +17,77 @@ void* SC_OSSL_ENGINE_zalloc(size_t num);
 void* SC_OSSL_ENGINE_realloc(void *mem, size_t num);
 void SC_OSSL_ENGINE_free(void *mem);
 
-void _sc_ossl_log(
+void _scossl_log(
     int trace_level,
     const char *func,
     const char *format, ...);
 
-#define SC_OSSL_LOG_DEBUG(...) \
-    _sc_ossl_log(SC_OSSL_LOG_LEVEL_DEBUG, __FUNCTION__, __VA_ARGS__)
-
-#define SC_OSSL_LOG_INFO(...) \
-    _sc_ossl_log(SC_OSSL_LOG_LEVEL_INFO, __FUNCTION__, __VA_ARGS__)
-
-#define SC_OSSL_LOG_ERROR(...) \
-    _sc_ossl_log(SC_OSSL_LOG_LEVEL_ERROR, __FUNCTION__, __VA_ARGS__)
-
-void _sc_ossl_log_bytes(
+void _scossl_log_bytes(
     int trace_level,
     const char *func,
     char *description,
     const char *s,
     int len);
 
-#define SC_OSSL_LOG_BYTES_DEBUG(description, s, len) \
-    _sc_ossl_log_bytes(SC_OSSL_LOG_LEVEL_DEBUG, __FUNCTION__, description, (const char*) s, len)
-
-#define SC_OSSL_LOG_BYTES_INFO(description, s, len) \
-    _sc_ossl_log_bytes(SC_OSSL_LOG_LEVEL_INFO, __FUNCTION__, description, (const char*) s, len)
-
-#define SC_OSSL_LOG_BYTES_ERROR(description, s, len) \
-    _sc_ossl_log_bytes(SC_OSSL_LOG_LEVEL_ERROR, __FUNCTION__, description, (const char*) s, len)
-
-
-void _sc_ossl_log_bignum(
+void _scossl_log_bignum(
     int trace_level,
     const char *func,
     char *description,
     BIGNUM *bn);
 
-#define SC_OSSL_LOG_BIGNUM_DEBUG(description, bn) \
-    _sc_ossl_log_bignum(SC_OSSL_LOG_LEVEL_DEBUG, __FUNCTION__, description, bn)
-
-#define SC_OSSL_LOG_BIGNUM_INFO(description, s, len) \
-    _sc_ossl_log_bignum(SC_OSSL_LOG_LEVEL_INFO, __FUNCTION__, description, bn)
-
-#define SC_OSSL_LOG_BIGNUM_ERROR(description, s, len) \
-    _sc_ossl_log_bignum(SC_OSSL_LOG_LEVEL_ERROR, __FUNCTION__, description, bn)
-
-
-void _sc_ossl_log_SYMCRYPT_ERROR(
+void _scossl_log_SYMCRYPT_ERROR(
     int trace_level,
     const char *func,
     char *description,
     SYMCRYPT_ERROR symError);
 
+// Enable debug and info messages in debug builds, but compile them out in release builds
+#if DBG
+    #define SC_OSSL_LOG_DEBUG(...) \
+        _scossl_log(SC_OSSL_LOG_LEVEL_DEBUG, __FUNCTION__, __VA_ARGS__)
 
-#define SC_OSSL_LOG_SYMERROR_DEBUG(description, symError) \
-    _sc_ossl_log_SYMCRYPT_ERROR(SC_OSSL_LOG_LEVEL_DEBUG, __FUNCTION__, description, symError)
+    #define SC_OSSL_LOG_INFO(...) \
+        _scossl_log(SC_OSSL_LOG_LEVEL_INFO, __FUNCTION__, __VA_ARGS__)
 
-#define SC_OSSL_LOG_SYMERROR_INFO(description, symError) \
-    _sc_ossl_log_SYMCRYPT_ERROR(SC_OSSL_LOG_LEVEL_INFO, __FUNCTION__, description, symError)
+    #define SC_OSSL_LOG_BYTES_DEBUG(description, s, len) \
+        _scossl_log_bytes(SC_OSSL_LOG_LEVEL_DEBUG, __FUNCTION__, description, (const char*) s, len)
+
+    #define SC_OSSL_LOG_BYTES_INFO(description, s, len) \
+        _scossl_log_bytes(SC_OSSL_LOG_LEVEL_INFO, __FUNCTION__, description, (const char*) s, len)
+
+    #define SC_OSSL_LOG_BIGNUM_DEBUG(description, bn) \
+        _scossl_log_bignum(SC_OSSL_LOG_LEVEL_DEBUG, __FUNCTION__, description, bn)
+
+    #define SC_OSSL_LOG_BIGNUM_INFO(description, s, len) \
+        _scossl_log_bignum(SC_OSSL_LOG_LEVEL_INFO, __FUNCTION__, description, bn)
+
+    #define SC_OSSL_LOG_SYMERROR_DEBUG(description, symError) \
+        _scossl_log_SYMCRYPT_ERROR(SC_OSSL_LOG_LEVEL_DEBUG, __FUNCTION__, description, symError)
+
+    #define SC_OSSL_LOG_SYMERROR_INFO(description, symError) \
+        _scossl_log_SYMCRYPT_ERROR(SC_OSSL_LOG_LEVEL_INFO, __FUNCTION__, description, symError)
+#else
+    #define SC_OSSL_LOG_DEBUG(...)
+    #define SC_OSSL_LOG_INFO(...)
+    #define SC_OSSL_LOG_BYTES_DEBUG(description, s, len)
+    #define SC_OSSL_LOG_BYTES_INFO(description, s, len)
+    #define SC_OSSL_LOG_BIGNUM_DEBUG(description, bn)
+    #define SC_OSSL_LOG_BIGNUM_INFO(description, s, len)
+    #define SC_OSSL_LOG_SYMERROR_DEBUG(description, symError)
+    #define SC_OSSL_LOG_SYMERROR_INFO(description, symError)
+#endif
+
+#define SC_OSSL_LOG_ERROR(...) \
+    _scossl_log(SC_OSSL_LOG_LEVEL_ERROR, __FUNCTION__, __VA_ARGS__)
+
+#define SC_OSSL_LOG_BYTES_ERROR(description, s, len) \
+    _scossl_log_bytes(SC_OSSL_LOG_LEVEL_ERROR, __FUNCTION__, description, (const char*) s, len)
+
+#define SC_OSSL_LOG_BIGNUM_ERROR(description, s, len) \
+    _scossl_log_bignum(SC_OSSL_LOG_LEVEL_ERROR, __FUNCTION__, description, bn)
 
 #define SC_OSSL_LOG_SYMERROR_ERROR(description, symError) \
-    _sc_ossl_log_SYMCRYPT_ERROR(SC_OSSL_LOG_LEVEL_ERROR, __FUNCTION__, description, symError)
+    _scossl_log_SYMCRYPT_ERROR(SC_OSSL_LOG_LEVEL_ERROR, __FUNCTION__, description, symError)
 
 #ifdef __cplusplus
 }

--- a/SymCryptEngine/static/CMakeLists.txt
+++ b/SymCryptEngine/static/CMakeLists.txt
@@ -1,6 +1,6 @@
-cmake_minimum_required(VERSION 2.8)
+cmake_minimum_required(VERSION 3.13.0)
 
-project(sc_ossl_engine)
+project(scossl_engine_static)
 
 set(DEFAULT_BUILD_TYPE "Release")
 
@@ -11,27 +11,7 @@ set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++1y -Wall -Wextra -Wno-unused-par
 find_package(OpenSSL REQUIRED)
 include_directories(${OPENSSL_INCLUDE_DIR})
 
-# Set CMake variables that subsequent CMake scripts can check against
-set(CMAKE_SYSTEM_NAME Linux)
-set(CMAKE_SYSTEM_PROCESSOR AMD64)
-
-# For now this is just used for separating the output directories
-set(SYMCRYPT_TARGET_ENV Linux)
-
-# Define _AMD64_ to set up the correct SymCrypt macros, e.g. SYMCRYPT_CPU_AMD64
-add_compile_options(-D_AMD64_)
-add_compile_options(-DDBG)
-add_compile_options(-O3)
-# Enable a baseline of features for the compiler to support everywhere
-# Other than for SSSE3 we do not expect the compiler to generate these instructions anywhere other than with intrinsics
-#
-# We cannot globally enable AVX and later, as we need to keep use of these instructions behind CPU detection, and the
-# instructions are definitely useful enough for a smart compiler to use them in C code (i.e. in memcpy)
-set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -mssse3 -mxsave -maes -mpclmul -msha -mrdrnd -mrdseed")
-set(CMAKE_ASM_FLAGS "-x assembler-with-cpp")
-
-
-add_library(sc_ossl STATIC
+add_library(scossl_static STATIC
     ../src/sc_ossl.c
     ../src/sc_ossl_ciphers.c
     ../src/sc_ossl_dh.c
@@ -47,14 +27,14 @@ add_library(sc_ossl STATIC
     ../src/sc_ossl_helpers.c
 )
 
-set_target_properties(sc_ossl PROPERTIES PUBLIC_HEADER ../inc/sc_ossl.h)
-# target_link_libraries(sc_ossl ${OPENSSL_CRYPTO_LIBRARY})
-target_include_directories(sc_ossl PUBLIC ../inc)
-target_include_directories(sc_ossl PRIVATE ../src)
-target_include_directories (sc_ossl PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/..)
+set_target_properties(scossl_static PROPERTIES PUBLIC_HEADER ../inc/sc_ossl.h)
+# target_link_libraries(scossl_static ${OPENSSL_CRYPTO_LIBRARY})
+target_include_directories(scossl_static PUBLIC ../inc)
+target_include_directories(scossl_static PRIVATE ../src)
+target_include_directories (scossl_static PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/..)
 
 
-install(TARGETS sc_ossl
+install(TARGETS scossl_static
     LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
     PUBLIC_HEADER DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
 

--- a/cmake-toolchain/LinuxUserMode-AMD64.cmake
+++ b/cmake-toolchain/LinuxUserMode-AMD64.cmake
@@ -1,0 +1,19 @@
+# This toolchain file configures CMake options for Linux User Mode AMD64 compilation with CPU optimizations.
+# To use the toolchain file, run cmake .. -DCMAKE_TOOLCHAIN_FILE="cmake-toolchain/LinuxUserMode-AMD64.cmake"
+
+# Set CMake variables that subsequent CMake scripts can check against
+set(CMAKE_SYSTEM_NAME Linux)
+set(CMAKE_SYSTEM_PROCESSOR AMD64)
+
+# Define _AMD64_ to set up the correct SymCrypt macros, e.g. SYMCRYPT_CPU_AMD64
+add_compile_options(-D_AMD64_)
+add_compile_options(-O3)
+
+# Enable a baseline of features for the compiler to support everywhere
+# Other than for SSSE3 we do not expect the compiler to generate these instructions anywhere other than with intrinsics
+#
+# We cannot globally enable AVX and later, as we need to keep use of these instructions behind CPU detection, and the
+# instructions are definitely useful enough for a smart compiler to use them in C code (i.e. in memcpy)
+set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -mssse3 -mxsave -maes -mpclmul -msha -mrdrnd -mrdseed")
+
+set(CMAKE_ASM_FLAGS "-x assembler-with-cpp")

--- a/cmake-toolchain/LinuxUserMode-ARM64.cmake
+++ b/cmake-toolchain/LinuxUserMode-ARM64.cmake
@@ -1,0 +1,40 @@
+# This toolchain file configures CMake options for Linux User Mode ARM64 compilation with CPU optimizations.
+# To use the toolchain file, run cmake .. -DCMAKE_TOOLCHAIN_FILE="cmake-toolchain/LinuxUserMode-ARM64.cmake"
+
+# Set CMake variables that subsequent CMake scripts can check against
+set(CMAKE_SYSTEM_NAME Linux)
+set(CMAKE_SYSTEM_PROCESSOR ARM64)
+
+set(TARGET_TRIPLE aarch64-linux-gnu)
+
+# Currently only use clang as it makes cross-compilation easier
+set(CMAKE_ASM_COMPILER_TARGET ${TARGET_TRIPLE})
+set(CMAKE_C_COMPILER clang)
+set(CMAKE_C_COMPILER_TARGET ${TARGET_TRIPLE})
+set(CMAKE_CXX_COMPILER clang++)
+set(CMAKE_CXX_COMPILER_TARGET ${TARGET_TRIPLE})
+
+# Point clang sysroot to cross compilation toolchain when cross compiling
+if(NOT CMAKE_HOST_SYSTEM_PROCESSOR MATCHES ARM64|aarch64)
+    message(STATUS "Using cross compilation toolchain")
+    # C/C++ toolchain (installed on Ubuntu using apt-get gcc-aarch64-linux-gnu g++-aarch64-linux-gnu)
+    set(CMAKE_SYSROOT_COMPILE /usr/${TARGET_TRIPLE})
+
+    # We would expect setting SYSROOT to be sufficient for clang to cross-compile with the gcc-aarch64-linux-gnu
+    # toolchain, but it seems that this misses a few key header files for C++...
+    # Hacky solution which seems to work for Ubuntu + clang:
+    # Get CMake to find the appropriate include directory and explicitly include it
+    # Seems like there should be a better way to install cross-compilation tools, or specify search paths to clang
+    find_path(CXX_CROSS_INCLUDE_DIR NAMES ${TARGET_TRIPLE} PATHS /usr/${TARGET_TRIPLE}/include/c++/ PATH_SUFFIXES 15 14 13 12 11 10 9 8 7 6 5 NO_DEFAULT_PATH)
+    add_compile_options(-I${CXX_CROSS_INCLUDE_DIR}/${TARGET_TRIPLE})
+endif()
+
+# Define _ARM64_ to set up the correct SymCrypt macros, e.g. SYMCRYPT_CPU_ARM64
+add_compile_options(-D_ARM64_)
+add_compile_options(-O3)
+
+# Enable a baseline of features for the compiler to support everywhere
+# Assumes that the compiler will not emit crypto instructions as a result of normal C code
+set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -march=armv8a+simd+crypto")
+
+# set(CMAKE_ASM_FLAGS "-x assembler-with-cpp")


### PR DESCRIPTION
+ Update README on how to use them
+ Compile out debug and info logging when building a release version of
  the engine, only leaving error logging