### PR TITLE
Complete HKDF implementation to use SymCrypt implementation for partial HKDF operations

### DIFF
--- a/SymCryptEngine/src/scossl_hkdf.h
+++ b/SymCryptEngine/src/scossl_hkdf.h
@@ -26,11 +26,11 @@ SCOSSL_STATUS scossl_hkdf_ctrl(_Inout_ EVP_PKEY_CTX *ctx, int type, int p1, _In_
 SCOSSL_STATUS scossl_hkdf_derive_init(_Inout_ EVP_PKEY_CTX *ctx);
 
 // Derives a shared secret using ctx. If key is NULL then the maximum size of the output buffer
-// is written to the keylen parameter. If key is not NULL, then the shared secret is written to key
-// and the amount of data written to keylen.
+// is written to the keylen parameter. If key is not NULL, then keylen should contain the length of
+// the key buffer, the shared secret is written to key and the amount of data written to keylen.
 // Returns SCOSSL_SUCCESS on success, or SCOSSL_FAILURE or a negative value for failure.
 SCOSSL_STATUS scossl_hkdf_derive(_Inout_ EVP_PKEY_CTX *ctx, _Out_writes_opt_(*keylen) unsigned char *key,
-                                    _Out_ size_t *keylen);
+                                    _Inout_ size_t *keylen);
 
 #ifdef __cplusplus
 }

--- a/SymCryptEngine/src/scossl_tls1prf.c
+++ b/SymCryptEngine/src/scossl_tls1prf.c
@@ -112,7 +112,7 @@ static PCSYMCRYPT_MAC scossl_get_symcrypt_mac_algorithm(const EVP_MD *evp_md)
 }
 
 SCOSSL_STATUS scossl_tls1prf_derive(_Inout_ EVP_PKEY_CTX *ctx, _Out_writes_opt_(*keylen) unsigned char *key,
-                                        _Out_ size_t *keylen)
+                                        _Inout_ size_t *keylen)
 {
     SCOSSL_TLS1_PRF_PKEY_CTX *key_context = (SCOSSL_TLS1_PRF_PKEY_CTX *)EVP_PKEY_CTX_get_data(ctx);
     PCSYMCRYPT_MAC scossl_mac_algo = NULL;
@@ -136,14 +136,10 @@ SCOSSL_STATUS scossl_tls1prf_derive(_Inout_ EVP_PKEY_CTX *ctx, _Out_writes_opt_(
         SCOSSL_LOG_INFO(SCOSSL_ERR_F_TLS1PRF_DERIVE, SCOSSL_ERR_R_NOT_FIPS_ALGORITHM,
             "Using Mac algorithm MD5+SHA1 which is not FIPS compliant");
         scError = SymCryptTlsPrf1_1(
-            key_context->secret,
-            key_context->secret_length,
-            NULL,
-            0,
-            key_context->seed,
-            key_context->seed_length,
-            key,
-            *keylen);
+            key_context->secret, key_context->secret_length,
+            NULL, 0,
+            key_context->seed, key_context->seed_length,
+            key, *keylen);
     }
     else
     {
@@ -155,14 +151,10 @@ SCOSSL_STATUS scossl_tls1prf_derive(_Inout_ EVP_PKEY_CTX *ctx, _Out_writes_opt_(
 
         scError = SymCryptTlsPrf1_2(
             scossl_mac_algo,
-            key_context->secret,
-            key_context->secret_length,
-            NULL,
-            0,
-            key_context->seed,
-            key_context->seed_length,
-            key,
-            *keylen);
+            key_context->secret, key_context->secret_length,
+            NULL, 0,
+            key_context->seed, key_context->seed_length,
+            key, *keylen);
     }
 
     if (scError != SYMCRYPT_NO_ERROR)

--- a/SymCryptEngine/src/scossl_tls1prf.h
+++ b/SymCryptEngine/src/scossl_tls1prf.h
@@ -26,11 +26,11 @@ SCOSSL_STATUS scossl_tls1prf_ctrl(_Inout_ EVP_PKEY_CTX *ctx, int type, int p1, _
 SCOSSL_STATUS scossl_tls1prf_derive_init(_Inout_ EVP_PKEY_CTX *ctx);
 
 // Derives a shared secret using ctx. If key is NULL then the maximum size of the output buffer
-// is written to the keylen parameter. If key is not NULL, then the shared secret is written to key
-// and the amount of data written to keylen.
+// is written to the keylen parameter. If key is not NULL, then keylen should contain the length of
+// the key buffer, the shared secret is written to key and the amount of data written to keylen.
 // Returns SCOSSL_SUCCESS on success, or SCOSSL_FAILURE on error.
 SCOSSL_STATUS scossl_tls1prf_derive(_Inout_ EVP_PKEY_CTX *ctx, _Out_writes_opt_(*keylen) unsigned char *key,
-                                        _Out_ size_t *keylen);
+                                        _Inout_ size_t *keylen);
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
+ Use proposed new SymCrypt API in order to produce PRK in Extract-only operation
+ Use existing SymCrypt APIs to consume a PRK in Expand-only operation
+ Change \_In\_ annotation to \_Inout\_ for keylen parameter in EVP_KDF derive functions