### PR TITLE
Define _Return_type_success_ to nothing if it is not already defined

### DIFF
--- a/SymCryptEngine/src/sc_ossl_helpers.h
+++ b/SymCryptEngine/src/sc_ossl_helpers.h
@@ -10,6 +10,10 @@
 extern "C" {
 #endif
 
+#ifndef _Return_type_success_
+#define _Return_type_success_(expr)
+#endif
+
 typedef _Return_type_success_(return == 1) int SCOSSL_STATUS;
 typedef _Return_type_success_(return >= 0) int SCOSSL_RETURNLENGTH; // For functions that return length on success and -1 on error
 


### PR DESCRIPTION
+ Fixes build break (#15) when trying to build SymCrypt-OpenSSL against older
  SymCrypt headers in a non-Windows environment