### PR TITLE
Add AES-CCM support to the engine

### DIFF
--- a/SymCryptEngine/src/sc_ossl_ecc.c
+++ b/SymCryptEngine/src/sc_ossl_ecc.c
@@ -1082,7 +1082,7 @@ int sc_ossl_eckey_compute_key(unsigned char **psec,
 
     int res = -1; // fail
 
-    switch( sc_ossl_get_context(ecdh, &keyCtx) )
+    switch( sc_ossl_get_context((EC_KEY*)ecdh, &keyCtx) )
     {
     case SC_OSSL_ECC_GET_CONTEXT_ERROR:
         SC_OSSL_LOG_ERROR("sc_ossl_get_context failed.");


### PR DESCRIPTION
+ Mostly copying GCM, but with some differences for the different way it
  is invoked by callers
+ Also update GCM to use EVP constants rather than locally defined
  versions to improve clarity a bit