### PR TITLE
Address various issues found in Code Review

### DIFF
--- a/SslPlay/SslPlay.cpp
+++ b/SslPlay/SslPlay.cpp
@@ -1515,7 +1515,6 @@ TestAesGcmGeneric()
     TestAesGcmCipher("EVP_aes_192_gcm", EVP_aes_192_gcm(), key, 24, iv, 12, aad, 16, plaintext, plaintext_len);
     TestAesGcmCipher("EVP_aes_256_gcm", EVP_aes_256_gcm(), key, 32, iv, 12, aad, 16, plaintext, plaintext_len);
 
-    // Test Nist Curves
     TestAesGcmCipher("EVP_aes_256_gcm", EVP_aes_256_gcm(), gcm_key, 32, gcm_iv, 12, gcm_aad, 16, gcm_pt, 16);
 
     printf("%s", SeparatorLine);

--- a/SymCryptEngine/dynamic/CMakeLists.txt
+++ b/SymCryptEngine/dynamic/CMakeLists.txt
@@ -6,6 +6,7 @@ set(DEFAULT_BUILD_TYPE "Release")
 
 include(GNUInstallDirs)
 
+set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wall -Wextra -Wno-unused-parameter -Wno-unknown-pragmas")
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++1y -Wall -Wextra -Wno-unused-parameter")
 
 find_package(OpenSSL REQUIRED)

--- a/SymCryptEngine/src/sc_ossl_ciphers.c
+++ b/SymCryptEngine/src/sc_ossl_ciphers.c
@@ -3,8 +3,6 @@
 //
 
 #include "sc_ossl_ciphers.h"
-#include "sc_ossl_helpers.h"
-#include <symcrypt.h>
 
 #ifdef __cplusplus
 extern "C" {
@@ -16,17 +14,14 @@ typedef int SC_OSSL_ENCRYPTION_MODE;
 #define SC_OSSL_ENCRYPTION_MODE_NOCHANGE (-1)
 
 struct cipher_cbc_ctx {
-    INT32 enc;                     /* COP_ENCRYPT or COP_DECRYPT */
     SYMCRYPT_AES_EXPANDED_KEY key;
 };
 
 struct cipher_ecb_ctx {
-    INT32 enc;                     /* COP_ENCRYPT or COP_DECRYPT */
     SYMCRYPT_AES_EXPANDED_KEY key;
 };
 
 struct cipher_xts_ctx {
-    INT32 enc;                     /* COP_ENCRYPT or COP_DECRYPT */
     BYTE iv[SYMCRYPT_AES_BLOCK_SIZE];
     SYMCRYPT_XTS_AES_EXPANDED_KEY key;
 };
@@ -36,7 +31,6 @@ struct cipher_xts_ctx {
 #define SCOSSL_GCM_MAX_TAG_LENGTH (16)
 
 struct cipher_gcm_ctx {
-    INT32 enc;                     /* COP_ENCRYPT or COP_DECRYPT */
     INT32 operationInProgress;
     BYTE iv[SCOSSL_GCM_IV_LENGTH];
     INT32 ivlen;
@@ -126,14 +120,13 @@ static SCOSSL_STATUS sc_ossl_aes_cbc_ctrl(_In_ EVP_CIPHER_CTX *ctx, int type, in
 static EVP_CIPHER *_hidden_aes_128_cbc = NULL;
 static const EVP_CIPHER *sc_ossl_aes_128_cbc(void)
 {
-    if( _hidden_aes_128_cbc == NULL
-        && ((_hidden_aes_128_cbc = EVP_CIPHER_meth_new(NID_aes_128_cbc, SYMCRYPT_AES_BLOCK_SIZE , AES_128_KEY_SIZE)) == NULL
-            || !EVP_CIPHER_meth_set_iv_length(_hidden_aes_128_cbc,16)
-            || !EVP_CIPHER_meth_set_flags(_hidden_aes_128_cbc, AES_CBC_FLAGS)
-            || !EVP_CIPHER_meth_set_init(_hidden_aes_128_cbc, sc_ossl_aes_cbc_init_key)
-            || !EVP_CIPHER_meth_set_do_cipher(_hidden_aes_128_cbc, sc_ossl_aes_cbc_cipher)
-            || !EVP_CIPHER_meth_set_ctrl(_hidden_aes_128_cbc, sc_ossl_aes_cbc_ctrl)
-            || !EVP_CIPHER_meth_set_impl_ctx_size(_hidden_aes_128_cbc, sizeof(struct cipher_cbc_ctx))) )
+    if( (_hidden_aes_128_cbc = EVP_CIPHER_meth_new(NID_aes_128_cbc, SYMCRYPT_AES_BLOCK_SIZE , AES_128_KEY_SIZE)) == NULL
+        || !EVP_CIPHER_meth_set_iv_length(_hidden_aes_128_cbc,16)
+        || !EVP_CIPHER_meth_set_flags(_hidden_aes_128_cbc, AES_CBC_FLAGS)
+        || !EVP_CIPHER_meth_set_init(_hidden_aes_128_cbc, sc_ossl_aes_cbc_init_key)
+        || !EVP_CIPHER_meth_set_do_cipher(_hidden_aes_128_cbc, sc_ossl_aes_cbc_cipher)
+        || !EVP_CIPHER_meth_set_ctrl(_hidden_aes_128_cbc, sc_ossl_aes_cbc_ctrl)
+        || !EVP_CIPHER_meth_set_impl_ctx_size(_hidden_aes_128_cbc, sizeof(struct cipher_cbc_ctx)) )
     {
         EVP_CIPHER_meth_free(_hidden_aes_128_cbc);
         _hidden_aes_128_cbc = NULL;
@@ -145,14 +138,13 @@ static const EVP_CIPHER *sc_ossl_aes_128_cbc(void)
 static EVP_CIPHER *_hidden_aes_192_cbc = NULL;
 static const EVP_CIPHER *sc_ossl_aes_192_cbc(void)
 {
-    if( _hidden_aes_192_cbc == NULL
-        && ((_hidden_aes_192_cbc = EVP_CIPHER_meth_new(NID_aes_192_cbc, SYMCRYPT_AES_BLOCK_SIZE , AES_192_KEY_SIZE)) == NULL
-            || !EVP_CIPHER_meth_set_iv_length(_hidden_aes_192_cbc,16)
-            || !EVP_CIPHER_meth_set_flags(_hidden_aes_192_cbc, AES_CBC_FLAGS)
-            || !EVP_CIPHER_meth_set_init(_hidden_aes_192_cbc, sc_ossl_aes_cbc_init_key)
-            || !EVP_CIPHER_meth_set_do_cipher(_hidden_aes_192_cbc, sc_ossl_aes_cbc_cipher)
-            || !EVP_CIPHER_meth_set_ctrl(_hidden_aes_192_cbc, sc_ossl_aes_cbc_ctrl)
-            || !EVP_CIPHER_meth_set_impl_ctx_size(_hidden_aes_192_cbc, sizeof(struct cipher_cbc_ctx))) )
+    if( (_hidden_aes_192_cbc = EVP_CIPHER_meth_new(NID_aes_192_cbc, SYMCRYPT_AES_BLOCK_SIZE , AES_192_KEY_SIZE)) == NULL
+        || !EVP_CIPHER_meth_set_iv_length(_hidden_aes_192_cbc,16)
+        || !EVP_CIPHER_meth_set_flags(_hidden_aes_192_cbc, AES_CBC_FLAGS)
+        || !EVP_CIPHER_meth_set_init(_hidden_aes_192_cbc, sc_ossl_aes_cbc_init_key)
+        || !EVP_CIPHER_meth_set_do_cipher(_hidden_aes_192_cbc, sc_ossl_aes_cbc_cipher)
+        || !EVP_CIPHER_meth_set_ctrl(_hidden_aes_192_cbc, sc_ossl_aes_cbc_ctrl)
+        || !EVP_CIPHER_meth_set_impl_ctx_size(_hidden_aes_192_cbc, sizeof(struct cipher_cbc_ctx)) )
     {
         EVP_CIPHER_meth_free(_hidden_aes_192_cbc);
         _hidden_aes_192_cbc = NULL;
@@ -164,14 +156,13 @@ static const EVP_CIPHER *sc_ossl_aes_192_cbc(void)
 static EVP_CIPHER *_hidden_aes_256_cbc = NULL;
 static const EVP_CIPHER *sc_ossl_aes_256_cbc(void)
 {
-    if( _hidden_aes_256_cbc == NULL
-        && ((_hidden_aes_256_cbc = EVP_CIPHER_meth_new(NID_aes_256_cbc, SYMCRYPT_AES_BLOCK_SIZE , AES_256_KEY_SIZE)) == NULL
-            || !EVP_CIPHER_meth_set_iv_length(_hidden_aes_256_cbc,16)
-            || !EVP_CIPHER_meth_set_flags(_hidden_aes_256_cbc, AES_CBC_FLAGS)
-            || !EVP_CIPHER_meth_set_init(_hidden_aes_256_cbc, sc_ossl_aes_cbc_init_key)
-            || !EVP_CIPHER_meth_set_do_cipher(_hidden_aes_256_cbc, sc_ossl_aes_cbc_cipher)
-            || !EVP_CIPHER_meth_set_ctrl(_hidden_aes_256_cbc, sc_ossl_aes_cbc_ctrl)
-            || !EVP_CIPHER_meth_set_impl_ctx_size(_hidden_aes_256_cbc, sizeof(struct cipher_cbc_ctx))) )
+    if( (_hidden_aes_256_cbc = EVP_CIPHER_meth_new(NID_aes_256_cbc, SYMCRYPT_AES_BLOCK_SIZE , AES_256_KEY_SIZE)) == NULL
+        || !EVP_CIPHER_meth_set_iv_length(_hidden_aes_256_cbc,16)
+        || !EVP_CIPHER_meth_set_flags(_hidden_aes_256_cbc, AES_CBC_FLAGS)
+        || !EVP_CIPHER_meth_set_init(_hidden_aes_256_cbc, sc_ossl_aes_cbc_init_key)
+        || !EVP_CIPHER_meth_set_do_cipher(_hidden_aes_256_cbc, sc_ossl_aes_cbc_cipher)
+        || !EVP_CIPHER_meth_set_ctrl(_hidden_aes_256_cbc, sc_ossl_aes_cbc_ctrl)
+        || !EVP_CIPHER_meth_set_impl_ctx_size(_hidden_aes_256_cbc, sizeof(struct cipher_cbc_ctx)) )
     {
         EVP_CIPHER_meth_free(_hidden_aes_256_cbc);
         _hidden_aes_256_cbc = NULL;
@@ -190,14 +181,13 @@ static SCOSSL_STATUS sc_ossl_aes_ecb_ctrl(_In_ EVP_CIPHER_CTX *ctx, int type, in
 static EVP_CIPHER *_hidden_aes_128_ecb = NULL;
 static const EVP_CIPHER *sc_ossl_aes_128_ecb(void)
 {
-    if( _hidden_aes_128_ecb == NULL
-        && ((_hidden_aes_128_ecb = EVP_CIPHER_meth_new(NID_aes_128_ecb, SYMCRYPT_AES_BLOCK_SIZE , AES_128_KEY_SIZE)) == NULL
-            || !EVP_CIPHER_meth_set_iv_length(_hidden_aes_128_ecb,16)
-            || !EVP_CIPHER_meth_set_flags(_hidden_aes_128_ecb, AES_ECB_FLAGS)
-            || !EVP_CIPHER_meth_set_init(_hidden_aes_128_ecb, sc_ossl_aes_ecb_init_key)
-            || !EVP_CIPHER_meth_set_do_cipher(_hidden_aes_128_ecb, sc_ossl_aes_ecb_cipher)
-            || !EVP_CIPHER_meth_set_ctrl(_hidden_aes_128_ecb, sc_ossl_aes_ecb_ctrl)
-            || !EVP_CIPHER_meth_set_impl_ctx_size(_hidden_aes_128_ecb, sizeof(struct cipher_ecb_ctx))) )
+    if( (_hidden_aes_128_ecb = EVP_CIPHER_meth_new(NID_aes_128_ecb, SYMCRYPT_AES_BLOCK_SIZE , AES_128_KEY_SIZE)) == NULL
+        || !EVP_CIPHER_meth_set_iv_length(_hidden_aes_128_ecb,16)
+        || !EVP_CIPHER_meth_set_flags(_hidden_aes_128_ecb, AES_ECB_FLAGS)
+        || !EVP_CIPHER_meth_set_init(_hidden_aes_128_ecb, sc_ossl_aes_ecb_init_key)
+        || !EVP_CIPHER_meth_set_do_cipher(_hidden_aes_128_ecb, sc_ossl_aes_ecb_cipher)
+        || !EVP_CIPHER_meth_set_ctrl(_hidden_aes_128_ecb, sc_ossl_aes_ecb_ctrl)
+        || !EVP_CIPHER_meth_set_impl_ctx_size(_hidden_aes_128_ecb, sizeof(struct cipher_ecb_ctx)) )
     {
         EVP_CIPHER_meth_free(_hidden_aes_128_ecb);
         _hidden_aes_128_ecb = NULL;
@@ -209,14 +199,13 @@ static const EVP_CIPHER *sc_ossl_aes_128_ecb(void)
 static EVP_CIPHER *_hidden_aes_192_ecb = NULL;
 static const EVP_CIPHER *sc_ossl_aes_192_ecb(void)
 {
-    if( _hidden_aes_192_ecb == NULL
-        && ((_hidden_aes_192_ecb = EVP_CIPHER_meth_new(NID_aes_192_ecb, SYMCRYPT_AES_BLOCK_SIZE , AES_192_KEY_SIZE)) == NULL
-            || !EVP_CIPHER_meth_set_iv_length(_hidden_aes_192_ecb,16)
-            || !EVP_CIPHER_meth_set_flags(_hidden_aes_192_ecb, AES_ECB_FLAGS)
-            || !EVP_CIPHER_meth_set_init(_hidden_aes_192_ecb, sc_ossl_aes_ecb_init_key)
-            || !EVP_CIPHER_meth_set_do_cipher(_hidden_aes_192_ecb, sc_ossl_aes_ecb_cipher)
-            || !EVP_CIPHER_meth_set_ctrl(_hidden_aes_192_ecb, sc_ossl_aes_ecb_ctrl)
-            || !EVP_CIPHER_meth_set_impl_ctx_size(_hidden_aes_192_ecb, sizeof(struct cipher_ecb_ctx))) )
+    if( (_hidden_aes_192_ecb = EVP_CIPHER_meth_new(NID_aes_192_ecb, SYMCRYPT_AES_BLOCK_SIZE , AES_192_KEY_SIZE)) == NULL
+        || !EVP_CIPHER_meth_set_iv_length(_hidden_aes_192_ecb,16)
+        || !EVP_CIPHER_meth_set_flags(_hidden_aes_192_ecb, AES_ECB_FLAGS)
+        || !EVP_CIPHER_meth_set_init(_hidden_aes_192_ecb, sc_ossl_aes_ecb_init_key)
+        || !EVP_CIPHER_meth_set_do_cipher(_hidden_aes_192_ecb, sc_ossl_aes_ecb_cipher)
+        || !EVP_CIPHER_meth_set_ctrl(_hidden_aes_192_ecb, sc_ossl_aes_ecb_ctrl)
+        || !EVP_CIPHER_meth_set_impl_ctx_size(_hidden_aes_192_ecb, sizeof(struct cipher_ecb_ctx)) )
     {
         EVP_CIPHER_meth_free(_hidden_aes_192_ecb);
         _hidden_aes_192_ecb = NULL;
@@ -228,14 +217,13 @@ static const EVP_CIPHER *sc_ossl_aes_192_ecb(void)
 static EVP_CIPHER *_hidden_aes_256_ecb = NULL;
 static const EVP_CIPHER *sc_ossl_aes_256_ecb(void)
 {
-    if( _hidden_aes_256_ecb == NULL
-        && ((_hidden_aes_256_ecb = EVP_CIPHER_meth_new(NID_aes_256_ecb, SYMCRYPT_AES_BLOCK_SIZE , AES_256_KEY_SIZE)) == NULL
-            || !EVP_CIPHER_meth_set_iv_length(_hidden_aes_256_ecb, 16)
-            || !EVP_CIPHER_meth_set_flags(_hidden_aes_256_ecb, AES_ECB_FLAGS)
-            || !EVP_CIPHER_meth_set_init(_hidden_aes_256_ecb, sc_ossl_aes_ecb_init_key)
-            || !EVP_CIPHER_meth_set_do_cipher(_hidden_aes_256_ecb, sc_ossl_aes_ecb_cipher)
-            || !EVP_CIPHER_meth_set_ctrl(_hidden_aes_256_ecb, sc_ossl_aes_ecb_ctrl)
-            || !EVP_CIPHER_meth_set_impl_ctx_size(_hidden_aes_256_ecb, sizeof(struct cipher_ecb_ctx))) )
+    if( (_hidden_aes_256_ecb = EVP_CIPHER_meth_new(NID_aes_256_ecb, SYMCRYPT_AES_BLOCK_SIZE , AES_256_KEY_SIZE)) == NULL
+        || !EVP_CIPHER_meth_set_iv_length(_hidden_aes_256_ecb, 16)
+        || !EVP_CIPHER_meth_set_flags(_hidden_aes_256_ecb, AES_ECB_FLAGS)
+        || !EVP_CIPHER_meth_set_init(_hidden_aes_256_ecb, sc_ossl_aes_ecb_init_key)
+        || !EVP_CIPHER_meth_set_do_cipher(_hidden_aes_256_ecb, sc_ossl_aes_ecb_cipher)
+        || !EVP_CIPHER_meth_set_ctrl(_hidden_aes_256_ecb, sc_ossl_aes_ecb_ctrl)
+        || !EVP_CIPHER_meth_set_impl_ctx_size(_hidden_aes_256_ecb, sizeof(struct cipher_ecb_ctx)) )
     {
         EVP_CIPHER_meth_free(_hidden_aes_256_ecb);
         _hidden_aes_256_ecb = NULL;
@@ -243,7 +231,8 @@ static const EVP_CIPHER *sc_ossl_aes_256_ecb(void)
     return _hidden_aes_256_ecb;
 }
 
-
+// Disabling XTS for now - remove with if region to avoid unused function warning
+#if 0
 SCOSSL_STATUS sc_ossl_aes_xts_init_key(
     _Inout_ EVP_CIPHER_CTX *ctx, _In_ const unsigned char *key, _In_ const unsigned char *iv, SC_OSSL_ENCRYPTION_MODE enc);
 SCOSSL_STATUS sc_ossl_aes_xts_cipher(
@@ -256,16 +245,14 @@ static SCOSSL_STATUS sc_ossl_aes_xts_ctrl(_Inout_ EVP_CIPHER_CTX *ctx, int type,
 static EVP_CIPHER *_hidden_aes_128_xts = NULL;
 static const EVP_CIPHER *sc_ossl_aes_128_xts(void)
 {
-    if( _hidden_aes_128_xts == NULL
-        && ((_hidden_aes_128_xts = EVP_CIPHER_meth_new(NID_aes_128_xts, SYMCRYPT_AES_BLOCK_SIZE , AES_128_KEY_SIZE * 2)) == NULL
-            || !EVP_CIPHER_meth_set_iv_length(_hidden_aes_128_xts, 16)
-            || !EVP_CIPHER_meth_set_flags(_hidden_aes_128_xts, AES_XTS_FLAGS)
-            || !EVP_CIPHER_meth_set_init(_hidden_aes_128_xts, sc_ossl_aes_xts_init_key)
-            || !EVP_CIPHER_meth_set_do_cipher(_hidden_aes_128_xts, sc_ossl_aes_xts_cipher)
-            || !EVP_CIPHER_meth_set_ctrl(_hidden_aes_128_xts, sc_ossl_aes_xts_ctrl)
-            || !EVP_CIPHER_meth_set_impl_ctx_size(_hidden_aes_128_xts, sizeof(struct cipher_xts_ctx))) )
+    if( (_hidden_aes_128_xts = EVP_CIPHER_meth_new(NID_aes_128_xts, SYMCRYPT_AES_BLOCK_SIZE , AES_128_KEY_SIZE * 2)) == NULL
+        || !EVP_CIPHER_meth_set_iv_length(_hidden_aes_128_xts, 16)
+        || !EVP_CIPHER_meth_set_flags(_hidden_aes_128_xts, AES_XTS_FLAGS)
+        || !EVP_CIPHER_meth_set_init(_hidden_aes_128_xts, sc_ossl_aes_xts_init_key)
+        || !EVP_CIPHER_meth_set_do_cipher(_hidden_aes_128_xts, sc_ossl_aes_xts_cipher)
+        || !EVP_CIPHER_meth_set_ctrl(_hidden_aes_128_xts, sc_ossl_aes_xts_ctrl)
+        || !EVP_CIPHER_meth_set_impl_ctx_size(_hidden_aes_128_xts, sizeof(struct cipher_xts_ctx)) )
     {
-        SC_OSSL_LOG_ERROR("CIPHER Initialization Failed");
         EVP_CIPHER_meth_free(_hidden_aes_128_xts);
         _hidden_aes_128_xts = NULL;
     }
@@ -276,21 +263,20 @@ static const EVP_CIPHER *sc_ossl_aes_128_xts(void)
 static EVP_CIPHER *_hidden_aes_256_xts = NULL;
 static const EVP_CIPHER *sc_ossl_aes_256_xts(void)
 {
-    if( _hidden_aes_256_xts == NULL
-        && ((_hidden_aes_256_xts = EVP_CIPHER_meth_new(NID_aes_256_xts, SYMCRYPT_AES_BLOCK_SIZE , AES_256_KEY_SIZE * 2)) == NULL
-            || !EVP_CIPHER_meth_set_iv_length(_hidden_aes_256_xts, 16)
-            || !EVP_CIPHER_meth_set_flags(_hidden_aes_256_xts, AES_XTS_FLAGS)
-            || !EVP_CIPHER_meth_set_init(_hidden_aes_256_xts, sc_ossl_aes_xts_init_key)
-            || !EVP_CIPHER_meth_set_do_cipher(_hidden_aes_256_xts, sc_ossl_aes_xts_cipher)
-            || !EVP_CIPHER_meth_set_ctrl(_hidden_aes_256_xts, sc_ossl_aes_xts_ctrl)
-            || !EVP_CIPHER_meth_set_impl_ctx_size(_hidden_aes_256_xts, sizeof(struct cipher_xts_ctx))) )
+    if( (_hidden_aes_256_xts = EVP_CIPHER_meth_new(NID_aes_256_xts, SYMCRYPT_AES_BLOCK_SIZE , AES_256_KEY_SIZE * 2)) == NULL
+        || !EVP_CIPHER_meth_set_iv_length(_hidden_aes_256_xts, 16)
+        || !EVP_CIPHER_meth_set_flags(_hidden_aes_256_xts, AES_XTS_FLAGS)
+        || !EVP_CIPHER_meth_set_init(_hidden_aes_256_xts, sc_ossl_aes_xts_init_key)
+        || !EVP_CIPHER_meth_set_do_cipher(_hidden_aes_256_xts, sc_ossl_aes_xts_cipher)
+        || !EVP_CIPHER_meth_set_ctrl(_hidden_aes_256_xts, sc_ossl_aes_xts_ctrl)
+        || !EVP_CIPHER_meth_set_impl_ctx_size(_hidden_aes_256_xts, sizeof(struct cipher_xts_ctx)) )
     {
-        SC_OSSL_LOG_ERROR("CIPHER Initialization Failed");
         EVP_CIPHER_meth_free(_hidden_aes_256_xts);
         _hidden_aes_256_xts = NULL;
     }
     return _hidden_aes_256_xts;
 }
+#endif
 
 
 SCOSSL_STATUS sc_ossl_aes_gcm_init_key(
@@ -306,14 +292,13 @@ static SCOSSL_STATUS sc_ossl_aes_gcm_ctrl(_Inout_ EVP_CIPHER_CTX *ctx, int type,
 static EVP_CIPHER *_hidden_aes_128_gcm = NULL;
 static const EVP_CIPHER *sc_ossl_aes_128_gcm(void)
 {
-    if( _hidden_aes_128_gcm == NULL
-        && ((_hidden_aes_128_gcm = EVP_CIPHER_meth_new(NID_aes_128_gcm, 1, AES_128_KEY_SIZE)) == NULL
-            || !EVP_CIPHER_meth_set_iv_length(_hidden_aes_128_gcm,12)
-            || !EVP_CIPHER_meth_set_flags(_hidden_aes_128_gcm, AES_GCM_FLAGS)
-            || !EVP_CIPHER_meth_set_init(_hidden_aes_128_gcm, sc_ossl_aes_gcm_init_key)
-            || !EVP_CIPHER_meth_set_do_cipher(_hidden_aes_128_gcm, sc_ossl_aes_gcm_cipher)
-            || !EVP_CIPHER_meth_set_ctrl(_hidden_aes_128_gcm, sc_ossl_aes_gcm_ctrl)
-            || !EVP_CIPHER_meth_set_impl_ctx_size(_hidden_aes_128_gcm, sizeof(struct cipher_gcm_ctx))) )
+    if( (_hidden_aes_128_gcm = EVP_CIPHER_meth_new(NID_aes_128_gcm, 1, AES_128_KEY_SIZE)) == NULL
+        || !EVP_CIPHER_meth_set_iv_length(_hidden_aes_128_gcm,12)
+        || !EVP_CIPHER_meth_set_flags(_hidden_aes_128_gcm, AES_GCM_FLAGS)
+        || !EVP_CIPHER_meth_set_init(_hidden_aes_128_gcm, sc_ossl_aes_gcm_init_key)
+        || !EVP_CIPHER_meth_set_do_cipher(_hidden_aes_128_gcm, sc_ossl_aes_gcm_cipher)
+        || !EVP_CIPHER_meth_set_ctrl(_hidden_aes_128_gcm, sc_ossl_aes_gcm_ctrl)
+        || !EVP_CIPHER_meth_set_impl_ctx_size(_hidden_aes_128_gcm, sizeof(struct cipher_gcm_ctx)) )
     {
         EVP_CIPHER_meth_free(_hidden_aes_128_gcm);
         _hidden_aes_128_gcm = NULL;
@@ -325,14 +310,13 @@ static const EVP_CIPHER *sc_ossl_aes_128_gcm(void)
 static EVP_CIPHER *_hidden_aes_192_gcm = NULL;
 static const EVP_CIPHER *sc_ossl_aes_192_gcm(void)
 {
-    if( _hidden_aes_192_gcm == NULL
-        && ((_hidden_aes_192_gcm = EVP_CIPHER_meth_new(NID_aes_192_gcm, 1, AES_192_KEY_SIZE)) == NULL
-            || !EVP_CIPHER_meth_set_iv_length(_hidden_aes_192_gcm,12)
-            || !EVP_CIPHER_meth_set_flags(_hidden_aes_192_gcm, AES_GCM_FLAGS)
-            || !EVP_CIPHER_meth_set_init(_hidden_aes_192_gcm, sc_ossl_aes_gcm_init_key)
-            || !EVP_CIPHER_meth_set_do_cipher(_hidden_aes_192_gcm, sc_ossl_aes_gcm_cipher)
-            || !EVP_CIPHER_meth_set_ctrl(_hidden_aes_192_gcm, sc_ossl_aes_gcm_ctrl)
-            || !EVP_CIPHER_meth_set_impl_ctx_size(_hidden_aes_192_gcm, sizeof(struct cipher_gcm_ctx))) )
+    if( (_hidden_aes_192_gcm = EVP_CIPHER_meth_new(NID_aes_192_gcm, 1, AES_192_KEY_SIZE)) == NULL
+        || !EVP_CIPHER_meth_set_iv_length(_hidden_aes_192_gcm,12)
+        || !EVP_CIPHER_meth_set_flags(_hidden_aes_192_gcm, AES_GCM_FLAGS)
+        || !EVP_CIPHER_meth_set_init(_hidden_aes_192_gcm, sc_ossl_aes_gcm_init_key)
+        || !EVP_CIPHER_meth_set_do_cipher(_hidden_aes_192_gcm, sc_ossl_aes_gcm_cipher)
+        || !EVP_CIPHER_meth_set_ctrl(_hidden_aes_192_gcm, sc_ossl_aes_gcm_ctrl)
+        || !EVP_CIPHER_meth_set_impl_ctx_size(_hidden_aes_192_gcm, sizeof(struct cipher_gcm_ctx)) )
     {
         EVP_CIPHER_meth_free(_hidden_aes_192_gcm);
         _hidden_aes_192_gcm = NULL;
@@ -344,14 +328,13 @@ static const EVP_CIPHER *sc_ossl_aes_192_gcm(void)
 static EVP_CIPHER *_hidden_aes_256_gcm = NULL;
 static const EVP_CIPHER *sc_ossl_aes_256_gcm(void)
 {
-    if( _hidden_aes_256_gcm == NULL
-        && ((_hidden_aes_256_gcm = EVP_CIPHER_meth_new(NID_aes_256_gcm, 1, AES_256_KEY_SIZE)) == NULL
-            || !EVP_CIPHER_meth_set_iv_length(_hidden_aes_256_gcm,12)
-            || !EVP_CIPHER_meth_set_flags(_hidden_aes_256_gcm, AES_GCM_FLAGS)
-            || !EVP_CIPHER_meth_set_init(_hidden_aes_256_gcm, sc_ossl_aes_gcm_init_key)
-            || !EVP_CIPHER_meth_set_do_cipher(_hidden_aes_256_gcm, sc_ossl_aes_gcm_cipher)
-            || !EVP_CIPHER_meth_set_ctrl(_hidden_aes_256_gcm, sc_ossl_aes_gcm_ctrl)
-            || !EVP_CIPHER_meth_set_impl_ctx_size(_hidden_aes_256_gcm, sizeof(struct cipher_gcm_ctx))) )
+    if( (_hidden_aes_256_gcm = EVP_CIPHER_meth_new(NID_aes_256_gcm, 1, AES_256_KEY_SIZE)) == NULL
+        || !EVP_CIPHER_meth_set_iv_length(_hidden_aes_256_gcm,12)
+        || !EVP_CIPHER_meth_set_flags(_hidden_aes_256_gcm, AES_GCM_FLAGS)
+        || !EVP_CIPHER_meth_set_init(_hidden_aes_256_gcm, sc_ossl_aes_gcm_init_key)
+        || !EVP_CIPHER_meth_set_do_cipher(_hidden_aes_256_gcm, sc_ossl_aes_gcm_cipher)
+        || !EVP_CIPHER_meth_set_ctrl(_hidden_aes_256_gcm, sc_ossl_aes_gcm_ctrl)
+        || !EVP_CIPHER_meth_set_impl_ctx_size(_hidden_aes_256_gcm, sizeof(struct cipher_gcm_ctx)) )
     {
         EVP_CIPHER_meth_free(_hidden_aes_256_gcm);
         _hidden_aes_256_gcm = NULL;
@@ -372,13 +355,12 @@ static SCOSSL_STATUS sc_ossl_aes_ccm_ctrl(_Inout_ EVP_CIPHER_CTX *ctx, int type,
 static EVP_CIPHER *_hidden_aes_128_ccm = NULL;
 static const EVP_CIPHER *sc_ossl_aes_128_ccm(void)
 {
-    if( _hidden_aes_128_ccm == NULL
-        && ((_hidden_aes_128_ccm = EVP_CIPHER_meth_new(NID_aes_128_ccm, 1, AES_128_KEY_SIZE)) == NULL
-            || !EVP_CIPHER_meth_set_flags(_hidden_aes_128_ccm, AES_CCM_FLAGS)
-            || !EVP_CIPHER_meth_set_init(_hidden_aes_128_ccm, sc_ossl_aes_ccm_init_key)
-            || !EVP_CIPHER_meth_set_do_cipher(_hidden_aes_128_ccm, sc_ossl_aes_ccm_cipher)
-            || !EVP_CIPHER_meth_set_ctrl(_hidden_aes_128_ccm, sc_ossl_aes_ccm_ctrl)
-            || !EVP_CIPHER_meth_set_impl_ctx_size(_hidden_aes_128_ccm, sizeof(struct cipher_ccm_ctx))) )
+    if( (_hidden_aes_128_ccm = EVP_CIPHER_meth_new(NID_aes_128_ccm, 1, AES_128_KEY_SIZE)) == NULL
+        || !EVP_CIPHER_meth_set_flags(_hidden_aes_128_ccm, AES_CCM_FLAGS)
+        || !EVP_CIPHER_meth_set_init(_hidden_aes_128_ccm, sc_ossl_aes_ccm_init_key)
+        || !EVP_CIPHER_meth_set_do_cipher(_hidden_aes_128_ccm, sc_ossl_aes_ccm_cipher)
+        || !EVP_CIPHER_meth_set_ctrl(_hidden_aes_128_ccm, sc_ossl_aes_ccm_ctrl)
+        || !EVP_CIPHER_meth_set_impl_ctx_size(_hidden_aes_128_ccm, sizeof(struct cipher_ccm_ctx)) )
     {
         EVP_CIPHER_meth_free(_hidden_aes_128_ccm);
         _hidden_aes_128_ccm = NULL;
@@ -390,13 +372,12 @@ static const EVP_CIPHER *sc_ossl_aes_128_ccm(void)
 static EVP_CIPHER *_hidden_aes_192_ccm = NULL;
 static const EVP_CIPHER *sc_ossl_aes_192_ccm(void)
 {
-    if( _hidden_aes_192_ccm == NULL
-        && ((_hidden_aes_192_ccm = EVP_CIPHER_meth_new(NID_aes_192_ccm, 1, AES_192_KEY_SIZE)) == NULL
-            || !EVP_CIPHER_meth_set_flags(_hidden_aes_192_ccm, AES_CCM_FLAGS)
-            || !EVP_CIPHER_meth_set_init(_hidden_aes_192_ccm, sc_ossl_aes_ccm_init_key)
-            || !EVP_CIPHER_meth_set_do_cipher(_hidden_aes_192_ccm, sc_ossl_aes_ccm_cipher)
-            || !EVP_CIPHER_meth_set_ctrl(_hidden_aes_192_ccm, sc_ossl_aes_ccm_ctrl)
-            || !EVP_CIPHER_meth_set_impl_ctx_size(_hidden_aes_192_ccm, sizeof(struct cipher_ccm_ctx))) )
+    if( (_hidden_aes_192_ccm = EVP_CIPHER_meth_new(NID_aes_192_ccm, 1, AES_192_KEY_SIZE)) == NULL
+        || !EVP_CIPHER_meth_set_flags(_hidden_aes_192_ccm, AES_CCM_FLAGS)
+        || !EVP_CIPHER_meth_set_init(_hidden_aes_192_ccm, sc_ossl_aes_ccm_init_key)
+        || !EVP_CIPHER_meth_set_do_cipher(_hidden_aes_192_ccm, sc_ossl_aes_ccm_cipher)
+        || !EVP_CIPHER_meth_set_ctrl(_hidden_aes_192_ccm, sc_ossl_aes_ccm_ctrl)
+        || !EVP_CIPHER_meth_set_impl_ctx_size(_hidden_aes_192_ccm, sizeof(struct cipher_ccm_ctx)) )
     {
         EVP_CIPHER_meth_free(_hidden_aes_192_ccm);
         _hidden_aes_192_ccm = NULL;
@@ -408,13 +389,12 @@ static const EVP_CIPHER *sc_ossl_aes_192_ccm(void)
 static EVP_CIPHER *_hidden_aes_256_ccm = NULL;
 static const EVP_CIPHER *sc_ossl_aes_256_ccm(void)
 {
-    if( _hidden_aes_256_ccm == NULL
-        && ((_hidden_aes_256_ccm = EVP_CIPHER_meth_new(NID_aes_256_ccm, 1, AES_256_KEY_SIZE)) == NULL
-            || !EVP_CIPHER_meth_set_flags(_hidden_aes_256_ccm, AES_CCM_FLAGS)
-            || !EVP_CIPHER_meth_set_init(_hidden_aes_256_ccm, sc_ossl_aes_ccm_init_key)
-            || !EVP_CIPHER_meth_set_do_cipher(_hidden_aes_256_ccm, sc_ossl_aes_ccm_cipher)
-            || !EVP_CIPHER_meth_set_ctrl(_hidden_aes_256_ccm, sc_ossl_aes_ccm_ctrl)
-            || !EVP_CIPHER_meth_set_impl_ctx_size(_hidden_aes_256_ccm, sizeof(struct cipher_ccm_ctx))) )
+    if( (_hidden_aes_256_ccm = EVP_CIPHER_meth_new(NID_aes_256_ccm, 1, AES_256_KEY_SIZE)) == NULL
+        || !EVP_CIPHER_meth_set_flags(_hidden_aes_256_ccm, AES_CCM_FLAGS)
+        || !EVP_CIPHER_meth_set_init(_hidden_aes_256_ccm, sc_ossl_aes_ccm_init_key)
+        || !EVP_CIPHER_meth_set_do_cipher(_hidden_aes_256_ccm, sc_ossl_aes_ccm_cipher)
+        || !EVP_CIPHER_meth_set_ctrl(_hidden_aes_256_ccm, sc_ossl_aes_ccm_ctrl)
+        || !EVP_CIPHER_meth_set_impl_ctx_size(_hidden_aes_256_ccm, sizeof(struct cipher_ccm_ctx)) )
     {
         EVP_CIPHER_meth_free(_hidden_aes_256_ccm);
         _hidden_aes_256_ccm = NULL;
@@ -445,14 +425,36 @@ void sc_ossl_destroy_ciphers(void)
     _hidden_aes_128_ecb = NULL;
     _hidden_aes_192_ecb = NULL;
     _hidden_aes_256_ecb = NULL;
-    _hidden_aes_128_xts = NULL;
-    _hidden_aes_256_xts = NULL;
+    // _hidden_aes_128_xts = NULL;
+    // _hidden_aes_256_xts = NULL;
     _hidden_aes_128_gcm = NULL;
     _hidden_aes_192_gcm = NULL;
     _hidden_aes_256_gcm = NULL;
     _hidden_aes_128_ccm = NULL;
     _hidden_aes_192_ccm = NULL;
     _hidden_aes_256_ccm = NULL;
+}
+
+SCOSSL_STATUS scossl_ciphers_init_static()
+{
+    if( (sc_ossl_aes_128_cbc() == NULL) ||
+        (sc_ossl_aes_192_cbc() == NULL) ||
+        (sc_ossl_aes_256_cbc() == NULL) ||
+        (sc_ossl_aes_128_ecb() == NULL) ||
+        (sc_ossl_aes_192_ecb() == NULL) ||
+        (sc_ossl_aes_256_ecb() == NULL) ||
+        // (sc_ossl_aes_128_xts() == NULL) ||
+        // (sc_ossl_aes_256_xts() == NULL) ||
+        (sc_ossl_aes_128_gcm() == NULL) ||
+        (sc_ossl_aes_192_gcm() == NULL) ||
+        (sc_ossl_aes_256_gcm() == NULL) ||
+        (sc_ossl_aes_128_ccm() == NULL) ||
+        (sc_ossl_aes_192_ccm() == NULL) ||
+        (sc_ossl_aes_256_ccm() == NULL) )
+    {
+        return 0;
+    }
+    return 1;
 }
 
 int sc_ossl_ciphers(ENGINE *e, const EVP_CIPHER **cipher,
@@ -471,46 +473,46 @@ int sc_ossl_ciphers(ENGINE *e, const EVP_CIPHER **cipher,
     switch( nid )
     {
     case NID_aes_128_cbc:
-        *cipher = sc_ossl_aes_128_cbc();
+        *cipher = _hidden_aes_128_cbc;
         break;
     case NID_aes_192_cbc:
-        *cipher = sc_ossl_aes_192_cbc();
+        *cipher = _hidden_aes_192_cbc;
         break;
     case NID_aes_256_cbc:
-        *cipher = sc_ossl_aes_256_cbc();
+        *cipher = _hidden_aes_256_cbc;
         break;
     case NID_aes_128_ecb:
-        *cipher = sc_ossl_aes_128_ecb();
+        *cipher = _hidden_aes_128_ecb;
         break;
     case NID_aes_192_ecb:
-        *cipher = sc_ossl_aes_192_ecb();
+        *cipher = _hidden_aes_192_ecb;
         break;
     case NID_aes_256_ecb:
-        *cipher = sc_ossl_aes_256_ecb();
+        *cipher = _hidden_aes_256_ecb;
         break;
     // case NID_aes_128_xts:
-    //     *cipher = sc_ossl_aes_128_xts();
+    //     *cipher = _hidden_aes_128_xts;
     //     break;
     // case NID_aes_256_xts:
-    //     *cipher = sc_ossl_aes_256_xts();
+    //     *cipher = _hidden_aes_256_xts;
     //     break;
     case NID_aes_128_gcm:
-        *cipher = sc_ossl_aes_128_gcm();
+        *cipher = _hidden_aes_128_gcm;
         break;
     case NID_aes_192_gcm:
-        *cipher = sc_ossl_aes_192_gcm();
+        *cipher = _hidden_aes_192_gcm;
         break;
     case NID_aes_256_gcm:
-        *cipher = sc_ossl_aes_256_gcm();
+        *cipher = _hidden_aes_256_gcm;
         break;
     case NID_aes_128_ccm:
-        *cipher = sc_ossl_aes_128_ccm();
+        *cipher = _hidden_aes_128_ccm;
         break;
     case NID_aes_192_ccm:
-        *cipher = sc_ossl_aes_192_ccm();
+        *cipher = _hidden_aes_192_ccm;
         break;
     case NID_aes_256_ccm:
-        *cipher = sc_ossl_aes_256_ccm();
+        *cipher = _hidden_aes_256_ccm;
         break;
     default:
         ok = 0;
@@ -525,22 +527,12 @@ int sc_ossl_ciphers(ENGINE *e, const EVP_CIPHER **cipher,
  */
 
 // Initializes ctx with the provided key and iv, along with enc/dec mode.
-// enc should be set to 1 for encryption, 0 for decryption, and -1 to leave value unchanged.
 // Returns 1 on success, or 0 on error.
 SCOSSL_STATUS sc_ossl_aes_cbc_init_key(_Inout_ EVP_CIPHER_CTX *ctx, _In_ const unsigned char *key,
                              _In_ const unsigned char *iv, SC_OSSL_ENCRYPTION_MODE enc)
 {
     struct cipher_cbc_ctx *cipherCtx = (struct cipher_cbc_ctx *)EVP_CIPHER_CTX_get_cipher_data(ctx);
     SYMCRYPT_ERROR SymError = SYMCRYPT_NO_ERROR;
-    PBYTE ctx_iv = EVP_CIPHER_CTX_iv_noconst(ctx);
-    if( enc != SC_OSSL_ENCRYPTION_MODE_NOCHANGE )
-    {
-        cipherCtx->enc = enc;
-    }
-    if( iv )
-    {
-        memcpy(ctx_iv, iv, EVP_CIPHER_CTX_iv_length(ctx));
-    }
     if( key )
     {
         SymError = SymCryptAesExpandKey(&cipherCtx->key, key, EVP_CIPHER_CTX_key_length(ctx));
@@ -557,26 +549,18 @@ SCOSSL_STATUS sc_ossl_aes_cbc_init_key(_Inout_ EVP_CIPHER_CTX *ctx, _In_ const u
 SCOSSL_STATUS sc_ossl_aes_cbc_cipher(_Inout_ EVP_CIPHER_CTX *ctx, _Out_ unsigned char *out,
                                _In_reads_bytes_(inl) const unsigned char *in, size_t inl)
 {
-    int ret = 0;
     struct cipher_cbc_ctx *cipherCtx = (struct cipher_cbc_ctx *)EVP_CIPHER_CTX_get_cipher_data(ctx);
     PBYTE ctx_iv = EVP_CIPHER_CTX_iv_noconst(ctx);
-    if( cipherCtx->enc == SC_OSSL_ENCRYPTION_MODE_ENCRYPT )
+    if( EVP_CIPHER_CTX_encrypting(ctx) )
     {
         SymCryptAesCbcEncrypt(&cipherCtx->key, ctx_iv, in, out, inl);
     }
-    else if( cipherCtx->enc == SC_OSSL_ENCRYPTION_MODE_DECRYPT )
+    else
     {
         SymCryptAesCbcDecrypt(&cipherCtx->key, ctx_iv, in, out, inl);
     }
-    else
-    {
-        SC_OSSL_LOG_ERROR("Encryption mode not set");
-        return 0;
-    }
 
-    ret = 1;
-
-    return ret;
+    return 1;
 }
 
 // Allows various cipher specific parameters to be determined and set.
@@ -608,17 +592,12 @@ static SCOSSL_STATUS sc_ossl_aes_cbc_ctrl(_In_ EVP_CIPHER_CTX *ctx, int type, in
  */
 
 // Initializes ctx with the provided key and iv, along with enc/dec mode.
-// enc should be set to 1 for encryption, 0 for decryption, and -1 to leave value unchanged.
 // Returns 1 on success, or 0 on error.
 SCOSSL_STATUS sc_ossl_aes_ecb_init_key(_Inout_ EVP_CIPHER_CTX *ctx, _In_ const unsigned char *key,
                              _In_ const unsigned char *iv, SC_OSSL_ENCRYPTION_MODE enc)
 {
     struct cipher_ecb_ctx *cipherCtx = (struct cipher_ecb_ctx *)EVP_CIPHER_CTX_get_cipher_data(ctx);
     SYMCRYPT_ERROR SymError = SYMCRYPT_NO_ERROR;
-    if( enc != SC_OSSL_ENCRYPTION_MODE_NOCHANGE )
-    {
-        cipherCtx->enc = enc;
-    }
     if( key )
     {
         SymError = SymCryptAesExpandKey(&cipherCtx->key, key, EVP_CIPHER_CTX_key_length(ctx));
@@ -635,25 +614,17 @@ SCOSSL_STATUS sc_ossl_aes_ecb_init_key(_Inout_ EVP_CIPHER_CTX *ctx, _In_ const u
 SCOSSL_STATUS sc_ossl_aes_ecb_cipher(_Inout_ EVP_CIPHER_CTX *ctx, _Out_ unsigned char *out,
                                _In_reads_bytes_(inl) const unsigned char *in, size_t inl)
 {
-    int ret = 0;
     struct cipher_ecb_ctx *cipherCtx = (struct cipher_ecb_ctx *)EVP_CIPHER_CTX_get_cipher_data(ctx);
-    if( cipherCtx->enc == SC_OSSL_ENCRYPTION_MODE_ENCRYPT )
+    if( EVP_CIPHER_CTX_encrypting(ctx) )
     {
         SymCryptAesEcbEncrypt(&cipherCtx->key, in, out, inl);
     }
-    else if( cipherCtx->enc == SC_OSSL_ENCRYPTION_MODE_DECRYPT )
+    else
     {
         SymCryptAesEcbDecrypt(&cipherCtx->key, in, out, inl);
     }
-    else
-    {
-        SC_OSSL_LOG_ERROR("Encryption mode not set");
-        return 0;
-    }
 
-    ret = 1;
-
-    return ret;
+    return 1;
 }
 
 // Allows various cipher specific parameters to be determined and set.
@@ -661,8 +632,8 @@ SCOSSL_STATUS sc_ossl_aes_ecb_cipher(_Inout_ EVP_CIPHER_CTX *ctx, _Out_ unsigned
 static SCOSSL_STATUS sc_ossl_aes_ecb_ctrl(_In_ EVP_CIPHER_CTX *ctx, int type, int arg,
                                     _Inout_ void *ptr)
 {
-    struct cipher_cbc_ctx *srcCtx;
-    struct cipher_cbc_ctx *dstCtx;
+    struct cipher_ecb_ctx *srcCtx;
+    struct cipher_ecb_ctx *dstCtx;
     switch( type )
     {
     case EVP_CTRL_COPY:
@@ -670,8 +641,8 @@ static SCOSSL_STATUS sc_ossl_aes_ecb_ctrl(_In_ EVP_CIPHER_CTX *ctx, int type, in
         // set EVP_CIPH_CUSTOM_COPY flag on all our AES ciphers
         // We must explicitly copy the AES key struct using SymCrypt as the AES key structure contains pointers
         // to itself, so a plain memcpy will maintain pointers to the source context
-        srcCtx = (struct cipher_cbc_ctx *)EVP_CIPHER_CTX_get_cipher_data(                  ctx);
-        dstCtx = (struct cipher_cbc_ctx *)EVP_CIPHER_CTX_get_cipher_data((EVP_CIPHER_CTX *)ptr);
+        srcCtx = (struct cipher_ecb_ctx *)EVP_CIPHER_CTX_get_cipher_data(                  ctx);
+        dstCtx = (struct cipher_ecb_ctx *)EVP_CIPHER_CTX_get_cipher_data((EVP_CIPHER_CTX *)ptr);
         SymCryptAesKeyCopy(&srcCtx->key, &dstCtx->key);
         break;
     default:
@@ -680,22 +651,19 @@ static SCOSSL_STATUS sc_ossl_aes_ecb_ctrl(_In_ EVP_CIPHER_CTX *ctx, int type, in
     return 1;
 }
 
+// Disabling XTS for now - remove with if region to avoid unused function warning
+#if 0
 /*
  * AES-XTS Implementation
  */
 
 // Initializes ctx with the provided key and iv, along with enc/dec mode.
-// enc should be set to 1 for encryption, 0 for decryption, and -1 to leave value unchanged.
 // Returns 1 on success, or 0 on error.
 SCOSSL_STATUS sc_ossl_aes_xts_init_key(_Inout_ EVP_CIPHER_CTX *ctx, _In_ const unsigned char *key,
                              _In_ const unsigned char *iv, SC_OSSL_ENCRYPTION_MODE enc)
 {
     SYMCRYPT_ERROR SymError = SYMCRYPT_NO_ERROR;
     struct cipher_xts_ctx *cipherCtx = (struct cipher_xts_ctx *)EVP_CIPHER_CTX_get_cipher_data(ctx);
-    if( enc != SC_OSSL_ENCRYPTION_MODE_NOCHANGE )
-    {
-        cipherCtx->enc = enc;
-    }
     if( iv )
     {
         memcpy(cipherCtx->iv, iv, 8); // copy only the first 8B
@@ -716,9 +684,9 @@ SCOSSL_STATUS sc_ossl_aes_xts_init_key(_Inout_ EVP_CIPHER_CTX *ctx, _In_ const u
     return 1;
 }
 
-// Encrypts or decrypts in, storing result in out, depending on mode set in ctx.
-// Returns 1 on success, or 0 on error.
-SCOSSL_STATUS sc_ossl_aes_xts_cipher(_Inout_ EVP_CIPHER_CTX *ctx, _Out_ unsigned char *out,
+// This is a EVP_CIPH_FLAG_CUSTOM_CIPHER do cipher method
+// return negative value on failure, and number of bytes written to out on success (may be 0)
+SCOSSL_RETURNLENGTH sc_ossl_aes_xts_cipher(_Inout_ EVP_CIPHER_CTX *ctx, _Out_ unsigned char *out,
                                _In_reads_bytes_(inl) const unsigned char *in, size_t inl)
 {
     int ret = 0;
@@ -735,7 +703,7 @@ SCOSSL_STATUS sc_ossl_aes_xts_cipher(_Inout_ EVP_CIPHER_CTX *ctx, _Out_ unsigned
         // a data unit. My understanding is that callers are expected to make a single call through
         // the EVP interface per data unit - so we pass inl to both cbDataUnit and cbData.
 
-        if( cipherCtx->enc == SC_OSSL_ENCRYPTION_MODE_ENCRYPT )
+        if( EVP_CIPHER_CTX_encrypting(ctx) )
         {
             SymCryptXtsAesEncrypt(
                 &cipherCtx->key,
@@ -745,7 +713,7 @@ SCOSSL_STATUS sc_ossl_aes_xts_cipher(_Inout_ EVP_CIPHER_CTX *ctx, _Out_ unsigned
                 out,
                 inl);
         }
-        else if( cipherCtx->enc == SC_OSSL_ENCRYPTION_MODE_DECRYPT )
+        else
         {
             SymCryptXtsAesDecrypt(
                 &cipherCtx->key,
@@ -755,13 +723,8 @@ SCOSSL_STATUS sc_ossl_aes_xts_cipher(_Inout_ EVP_CIPHER_CTX *ctx, _Out_ unsigned
                 out,
                 inl);
         }
-        else
-        {
-            SC_OSSL_LOG_ERROR("Encryption mode not set");
-            return 0;
-        }
 
-        ret = 1;
+        ret = inl;
     }
 
     return ret;
@@ -791,13 +754,13 @@ static SCOSSL_STATUS sc_ossl_aes_xts_ctrl(_In_ EVP_CIPHER_CTX *ctx, int type, in
     }
     return 1;
 }
+#endif
 
 /*
  * AES-GCM Implementation
  */
 
 // Initializes ctx with the provided key and iv, along with enc/dec mode.
-// enc should be set to 1 for encryption, 0 for decryption, and -1 to leave value unchanged.
 // Returns 1 on success, or 0 on error.
 SCOSSL_STATUS sc_ossl_aes_gcm_init_key(_Inout_ EVP_CIPHER_CTX *ctx, _In_ const unsigned char *key,
                              _In_ const unsigned char *iv, SC_OSSL_ENCRYPTION_MODE enc)
@@ -806,10 +769,6 @@ SCOSSL_STATUS sc_ossl_aes_gcm_init_key(_Inout_ EVP_CIPHER_CTX *ctx, _In_ const u
     struct cipher_gcm_ctx *cipherCtx = (struct cipher_gcm_ctx *)EVP_CIPHER_CTX_get_cipher_data(ctx);
 
     cipherCtx->operationInProgress = 0;
-    if( enc != SC_OSSL_ENCRYPTION_MODE_NOCHANGE )
-    {
-        cipherCtx->enc = enc;
-    }
     if( iv )
     {
         memcpy(cipherCtx->iv, iv, EVP_CIPHER_CTX_iv_length(ctx));
@@ -829,12 +788,11 @@ SCOSSL_STATUS sc_ossl_aes_gcm_init_key(_Inout_ EVP_CIPHER_CTX *ctx, _In_ const u
 
 // Encrypts or decrypts in, storing result in out, depending on mode set in ctx.
 // Returns length of out on success, or -1 on error.
-static SCOSSL_RETURNLENGTH sc_ossl_aes_gcm_tls(_Inout_ struct cipher_gcm_ctx *cipherCtx, _Out_ unsigned char *out,
-                               _In_reads_bytes_(inl) const unsigned char *in, size_t inl)
+static SCOSSL_RETURNLENGTH sc_ossl_aes_gcm_tls(_In_ const EVP_CIPHER_CTX *ctx, _Inout_ struct cipher_gcm_ctx *cipherCtx, _Out_ unsigned char *out,
+                               _In_reads_bytes_(inl) const unsigned char *in, size_t inl, BOOL enc)
 {
     int ret = -1;
     SYMCRYPT_ERROR SymError = SYMCRYPT_NO_ERROR;
-    UINT64 nextIV = 0;
     PBYTE  pbPayload = NULL;
     SIZE_T cbPayload = 0;
 
@@ -867,7 +825,7 @@ static SCOSSL_RETURNLENGTH sc_ossl_aes_gcm_tls(_Inout_ struct cipher_gcm_ctx *ci
     pbPayload = out + EVP_GCM_TLS_EXPLICIT_IV_LEN;
     cbPayload = inl - (EVP_GCM_TLS_EXPLICIT_IV_LEN + EVP_GCM_TLS_TAG_LEN);
 
-    if( cipherCtx->enc == SC_OSSL_ENCRYPTION_MODE_ENCRYPT )
+    if( EVP_CIPHER_CTX_encrypting(ctx) )
     {
         // First 8B of ESP payload data are the variable part of the IV (last 8B)
         // Copy it from the context
@@ -883,7 +841,7 @@ static SCOSSL_RETURNLENGTH sc_ossl_aes_gcm_tls(_Inout_ struct cipher_gcm_ctx *ci
 
         ret = inl;
     }
-    else if( cipherCtx->enc == SC_OSSL_ENCRYPTION_MODE_DECRYPT )
+    else
     {
         // First 8B of ESP payload data are the variable part of the IV (last 8B)
         // Copy it to the context
@@ -924,7 +882,7 @@ SCOSSL_RETURNLENGTH sc_ossl_aes_gcm_cipher(_Inout_ EVP_CIPHER_CTX *ctx, _Out_ un
 
     if( cipherCtx->tlsAadSet )
     {
-        return sc_ossl_aes_gcm_tls(cipherCtx, out, in, inl);
+        return sc_ossl_aes_gcm_tls(ctx, cipherCtx, out, in, inl, EVP_CIPHER_CTX_encrypting(ctx));
     }
 
     if( !cipherCtx->operationInProgress )
@@ -941,7 +899,7 @@ SCOSSL_RETURNLENGTH sc_ossl_aes_gcm_cipher(_Inout_ EVP_CIPHER_CTX *ctx, _Out_ un
         goto cleanup;
     }
 
-    if( cipherCtx->enc == SC_OSSL_ENCRYPTION_MODE_ENCRYPT )
+    if( EVP_CIPHER_CTX_encrypting(ctx) )
     {
         if( inl > 0 )
         {
@@ -956,7 +914,7 @@ SCOSSL_RETURNLENGTH sc_ossl_aes_gcm_cipher(_Inout_ EVP_CIPHER_CTX *ctx, _Out_ un
             ret = 0;
         }
     }
-    else if ( cipherCtx->enc == SC_OSSL_ENCRYPTION_MODE_DECRYPT )
+    else
     {
         if( inl > 0 )
         {
@@ -975,11 +933,6 @@ SCOSSL_RETURNLENGTH sc_ossl_aes_gcm_cipher(_Inout_ EVP_CIPHER_CTX *ctx, _Out_ un
             ret = 0;
         }
     }
-    else
-    {
-        SC_OSSL_LOG_ERROR("Encryption mode not set");
-        goto cleanup;
-    }
 
 cleanup:
     return ret;
@@ -993,7 +946,6 @@ static SCOSSL_STATUS sc_ossl_aes_gcm_ctrl(_Inout_ EVP_CIPHER_CTX *ctx, int type,
     struct cipher_gcm_ctx *cipherCtx = (struct cipher_gcm_ctx *)EVP_CIPHER_CTX_get_cipher_data(ctx);
     struct cipher_gcm_ctx *dstCtx;
     unsigned char *iv = NULL;
-    SYMCRYPT_ERROR SymError = SYMCRYPT_NO_ERROR;
     UINT16 tls_buffer_len = 0;
     UINT16 min_tls_buffer_len = 0;
     switch( type )
@@ -1113,7 +1065,6 @@ static SCOSSL_STATUS sc_ossl_aes_gcm_ctrl(_Inout_ EVP_CIPHER_CTX *ctx, int type,
  */
 
 // Initializes ctx with the provided key and iv, along with enc/dec mode.
-// enc should be set to 1 for encryption, 0 for decryption, and -1 to leave value unchanged.
 // Returns 1 on success, or 0 on error.
 SCOSSL_STATUS sc_ossl_aes_ccm_init_key(_Inout_ EVP_CIPHER_CTX *ctx, _In_ const unsigned char *key,
                              _In_ const unsigned char *iv, SC_OSSL_ENCRYPTION_MODE enc)
@@ -1123,10 +1074,6 @@ SCOSSL_STATUS sc_ossl_aes_ccm_init_key(_Inout_ EVP_CIPHER_CTX *ctx, _In_ const u
 
     cipherCtx->ccmStage = SCOSSL_CCM_STAGE_INIT;
     cipherCtx->cbData = 0;
-    if( enc != SC_OSSL_ENCRYPTION_MODE_NOCHANGE )
-    {
-        cipherCtx->enc = enc;
-    }
     if( iv )
     {
         memcpy(cipherCtx->iv, iv, cipherCtx->ivlen);
@@ -1144,12 +1091,11 @@ SCOSSL_STATUS sc_ossl_aes_ccm_init_key(_Inout_ EVP_CIPHER_CTX *ctx, _In_ const u
 
 // Encrypts or decrypts in, storing result in out, depending on mode set in ctx.
 // Returns length of out on success, or -1 on error.
-static SCOSSL_RETURNLENGTH sc_ossl_aes_ccm_tls(_Inout_ struct cipher_ccm_ctx *cipherCtx, _Out_ unsigned char *out,
+static SCOSSL_RETURNLENGTH sc_ossl_aes_ccm_tls(_In_ const EVP_CIPHER_CTX *ctx, _Inout_ struct cipher_ccm_ctx *cipherCtx, _Out_ unsigned char *out,
                                _In_reads_bytes_(inl) const unsigned char *in, size_t inl)
 {
     int ret = -1;
     SYMCRYPT_ERROR SymError = SYMCRYPT_NO_ERROR;
-    UINT64 nextIV = 0;
     PBYTE  pbPayload = NULL;
     SIZE_T cbPayload = 0;
 
@@ -1163,7 +1109,7 @@ static SCOSSL_RETURNLENGTH sc_ossl_aes_ccm_tls(_Inout_ struct cipher_ccm_ctx *ci
         SC_OSSL_LOG_ERROR("AES-CCM TLS does not support out-of-place operation");
         goto cleanup;
     }
-    if( inl < EVP_CCM_TLS_EXPLICIT_IV_LEN + cipherCtx->taglen )
+    if( inl < (SIZE_T) EVP_CCM_TLS_EXPLICIT_IV_LEN + cipherCtx->taglen )
     {
         SC_OSSL_LOG_ERROR("AES-CCM TLS buffer too small");
         goto cleanup;
@@ -1187,7 +1133,7 @@ static SCOSSL_RETURNLENGTH sc_ossl_aes_ccm_tls(_Inout_ struct cipher_ccm_ctx *ci
     pbPayload = out + EVP_CCM_TLS_EXPLICIT_IV_LEN;
     cbPayload = inl - (EVP_CCM_TLS_EXPLICIT_IV_LEN + cipherCtx->taglen);
 
-    if( cipherCtx->enc == SC_OSSL_ENCRYPTION_MODE_ENCRYPT )
+    if( EVP_CIPHER_CTX_encrypting(ctx) )
     {
         // First 8B of ESP payload data are the variable part of the IV (last 8B)
         // Copy it from the context
@@ -1204,7 +1150,7 @@ static SCOSSL_RETURNLENGTH sc_ossl_aes_ccm_tls(_Inout_ struct cipher_ccm_ctx *ci
 
         ret = inl;
     }
-    else if( cipherCtx->enc == SC_OSSL_ENCRYPTION_MODE_DECRYPT )
+    else
     {
         // First 8B of ESP payload data are the variable part of the IV (last 8B)
         // Copy it to the context
@@ -1248,7 +1194,7 @@ SCOSSL_RETURNLENGTH sc_ossl_aes_ccm_cipher(_Inout_ EVP_CIPHER_CTX *ctx, _Out_ un
 
     if( cipherCtx->tlsAadSet )
     {
-        return sc_ossl_aes_ccm_tls(cipherCtx, out, in, inl);
+        return sc_ossl_aes_ccm_tls(ctx, cipherCtx, out, in, inl);
     }
 
     // See SCOSSL_CCM_STAGE definition above - callers to CCM must use the API in a very particular way
@@ -1326,7 +1272,7 @@ SCOSSL_RETURNLENGTH sc_ossl_aes_ccm_cipher(_Inout_ EVP_CIPHER_CTX *ctx, _Out_ un
 
     if( cipherCtx->ccmStage == SCOSSL_CCM_STAGE_SET_AAD)
     {
-        if( cipherCtx->enc == SC_OSSL_ENCRYPTION_MODE_ENCRYPT )
+        if( EVP_CIPHER_CTX_encrypting(ctx) )
         {
             // Encryption
             if( in != NULL )
@@ -1336,7 +1282,7 @@ SCOSSL_RETURNLENGTH sc_ossl_aes_ccm_cipher(_Inout_ EVP_CIPHER_CTX *ctx, _Out_ un
             SymCryptCcmEncryptFinal(&cipherCtx->state, cipherCtx->tag, cipherCtx->taglen);
             cipherCtx->ccmStage = SCOSSL_CCM_STAGE_COMPLETE;
         }
-        else if( cipherCtx->enc == SC_OSSL_ENCRYPTION_MODE_DECRYPT )
+        else
         {
             // Decryption
             if( in != NULL )
@@ -1366,7 +1312,6 @@ static SCOSSL_STATUS sc_ossl_aes_ccm_ctrl(_Inout_ EVP_CIPHER_CTX *ctx, int type,
     struct cipher_ccm_ctx *cipherCtx = (struct cipher_ccm_ctx *)EVP_CIPHER_CTX_get_cipher_data(ctx);
     struct cipher_ccm_ctx *dstCtx;
     unsigned char *iv = NULL;
-    SYMCRYPT_ERROR SymError = SYMCRYPT_NO_ERROR;
     UINT16 tls_buffer_len = 0;
     UINT16 min_tls_buffer_len = 0;
     switch( type )

--- a/SymCryptEngine/src/sc_ossl_ciphers.c
+++ b/SymCryptEngine/src/sc_ossl_ciphers.c
@@ -532,11 +532,11 @@ SCOSSL_STATUS sc_ossl_aes_cbc_init_key(_Inout_ EVP_CIPHER_CTX *ctx, _In_ const u
                              _In_ const unsigned char *iv, SC_OSSL_ENCRYPTION_MODE enc)
 {
     struct cipher_cbc_ctx *cipherCtx = (struct cipher_cbc_ctx *)EVP_CIPHER_CTX_get_cipher_data(ctx);
-    SYMCRYPT_ERROR SymError = SYMCRYPT_NO_ERROR;
+    SYMCRYPT_ERROR symError = SYMCRYPT_NO_ERROR;
     if( key )
     {
-        SymError = SymCryptAesExpandKey(&cipherCtx->key, key, EVP_CIPHER_CTX_key_length(ctx));
-        if( SymError != SYMCRYPT_NO_ERROR )
+        symError = SymCryptAesExpandKey(&cipherCtx->key, key, EVP_CIPHER_CTX_key_length(ctx));
+        if( symError != SYMCRYPT_NO_ERROR )
         {
             return 0;
         }
@@ -597,11 +597,11 @@ SCOSSL_STATUS sc_ossl_aes_ecb_init_key(_Inout_ EVP_CIPHER_CTX *ctx, _In_ const u
                              _In_ const unsigned char *iv, SC_OSSL_ENCRYPTION_MODE enc)
 {
     struct cipher_ecb_ctx *cipherCtx = (struct cipher_ecb_ctx *)EVP_CIPHER_CTX_get_cipher_data(ctx);
-    SYMCRYPT_ERROR SymError = SYMCRYPT_NO_ERROR;
+    SYMCRYPT_ERROR symError = SYMCRYPT_NO_ERROR;
     if( key )
     {
-        SymError = SymCryptAesExpandKey(&cipherCtx->key, key, EVP_CIPHER_CTX_key_length(ctx));
-        if( SymError != SYMCRYPT_NO_ERROR )
+        symError = SymCryptAesExpandKey(&cipherCtx->key, key, EVP_CIPHER_CTX_key_length(ctx));
+        if( symError != SYMCRYPT_NO_ERROR )
         {
             return 0;
         }
@@ -662,7 +662,7 @@ static SCOSSL_STATUS sc_ossl_aes_ecb_ctrl(_In_ EVP_CIPHER_CTX *ctx, int type, in
 SCOSSL_STATUS sc_ossl_aes_xts_init_key(_Inout_ EVP_CIPHER_CTX *ctx, _In_ const unsigned char *key,
                              _In_ const unsigned char *iv, SC_OSSL_ENCRYPTION_MODE enc)
 {
-    SYMCRYPT_ERROR SymError = SYMCRYPT_NO_ERROR;
+    SYMCRYPT_ERROR symError = SYMCRYPT_NO_ERROR;
     struct cipher_xts_ctx *cipherCtx = (struct cipher_xts_ctx *)EVP_CIPHER_CTX_get_cipher_data(ctx);
     if( iv )
     {
@@ -675,8 +675,8 @@ SCOSSL_STATUS sc_ossl_aes_xts_init_key(_Inout_ EVP_CIPHER_CTX *ctx, _In_ const u
     }
     if( key )
     {
-        SymError = SymCryptXtsAesExpandKey(&cipherCtx->key, key, EVP_CIPHER_CTX_key_length(ctx));
-        if( SymError != SYMCRYPT_NO_ERROR )
+        symError = SymCryptXtsAesExpandKey(&cipherCtx->key, key, EVP_CIPHER_CTX_key_length(ctx));
+        if( symError != SYMCRYPT_NO_ERROR )
         {
             return 0;
         }
@@ -765,7 +765,7 @@ static SCOSSL_STATUS sc_ossl_aes_xts_ctrl(_In_ EVP_CIPHER_CTX *ctx, int type, in
 SCOSSL_STATUS sc_ossl_aes_gcm_init_key(_Inout_ EVP_CIPHER_CTX *ctx, _In_ const unsigned char *key,
                              _In_ const unsigned char *iv, SC_OSSL_ENCRYPTION_MODE enc)
 {
-    SYMCRYPT_ERROR SymError = SYMCRYPT_NO_ERROR;
+    SYMCRYPT_ERROR symError = SYMCRYPT_NO_ERROR;
     struct cipher_gcm_ctx *cipherCtx = (struct cipher_gcm_ctx *)EVP_CIPHER_CTX_get_cipher_data(ctx);
 
     cipherCtx->operationInProgress = 0;
@@ -775,8 +775,8 @@ SCOSSL_STATUS sc_ossl_aes_gcm_init_key(_Inout_ EVP_CIPHER_CTX *ctx, _In_ const u
     }
     if( key )
     {
-        SymError = SymCryptGcmExpandKey(&cipherCtx->key, SymCryptAesBlockCipher, key, EVP_CIPHER_CTX_key_length(ctx));
-        if( SymError != SYMCRYPT_NO_ERROR )
+        symError = SymCryptGcmExpandKey(&cipherCtx->key, SymCryptAesBlockCipher, key, EVP_CIPHER_CTX_key_length(ctx));
+        if( symError != SYMCRYPT_NO_ERROR )
         {
             return 0;
         }
@@ -792,7 +792,7 @@ static SCOSSL_RETURNLENGTH sc_ossl_aes_gcm_tls(_In_ const EVP_CIPHER_CTX *ctx, _
                                _In_reads_bytes_(inl) const unsigned char *in, size_t inl, BOOL enc)
 {
     int ret = -1;
-    SYMCRYPT_ERROR SymError = SYMCRYPT_NO_ERROR;
+    SYMCRYPT_ERROR symError = SYMCRYPT_NO_ERROR;
     PBYTE  pbPayload = NULL;
     SIZE_T cbPayload = 0;
 
@@ -848,13 +848,13 @@ static SCOSSL_RETURNLENGTH sc_ossl_aes_gcm_tls(_In_ const EVP_CIPHER_CTX *ctx, _
         memcpy(cipherCtx->iv + cipherCtx->ivlen - EVP_GCM_TLS_EXPLICIT_IV_LEN, out, EVP_GCM_TLS_EXPLICIT_IV_LEN);
 
         // Check ICV
-        SymError = SymCryptGcmDecrypt(
+        symError = SymCryptGcmDecrypt(
             &cipherCtx->key,
             cipherCtx->iv, cipherCtx->ivlen,
             cipherCtx->tlsAad, EVP_AEAD_TLS1_AAD_LEN,
             pbPayload, pbPayload, cbPayload,
             pbPayload+cbPayload, EVP_GCM_TLS_TAG_LEN );
-        if( SymError != SYMCRYPT_NO_ERROR )
+        if( symError != SYMCRYPT_NO_ERROR )
         {
             goto cleanup;
         }
@@ -877,7 +877,7 @@ SCOSSL_RETURNLENGTH sc_ossl_aes_gcm_cipher(_Inout_ EVP_CIPHER_CTX *ctx, _Out_ un
                                _In_reads_bytes_(inl) const unsigned char *in, size_t inl)
 {
     int ret = -1;
-    SYMCRYPT_ERROR SymError = SYMCRYPT_NO_ERROR;
+    SYMCRYPT_ERROR symError = SYMCRYPT_NO_ERROR;
     struct cipher_gcm_ctx *cipherCtx = (struct cipher_gcm_ctx *)EVP_CIPHER_CTX_get_cipher_data(ctx);
 
     if( cipherCtx->tlsAadSet )
@@ -925,8 +925,8 @@ SCOSSL_RETURNLENGTH sc_ossl_aes_gcm_cipher(_Inout_ EVP_CIPHER_CTX *ctx, _Out_ un
         else
         {
             // Final Decrypt Call
-            SymError = SymCryptGcmDecryptFinal(&cipherCtx->state, cipherCtx->tag, cipherCtx->taglen);
-            if( SymError != SYMCRYPT_NO_ERROR )
+            symError = SymCryptGcmDecryptFinal(&cipherCtx->state, cipherCtx->tag, cipherCtx->taglen);
+            if( symError != SYMCRYPT_NO_ERROR )
             {
                 goto cleanup;
             }
@@ -1069,7 +1069,7 @@ static SCOSSL_STATUS sc_ossl_aes_gcm_ctrl(_Inout_ EVP_CIPHER_CTX *ctx, int type,
 SCOSSL_STATUS sc_ossl_aes_ccm_init_key(_Inout_ EVP_CIPHER_CTX *ctx, _In_ const unsigned char *key,
                              _In_ const unsigned char *iv, SC_OSSL_ENCRYPTION_MODE enc)
 {
-    SYMCRYPT_ERROR SymError = SYMCRYPT_NO_ERROR;
+    SYMCRYPT_ERROR symError = SYMCRYPT_NO_ERROR;
     struct cipher_ccm_ctx *cipherCtx = (struct cipher_ccm_ctx *)EVP_CIPHER_CTX_get_cipher_data(ctx);
 
     cipherCtx->ccmStage = SCOSSL_CCM_STAGE_INIT;
@@ -1080,8 +1080,8 @@ SCOSSL_STATUS sc_ossl_aes_ccm_init_key(_Inout_ EVP_CIPHER_CTX *ctx, _In_ const u
     }
     if( key )
     {
-        SymError = SymCryptAesExpandKey(&cipherCtx->key, key, EVP_CIPHER_CTX_key_length(ctx));
-        if( SymError != SYMCRYPT_NO_ERROR )
+        symError = SymCryptAesExpandKey(&cipherCtx->key, key, EVP_CIPHER_CTX_key_length(ctx));
+        if( symError != SYMCRYPT_NO_ERROR )
         {
             return 0;
         }
@@ -1095,7 +1095,7 @@ static SCOSSL_RETURNLENGTH sc_ossl_aes_ccm_tls(_In_ const EVP_CIPHER_CTX *ctx, _
                                _In_reads_bytes_(inl) const unsigned char *in, size_t inl)
 {
     int ret = -1;
-    SYMCRYPT_ERROR SymError = SYMCRYPT_NO_ERROR;
+    SYMCRYPT_ERROR symError = SYMCRYPT_NO_ERROR;
     PBYTE  pbPayload = NULL;
     SIZE_T cbPayload = 0;
 
@@ -1157,14 +1157,14 @@ static SCOSSL_RETURNLENGTH sc_ossl_aes_ccm_tls(_In_ const EVP_CIPHER_CTX *ctx, _
         memcpy(cipherCtx->iv + cipherCtx->ivlen - EVP_CCM_TLS_EXPLICIT_IV_LEN, out, EVP_CCM_TLS_EXPLICIT_IV_LEN);
 
         // Check ICV
-        SymError = SymCryptCcmDecrypt(
+        symError = SymCryptCcmDecrypt(
             SymCryptAesBlockCipher,
             &cipherCtx->key,
             cipherCtx->iv, cipherCtx->ivlen,
             cipherCtx->tlsAad, EVP_AEAD_TLS1_AAD_LEN,
             pbPayload, pbPayload, cbPayload,
             pbPayload+cbPayload, cipherCtx->taglen );
-        if( SymError != SYMCRYPT_NO_ERROR )
+        if( symError != SYMCRYPT_NO_ERROR )
         {
             goto cleanup;
         }
@@ -1187,7 +1187,7 @@ SCOSSL_RETURNLENGTH sc_ossl_aes_ccm_cipher(_Inout_ EVP_CIPHER_CTX *ctx, _Out_ un
                                _In_reads_bytes_(inl) const unsigned char *in, size_t inl)
 {
     int ret = -1;
-    SYMCRYPT_ERROR SymError = SYMCRYPT_NO_ERROR;
+    SYMCRYPT_ERROR symError = SYMCRYPT_NO_ERROR;
     struct cipher_ccm_ctx *cipherCtx = (struct cipher_ccm_ctx *)EVP_CIPHER_CTX_get_cipher_data(ctx);
     PCBYTE pbAuthData = NULL;
     SIZE_T cbAuthdata = 0;
@@ -1289,9 +1289,9 @@ SCOSSL_RETURNLENGTH sc_ossl_aes_ccm_cipher(_Inout_ EVP_CIPHER_CTX *ctx, _Out_ un
             {
                 SymCryptCcmDecryptPart(&cipherCtx->state, in, out, inl);
             }
-            SymError = SymCryptCcmDecryptFinal(&cipherCtx->state, cipherCtx->tag, cipherCtx->taglen);
+            symError = SymCryptCcmDecryptFinal(&cipherCtx->state, cipherCtx->tag, cipherCtx->taglen);
             cipherCtx->ccmStage = SCOSSL_CCM_STAGE_COMPLETE;
-            if( SymError != SYMCRYPT_NO_ERROR )
+            if( symError != SYMCRYPT_NO_ERROR )
             {
                 ret = -1;
                 goto cleanup;

--- a/SymCryptEngine/src/sc_ossl_ciphers.c
+++ b/SymCryptEngine/src/sc_ossl_ciphers.c
@@ -121,7 +121,7 @@ static EVP_CIPHER *_hidden_aes_128_cbc = NULL;
 static const EVP_CIPHER *sc_ossl_aes_128_cbc(void)
 {
     if( (_hidden_aes_128_cbc = EVP_CIPHER_meth_new(NID_aes_128_cbc, SYMCRYPT_AES_BLOCK_SIZE , AES_128_KEY_SIZE)) == NULL
-        || !EVP_CIPHER_meth_set_iv_length(_hidden_aes_128_cbc,16)
+        || !EVP_CIPHER_meth_set_iv_length(_hidden_aes_128_cbc, SYMCRYPT_AES_BLOCK_SIZE)
         || !EVP_CIPHER_meth_set_flags(_hidden_aes_128_cbc, AES_CBC_FLAGS)
         || !EVP_CIPHER_meth_set_init(_hidden_aes_128_cbc, sc_ossl_aes_cbc_init_key)
         || !EVP_CIPHER_meth_set_do_cipher(_hidden_aes_128_cbc, sc_ossl_aes_cbc_cipher)
@@ -139,7 +139,7 @@ static EVP_CIPHER *_hidden_aes_192_cbc = NULL;
 static const EVP_CIPHER *sc_ossl_aes_192_cbc(void)
 {
     if( (_hidden_aes_192_cbc = EVP_CIPHER_meth_new(NID_aes_192_cbc, SYMCRYPT_AES_BLOCK_SIZE , AES_192_KEY_SIZE)) == NULL
-        || !EVP_CIPHER_meth_set_iv_length(_hidden_aes_192_cbc,16)
+        || !EVP_CIPHER_meth_set_iv_length(_hidden_aes_192_cbc, SYMCRYPT_AES_BLOCK_SIZE)
         || !EVP_CIPHER_meth_set_flags(_hidden_aes_192_cbc, AES_CBC_FLAGS)
         || !EVP_CIPHER_meth_set_init(_hidden_aes_192_cbc, sc_ossl_aes_cbc_init_key)
         || !EVP_CIPHER_meth_set_do_cipher(_hidden_aes_192_cbc, sc_ossl_aes_cbc_cipher)
@@ -157,7 +157,7 @@ static EVP_CIPHER *_hidden_aes_256_cbc = NULL;
 static const EVP_CIPHER *sc_ossl_aes_256_cbc(void)
 {
     if( (_hidden_aes_256_cbc = EVP_CIPHER_meth_new(NID_aes_256_cbc, SYMCRYPT_AES_BLOCK_SIZE , AES_256_KEY_SIZE)) == NULL
-        || !EVP_CIPHER_meth_set_iv_length(_hidden_aes_256_cbc,16)
+        || !EVP_CIPHER_meth_set_iv_length(_hidden_aes_256_cbc, SYMCRYPT_AES_BLOCK_SIZE)
         || !EVP_CIPHER_meth_set_flags(_hidden_aes_256_cbc, AES_CBC_FLAGS)
         || !EVP_CIPHER_meth_set_init(_hidden_aes_256_cbc, sc_ossl_aes_cbc_init_key)
         || !EVP_CIPHER_meth_set_do_cipher(_hidden_aes_256_cbc, sc_ossl_aes_cbc_cipher)
@@ -182,7 +182,6 @@ static EVP_CIPHER *_hidden_aes_128_ecb = NULL;
 static const EVP_CIPHER *sc_ossl_aes_128_ecb(void)
 {
     if( (_hidden_aes_128_ecb = EVP_CIPHER_meth_new(NID_aes_128_ecb, SYMCRYPT_AES_BLOCK_SIZE , AES_128_KEY_SIZE)) == NULL
-        || !EVP_CIPHER_meth_set_iv_length(_hidden_aes_128_ecb,16)
         || !EVP_CIPHER_meth_set_flags(_hidden_aes_128_ecb, AES_ECB_FLAGS)
         || !EVP_CIPHER_meth_set_init(_hidden_aes_128_ecb, sc_ossl_aes_ecb_init_key)
         || !EVP_CIPHER_meth_set_do_cipher(_hidden_aes_128_ecb, sc_ossl_aes_ecb_cipher)
@@ -200,7 +199,6 @@ static EVP_CIPHER *_hidden_aes_192_ecb = NULL;
 static const EVP_CIPHER *sc_ossl_aes_192_ecb(void)
 {
     if( (_hidden_aes_192_ecb = EVP_CIPHER_meth_new(NID_aes_192_ecb, SYMCRYPT_AES_BLOCK_SIZE , AES_192_KEY_SIZE)) == NULL
-        || !EVP_CIPHER_meth_set_iv_length(_hidden_aes_192_ecb,16)
         || !EVP_CIPHER_meth_set_flags(_hidden_aes_192_ecb, AES_ECB_FLAGS)
         || !EVP_CIPHER_meth_set_init(_hidden_aes_192_ecb, sc_ossl_aes_ecb_init_key)
         || !EVP_CIPHER_meth_set_do_cipher(_hidden_aes_192_ecb, sc_ossl_aes_ecb_cipher)
@@ -218,7 +216,6 @@ static EVP_CIPHER *_hidden_aes_256_ecb = NULL;
 static const EVP_CIPHER *sc_ossl_aes_256_ecb(void)
 {
     if( (_hidden_aes_256_ecb = EVP_CIPHER_meth_new(NID_aes_256_ecb, SYMCRYPT_AES_BLOCK_SIZE , AES_256_KEY_SIZE)) == NULL
-        || !EVP_CIPHER_meth_set_iv_length(_hidden_aes_256_ecb, 16)
         || !EVP_CIPHER_meth_set_flags(_hidden_aes_256_ecb, AES_ECB_FLAGS)
         || !EVP_CIPHER_meth_set_init(_hidden_aes_256_ecb, sc_ossl_aes_ecb_init_key)
         || !EVP_CIPHER_meth_set_do_cipher(_hidden_aes_256_ecb, sc_ossl_aes_ecb_cipher)
@@ -246,7 +243,7 @@ static EVP_CIPHER *_hidden_aes_128_xts = NULL;
 static const EVP_CIPHER *sc_ossl_aes_128_xts(void)
 {
     if( (_hidden_aes_128_xts = EVP_CIPHER_meth_new(NID_aes_128_xts, SYMCRYPT_AES_BLOCK_SIZE , AES_128_KEY_SIZE * 2)) == NULL
-        || !EVP_CIPHER_meth_set_iv_length(_hidden_aes_128_xts, 16)
+        || !EVP_CIPHER_meth_set_iv_length(_hidden_aes_128_xts, SYMCRYPT_AES_BLOCK_SIZE)
         || !EVP_CIPHER_meth_set_flags(_hidden_aes_128_xts, AES_XTS_FLAGS)
         || !EVP_CIPHER_meth_set_init(_hidden_aes_128_xts, sc_ossl_aes_xts_init_key)
         || !EVP_CIPHER_meth_set_do_cipher(_hidden_aes_128_xts, sc_ossl_aes_xts_cipher)
@@ -264,7 +261,7 @@ static EVP_CIPHER *_hidden_aes_256_xts = NULL;
 static const EVP_CIPHER *sc_ossl_aes_256_xts(void)
 {
     if( (_hidden_aes_256_xts = EVP_CIPHER_meth_new(NID_aes_256_xts, SYMCRYPT_AES_BLOCK_SIZE , AES_256_KEY_SIZE * 2)) == NULL
-        || !EVP_CIPHER_meth_set_iv_length(_hidden_aes_256_xts, 16)
+        || !EVP_CIPHER_meth_set_iv_length(_hidden_aes_256_xts, SYMCRYPT_AES_BLOCK_SIZE)
         || !EVP_CIPHER_meth_set_flags(_hidden_aes_256_xts, AES_XTS_FLAGS)
         || !EVP_CIPHER_meth_set_init(_hidden_aes_256_xts, sc_ossl_aes_xts_init_key)
         || !EVP_CIPHER_meth_set_do_cipher(_hidden_aes_256_xts, sc_ossl_aes_xts_cipher)
@@ -293,7 +290,6 @@ static EVP_CIPHER *_hidden_aes_128_gcm = NULL;
 static const EVP_CIPHER *sc_ossl_aes_128_gcm(void)
 {
     if( (_hidden_aes_128_gcm = EVP_CIPHER_meth_new(NID_aes_128_gcm, 1, AES_128_KEY_SIZE)) == NULL
-        || !EVP_CIPHER_meth_set_iv_length(_hidden_aes_128_gcm,12)
         || !EVP_CIPHER_meth_set_flags(_hidden_aes_128_gcm, AES_GCM_FLAGS)
         || !EVP_CIPHER_meth_set_init(_hidden_aes_128_gcm, sc_ossl_aes_gcm_init_key)
         || !EVP_CIPHER_meth_set_do_cipher(_hidden_aes_128_gcm, sc_ossl_aes_gcm_cipher)
@@ -311,7 +307,6 @@ static EVP_CIPHER *_hidden_aes_192_gcm = NULL;
 static const EVP_CIPHER *sc_ossl_aes_192_gcm(void)
 {
     if( (_hidden_aes_192_gcm = EVP_CIPHER_meth_new(NID_aes_192_gcm, 1, AES_192_KEY_SIZE)) == NULL
-        || !EVP_CIPHER_meth_set_iv_length(_hidden_aes_192_gcm,12)
         || !EVP_CIPHER_meth_set_flags(_hidden_aes_192_gcm, AES_GCM_FLAGS)
         || !EVP_CIPHER_meth_set_init(_hidden_aes_192_gcm, sc_ossl_aes_gcm_init_key)
         || !EVP_CIPHER_meth_set_do_cipher(_hidden_aes_192_gcm, sc_ossl_aes_gcm_cipher)
@@ -329,7 +324,6 @@ static EVP_CIPHER *_hidden_aes_256_gcm = NULL;
 static const EVP_CIPHER *sc_ossl_aes_256_gcm(void)
 {
     if( (_hidden_aes_256_gcm = EVP_CIPHER_meth_new(NID_aes_256_gcm, 1, AES_256_KEY_SIZE)) == NULL
-        || !EVP_CIPHER_meth_set_iv_length(_hidden_aes_256_gcm,12)
         || !EVP_CIPHER_meth_set_flags(_hidden_aes_256_gcm, AES_GCM_FLAGS)
         || !EVP_CIPHER_meth_set_init(_hidden_aes_256_gcm, sc_ossl_aes_gcm_init_key)
         || !EVP_CIPHER_meth_set_do_cipher(_hidden_aes_256_gcm, sc_ossl_aes_gcm_cipher)
@@ -693,7 +687,7 @@ SCOSSL_RETURNLENGTH sc_ossl_aes_xts_cipher(_Inout_ EVP_CIPHER_CTX *ctx, _Out_ un
     struct cipher_xts_ctx *cipherCtx = (struct cipher_xts_ctx *)EVP_CIPHER_CTX_get_cipher_data(ctx);
     if( inl > 0 )
     {
-        if( (inl % 16) != 0 )
+        if( (inl % SYMCRYPT_AES_BLOCK_SIZE) != 0 )
         {
             SC_OSSL_LOG_ERROR("Data length (%d) is not a multiple of the AES block size. SymCrypt does not support this size", inl);
             return -1;

--- a/SymCryptEngine/src/sc_ossl_ciphers.h
+++ b/SymCryptEngine/src/sc_ossl_ciphers.h
@@ -3,13 +3,15 @@
 //
 
 #include "sc_ossl.h"
-#include <symcrypt.h>
+#include "sc_ossl_helpers.h"
 #include <string.h>
 
 #ifdef __cplusplus
 extern "C" {
 #endif
 
+// Initialize all of the _hidden_* cipher variables
+SCOSSL_STATUS scossl_ciphers_init_static();
 
 // Using ENGINE e, populate cipher with the one asked for by nid.
 // If cipher is NULL, return a list of supported nids in the nids parameter.
@@ -17,7 +19,6 @@ extern "C" {
 _Success_(return > 0)
 int sc_ossl_ciphers(_Inout_ ENGINE *e, _Out_ const EVP_CIPHER **cipher,
                             _Out_ const int **nids, int nid);
-
 
 void sc_ossl_destroy_ciphers(void);
 

--- a/SymCryptEngine/src/sc_ossl_dh.h
+++ b/SymCryptEngine/src/sc_ossl_dh.h
@@ -12,6 +12,9 @@ extern "C" {
 
 extern int dh_sc_ossl_idx;
 
+// Initialize all of the _hidden_* dh variables
+SCOSSL_STATUS scossl_dh_init_static();
+
 // Generates public and private DH values.
 // Expects shared parameters dh->p and dh->g to be set.
 // Generates a random private DH key unless dh->priv_key set, and computes corresponding

--- a/SymCryptEngine/src/sc_ossl_digests.c
+++ b/SymCryptEngine/src/sc_ossl_digests.c
@@ -3,8 +3,6 @@
 //
 
 #include "sc_ossl_digests.h"
-#include "sc_ossl_helpers.h"
-#include <symcrypt.h>
 
 #ifdef __cplusplus
 extern "C" {
@@ -26,23 +24,19 @@ static SCOSSL_STATUS sc_ossl_digest_md5_copy(_Out_ EVP_MD_CTX *to, _In_ const EV
 static EVP_MD *_hidden_md5_md = NULL;
 static const EVP_MD *sc_ossl_digest_md5(void)
 {
-    if (_hidden_md5_md == NULL) {
-        EVP_MD *md;
-        if ((md = EVP_MD_meth_new(NID_md5, NID_md5WithRSAEncryption)) == NULL
-            || !EVP_MD_meth_set_result_size(md, MD5_DIGEST_LENGTH)
-            || !EVP_MD_meth_set_input_blocksize(md, MD5_CBLOCK)
-            || !EVP_MD_meth_set_app_datasize(md, sizeof(SYMCRYPT_MD5_STATE))
-            || !EVP_MD_meth_set_flags(md, 0)
-            || !EVP_MD_meth_set_init(md, sc_ossl_digest_md5_init)
-            || !EVP_MD_meth_set_update(md, sc_ossl_digest_md5_update)
-            || !EVP_MD_meth_set_final(md, sc_ossl_digest_md5_final)
-            || !EVP_MD_meth_set_copy(md, sc_ossl_digest_md5_copy)
-            )
-        {
-            EVP_MD_meth_free(md);
-            md = NULL;
-        }
-        _hidden_md5_md = md;
+    if ((_hidden_md5_md = EVP_MD_meth_new(NID_md5, NID_md5WithRSAEncryption)) == NULL
+        || !EVP_MD_meth_set_result_size(_hidden_md5_md, MD5_DIGEST_LENGTH)
+        || !EVP_MD_meth_set_input_blocksize(_hidden_md5_md, MD5_CBLOCK)
+        || !EVP_MD_meth_set_app_datasize(_hidden_md5_md, sizeof(SYMCRYPT_MD5_STATE))
+        || !EVP_MD_meth_set_flags(_hidden_md5_md, 0)
+        || !EVP_MD_meth_set_init(_hidden_md5_md, sc_ossl_digest_md5_init)
+        || !EVP_MD_meth_set_update(_hidden_md5_md, sc_ossl_digest_md5_update)
+        || !EVP_MD_meth_set_final(_hidden_md5_md, sc_ossl_digest_md5_final)
+        || !EVP_MD_meth_set_copy(_hidden_md5_md, sc_ossl_digest_md5_copy)
+        )
+    {
+        EVP_MD_meth_free(_hidden_md5_md);
+        _hidden_md5_md = NULL;
     }
     return _hidden_md5_md;
 }
@@ -55,24 +49,19 @@ static SCOSSL_STATUS sc_ossl_digest_sha1_copy(_Out_ EVP_MD_CTX *to, _In_ const E
 static EVP_MD *_hidden_sha1_md = NULL;
 static const EVP_MD *sc_ossl_digest_sha1(void)
 {
-    if( _hidden_sha1_md == NULL )
+    if( (_hidden_sha1_md = EVP_MD_meth_new(NID_sha1, NID_sha1WithRSAEncryption)) == NULL
+        || !EVP_MD_meth_set_result_size(_hidden_sha1_md, SHA_DIGEST_LENGTH)
+        || !EVP_MD_meth_set_input_blocksize(_hidden_sha1_md, SHA_CBLOCK)
+        || !EVP_MD_meth_set_app_datasize(_hidden_sha1_md, sizeof(SYMCRYPT_SHA1_STATE))
+        || !EVP_MD_meth_set_flags(_hidden_sha1_md, EVP_MD_FLAG_DIGALGID_ABSENT)
+        || !EVP_MD_meth_set_init(_hidden_sha1_md, sc_ossl_digest_sha1_init)
+        || !EVP_MD_meth_set_update(_hidden_sha1_md, sc_ossl_digest_sha1_update)
+        || !EVP_MD_meth_set_final(_hidden_sha1_md, sc_ossl_digest_sha1_final)
+        || !EVP_MD_meth_set_copy(_hidden_sha1_md, sc_ossl_digest_sha1_copy)
+        )
     {
-        EVP_MD *md;
-        if( (md = EVP_MD_meth_new(NID_sha1, NID_sha1WithRSAEncryption)) == NULL
-            || !EVP_MD_meth_set_result_size(md, SHA_DIGEST_LENGTH)
-            || !EVP_MD_meth_set_input_blocksize(md, SHA_CBLOCK)
-            || !EVP_MD_meth_set_app_datasize(md, sizeof(SYMCRYPT_SHA1_STATE))
-            || !EVP_MD_meth_set_flags(md, EVP_MD_FLAG_DIGALGID_ABSENT)
-            || !EVP_MD_meth_set_init(md, sc_ossl_digest_sha1_init)
-            || !EVP_MD_meth_set_update(md, sc_ossl_digest_sha1_update)
-            || !EVP_MD_meth_set_final(md, sc_ossl_digest_sha1_final)
-            || !EVP_MD_meth_set_copy(md, sc_ossl_digest_sha1_copy)
-            )
-        {
-            EVP_MD_meth_free(md);
-            md = NULL;
-        }
-        _hidden_sha1_md = md;
+        EVP_MD_meth_free(_hidden_sha1_md);
+        _hidden_sha1_md = NULL;
     }
     return _hidden_sha1_md;
 }
@@ -85,24 +74,19 @@ static SCOSSL_STATUS sc_ossl_digest_sha256_copy(_Out_ EVP_MD_CTX *to, _In_ const
 static EVP_MD *_hidden_sha256_md = NULL;
 static const EVP_MD *sc_ossl_digest_sha256(void)
 {
-    if( _hidden_sha256_md == NULL )
+    if( (_hidden_sha256_md = EVP_MD_meth_new(NID_sha256, NID_sha256WithRSAEncryption)) == NULL
+        || !EVP_MD_meth_set_result_size(_hidden_sha256_md, SHA256_DIGEST_LENGTH)
+        || !EVP_MD_meth_set_input_blocksize(_hidden_sha256_md, SHA256_CBLOCK)
+        || !EVP_MD_meth_set_app_datasize(_hidden_sha256_md, sizeof(SYMCRYPT_SHA256_STATE))
+        || !EVP_MD_meth_set_flags(_hidden_sha256_md, EVP_MD_FLAG_DIGALGID_ABSENT)
+        || !EVP_MD_meth_set_init(_hidden_sha256_md, sc_ossl_digest_sha256_init)
+        || !EVP_MD_meth_set_update(_hidden_sha256_md, sc_ossl_digest_sha256_update)
+        || !EVP_MD_meth_set_final(_hidden_sha256_md, sc_ossl_digest_sha256_final)
+        || !EVP_MD_meth_set_copy(_hidden_sha256_md, sc_ossl_digest_sha256_copy)
+        )
     {
-        EVP_MD *md;
-        if( (md = EVP_MD_meth_new(NID_sha256, NID_sha256WithRSAEncryption)) == NULL
-            || !EVP_MD_meth_set_result_size(md, SHA256_DIGEST_LENGTH)
-            || !EVP_MD_meth_set_input_blocksize(md, SHA256_CBLOCK)
-            || !EVP_MD_meth_set_app_datasize(md, sizeof(SYMCRYPT_SHA256_STATE))
-            || !EVP_MD_meth_set_flags(md, EVP_MD_FLAG_DIGALGID_ABSENT)
-            || !EVP_MD_meth_set_init(md, sc_ossl_digest_sha256_init)
-            || !EVP_MD_meth_set_update(md, sc_ossl_digest_sha256_update)
-            || !EVP_MD_meth_set_final(md, sc_ossl_digest_sha256_final)
-            || !EVP_MD_meth_set_copy(md, sc_ossl_digest_sha256_copy)
-            )
-        {
-            EVP_MD_meth_free(md);
-            md = NULL;
-        }
-        _hidden_sha256_md = md;
+        EVP_MD_meth_free(_hidden_sha256_md);
+        _hidden_sha256_md = NULL;
     }
     return _hidden_sha256_md;
 }
@@ -115,24 +99,19 @@ static SCOSSL_STATUS sc_ossl_digest_sha384_copy(_Out_ EVP_MD_CTX *to, _In_ const
 static EVP_MD *_hidden_sha384_md = NULL;
 static const EVP_MD *sc_ossl_digest_sha384(void)
 {
-    if( _hidden_sha384_md == NULL )
+    if( (_hidden_sha384_md = EVP_MD_meth_new(NID_sha384, NID_sha384WithRSAEncryption)) == NULL
+        || !EVP_MD_meth_set_result_size(_hidden_sha384_md, SHA384_DIGEST_LENGTH)
+        || !EVP_MD_meth_set_input_blocksize(_hidden_sha384_md, SHA512_CBLOCK)
+        || !EVP_MD_meth_set_app_datasize(_hidden_sha384_md, sizeof(SYMCRYPT_SHA384_STATE))
+        || !EVP_MD_meth_set_flags(_hidden_sha384_md, EVP_MD_FLAG_DIGALGID_ABSENT)
+        || !EVP_MD_meth_set_init(_hidden_sha384_md, sc_ossl_digest_sha384_init)
+        || !EVP_MD_meth_set_update(_hidden_sha384_md, sc_ossl_digest_sha384_update)
+        || !EVP_MD_meth_set_final(_hidden_sha384_md, sc_ossl_digest_sha384_final)
+        || !EVP_MD_meth_set_copy(_hidden_sha384_md, sc_ossl_digest_sha384_copy)
+        )
     {
-        EVP_MD *md;
-        if( (md = EVP_MD_meth_new(NID_sha384, NID_sha384WithRSAEncryption)) == NULL
-            || !EVP_MD_meth_set_result_size(md, SHA384_DIGEST_LENGTH)
-            || !EVP_MD_meth_set_input_blocksize(md, SHA512_CBLOCK)
-            || !EVP_MD_meth_set_app_datasize(md, sizeof(SYMCRYPT_SHA384_STATE))
-            || !EVP_MD_meth_set_flags(md, EVP_MD_FLAG_DIGALGID_ABSENT)
-            || !EVP_MD_meth_set_init(md, sc_ossl_digest_sha384_init)
-            || !EVP_MD_meth_set_update(md, sc_ossl_digest_sha384_update)
-            || !EVP_MD_meth_set_final(md, sc_ossl_digest_sha384_final)
-            || !EVP_MD_meth_set_copy(md, sc_ossl_digest_sha384_copy)
-            )
-        {
-            EVP_MD_meth_free(md);
-            md = NULL;
-        }
-        _hidden_sha384_md = md;
+        EVP_MD_meth_free(_hidden_sha384_md);
+        _hidden_sha384_md = NULL;
     }
     return _hidden_sha384_md;
 }
@@ -145,24 +124,19 @@ static SCOSSL_STATUS sc_ossl_digest_sha512_copy(_Out_ EVP_MD_CTX *to, _In_ const
 static EVP_MD *_hidden_sha512_md = NULL;
 static const EVP_MD *sc_ossl_digest_sha512(void)
 {
-    if( _hidden_sha512_md == NULL )
+    if( (_hidden_sha512_md = EVP_MD_meth_new(NID_sha512, NID_sha512WithRSAEncryption)) == NULL
+        || !EVP_MD_meth_set_result_size(_hidden_sha512_md, SHA512_DIGEST_LENGTH)
+        || !EVP_MD_meth_set_input_blocksize(_hidden_sha512_md, SHA512_CBLOCK)
+        || !EVP_MD_meth_set_app_datasize(_hidden_sha512_md, sizeof(SYMCRYPT_SHA512_STATE))
+        || !EVP_MD_meth_set_flags(_hidden_sha512_md, EVP_MD_FLAG_DIGALGID_ABSENT)
+        || !EVP_MD_meth_set_init(_hidden_sha512_md, sc_ossl_digest_sha512_init)
+        || !EVP_MD_meth_set_update(_hidden_sha512_md, sc_ossl_digest_sha512_update)
+        || !EVP_MD_meth_set_final(_hidden_sha512_md, sc_ossl_digest_sha512_final)
+        || !EVP_MD_meth_set_copy(_hidden_sha512_md, sc_ossl_digest_sha512_copy)
+        )
     {
-        EVP_MD *md;
-        if( (md = EVP_MD_meth_new(NID_sha512, NID_sha512WithRSAEncryption)) == NULL
-            || !EVP_MD_meth_set_result_size(md, SHA512_DIGEST_LENGTH)
-            || !EVP_MD_meth_set_input_blocksize(md, SHA512_CBLOCK)
-            || !EVP_MD_meth_set_app_datasize(md, sizeof(SYMCRYPT_SHA512_STATE))
-            || !EVP_MD_meth_set_flags(md, EVP_MD_FLAG_DIGALGID_ABSENT)
-            || !EVP_MD_meth_set_init(md, sc_ossl_digest_sha512_init)
-            || !EVP_MD_meth_set_update(md, sc_ossl_digest_sha512_update)
-            || !EVP_MD_meth_set_final(md, sc_ossl_digest_sha512_final)
-            || !EVP_MD_meth_set_copy(md, sc_ossl_digest_sha512_copy)
-            )
-        {
-            EVP_MD_meth_free(md);
-            md = NULL;
-        }
-        _hidden_sha512_md = md;
+        EVP_MD_meth_free(_hidden_sha512_md);
+        _hidden_sha512_md = NULL;
     }
     return _hidden_sha512_md;
 }
@@ -170,15 +144,28 @@ static const EVP_MD *sc_ossl_digest_sha512(void)
 void sc_ossl_destroy_digests(void)
 {
     EVP_MD_meth_free(_hidden_md5_md);
-    _hidden_md5_md = NULL;
     EVP_MD_meth_free(_hidden_sha1_md);
-    _hidden_sha1_md = NULL;
     EVP_MD_meth_free(_hidden_sha256_md);
-    _hidden_sha256_md = NULL;
     EVP_MD_meth_free(_hidden_sha384_md);
-    _hidden_sha384_md = NULL;
     EVP_MD_meth_free(_hidden_sha512_md);
+    _hidden_md5_md = NULL;
+    _hidden_sha1_md = NULL;
+    _hidden_sha256_md = NULL;
+    _hidden_sha384_md = NULL;
     _hidden_sha512_md = NULL;
+}
+
+SCOSSL_STATUS scossl_digests_init_static()
+{
+    if( (sc_ossl_digest_md5() == NULL) ||
+        (sc_ossl_digest_sha1() == NULL) ||
+        (sc_ossl_digest_sha256() == NULL) ||
+        (sc_ossl_digest_sha384() == NULL) ||
+        (sc_ossl_digest_sha512() == NULL) )
+    {
+        return 0;
+    }
+    return 1;
 }
 
 _Success_(return > 0)
@@ -198,19 +185,19 @@ int sc_ossl_digests(_Inout_ ENGINE *e, _Out_opt_ const EVP_MD **digest,
     switch (nid)
     {
     case NID_md5:
-        *digest = sc_ossl_digest_md5();
+        *digest = _hidden_md5_md;
         break;
     case NID_sha1:
-        *digest = sc_ossl_digest_sha1();
+        *digest = _hidden_sha1_md;
         break;
     case NID_sha256:
-        *digest = sc_ossl_digest_sha256();
+        *digest = _hidden_sha256_md;
         break;
     case NID_sha384:
-        *digest = sc_ossl_digest_sha384();
+        *digest = _hidden_sha384_md;
         break;
     case NID_sha512:
-        *digest = sc_ossl_digest_sha512();
+        *digest = _hidden_sha512_md;
         break;
     default:
         ok = 0;

--- a/SymCryptEngine/src/sc_ossl_digests.h
+++ b/SymCryptEngine/src/sc_ossl_digests.h
@@ -3,15 +3,18 @@
 //
 
 #include "sc_ossl.h"
+#include "sc_ossl_helpers.h"
 #include <openssl/sha.h>
 #include <openssl/md5.h>
 #include <openssl/md4.h>
 #include <openssl/md2.h>
-#include <symcrypt.h>
 
 #ifdef __cplusplus
 extern "C" {
 #endif
+
+// Initialize all of the _hidden_* digests variables
+SCOSSL_STATUS scossl_digests_init_static();
 
 /*
  * Returns either the digest for 'nid', or a list of supported 'nids'.

--- a/SymCryptEngine/src/sc_ossl_ecc.h
+++ b/SymCryptEngine/src/sc_ossl_ecc.h
@@ -10,12 +10,15 @@
 extern "C" {
 #endif
 
-extern int eckey_sc_ossl_idx;
+extern int scossl_eckey_idx;
 
 typedef int (*PFN_eckey_copy)(EC_KEY *dest, const EC_KEY *src);
 typedef int (*PFN_eckey_set_group)(EC_KEY *key, const EC_GROUP *grp);
 typedef int (*PFN_eckey_set_private)(EC_KEY *key, const BIGNUM *priv_key);
 typedef int (*PFN_eckey_set_public)(EC_KEY *key, const EC_POINT *pub_key);
+
+// Initialize all of the _hidden_* ecc variables
+SCOSSL_STATUS scossl_ecc_init_static();
 
 // Frees SymCrypt-specific components of key
 void sc_ossl_eckey_finish(_Inout_ EC_KEY *key);

--- a/SymCryptEngine/src/sc_ossl_helpers.c
+++ b/SymCryptEngine/src/sc_ossl_helpers.c
@@ -41,14 +41,14 @@ void SC_OSSL_ENGINE_set_trace_log_filename(const char *filename)
 
 static FILE *_open_trace_log_filename()
 {
-    FILE *fp = stdout;
+    FILE *fp = stderr;
 
     if( _traceLogFilename != NULL )
     {
         fp = fopen(_traceLogFilename, "a");
         if( fp == NULL )
         {
-            fp = stdout;
+            fp = stderr;
         }
     }
     return fp;
@@ -56,7 +56,7 @@ static FILE *_open_trace_log_filename()
 
 static void _close_trace_log_filename(FILE *fp)
 {
-    if( fp != stdout )
+    if( fp != stderr )
     {
         fflush(fp);
         fclose(fp);
@@ -138,7 +138,6 @@ void _scossl_log_bignum(
 {
     unsigned char *string = NULL;
     int length = 0;
-    FILE *fp = NULL;
 
     if( _traceLogLevel < trace_level )
     {

--- a/SymCryptEngine/src/sc_ossl_helpers.h
+++ b/SymCryptEngine/src/sc_ossl_helpers.h
@@ -48,28 +48,28 @@ void _scossl_log_SYMCRYPT_ERROR(
 // Enable debug and info messages in debug builds, but compile them out in release builds
 #if DBG
     #define SC_OSSL_LOG_DEBUG(...) \
-        _scossl_log(SC_OSSL_LOG_LEVEL_DEBUG, __FUNCTION__, __VA_ARGS__)
+        _scossl_log(SC_OSSL_LOG_LEVEL_DEBUG, __func__, __VA_ARGS__)
 
     #define SC_OSSL_LOG_INFO(...) \
-        _scossl_log(SC_OSSL_LOG_LEVEL_INFO, __FUNCTION__, __VA_ARGS__)
+        _scossl_log(SC_OSSL_LOG_LEVEL_INFO, __func__, __VA_ARGS__)
 
     #define SC_OSSL_LOG_BYTES_DEBUG(description, s, len) \
-        _scossl_log_bytes(SC_OSSL_LOG_LEVEL_DEBUG, __FUNCTION__, description, (const char*) s, len)
+        _scossl_log_bytes(SC_OSSL_LOG_LEVEL_DEBUG, __func__, description, (const char*) s, len)
 
     #define SC_OSSL_LOG_BYTES_INFO(description, s, len) \
-        _scossl_log_bytes(SC_OSSL_LOG_LEVEL_INFO, __FUNCTION__, description, (const char*) s, len)
+        _scossl_log_bytes(SC_OSSL_LOG_LEVEL_INFO, __func__, description, (const char*) s, len)
 
     #define SC_OSSL_LOG_BIGNUM_DEBUG(description, bn) \
-        _scossl_log_bignum(SC_OSSL_LOG_LEVEL_DEBUG, __FUNCTION__, description, bn)
+        _scossl_log_bignum(SC_OSSL_LOG_LEVEL_DEBUG, __func__, description, bn)
 
     #define SC_OSSL_LOG_BIGNUM_INFO(description, s, len) \
-        _scossl_log_bignum(SC_OSSL_LOG_LEVEL_INFO, __FUNCTION__, description, bn)
+        _scossl_log_bignum(SC_OSSL_LOG_LEVEL_INFO, __func__, description, bn)
 
     #define SC_OSSL_LOG_SYMERROR_DEBUG(description, symError) \
-        _scossl_log_SYMCRYPT_ERROR(SC_OSSL_LOG_LEVEL_DEBUG, __FUNCTION__, description, symError)
+        _scossl_log_SYMCRYPT_ERROR(SC_OSSL_LOG_LEVEL_DEBUG, __func__, description, symError)
 
     #define SC_OSSL_LOG_SYMERROR_INFO(description, symError) \
-        _scossl_log_SYMCRYPT_ERROR(SC_OSSL_LOG_LEVEL_INFO, __FUNCTION__, description, symError)
+        _scossl_log_SYMCRYPT_ERROR(SC_OSSL_LOG_LEVEL_INFO, __func__, description, symError)
 #else
     #define SC_OSSL_LOG_DEBUG(...)
     #define SC_OSSL_LOG_INFO(...)

--- a/SymCryptEngine/src/sc_ossl_hkdf.c
+++ b/SymCryptEngine/src/sc_ossl_hkdf.c
@@ -2,11 +2,8 @@
 // Copyright (c) Microsoft Corporation. Licensed under the MIT license.
 //
 
-#include "sc_ossl.h"
 #include "sc_ossl_hkdf.h"
-#include "sc_ossl_helpers.h"
 #include <openssl/hmac.h>
-#include <symcrypt.h>
 #include <openssl/kdf.h>
 
 #ifdef __cplusplus
@@ -210,9 +207,7 @@ static unsigned char *HKDF(const EVP_MD *evp_md,
     return ret;
 }
 
-PCSYMCRYPT_MAC
-SymCryptMacAlgorithm(
-    _In_ const EVP_MD *evp_md)
+static PCSYMCRYPT_MAC scossl_get_symcrypt_mac_algorithm( _In_ const EVP_MD *evp_md )
 {
     int type = EVP_MD_type(evp_md);
 
@@ -226,6 +221,7 @@ SymCryptMacAlgorithm(
         return SymCryptHmacSha512Algorithm;
     // if (type == NID_AES_CMC)
     //     return SymCryptAesCmacAlgorithm;
+    SC_OSSL_LOG_ERROR("SymCrypt engine does not support Mac algorithm %d", type);
     return NULL;
 }
 
@@ -235,13 +231,13 @@ SCOSSL_STATUS sc_ossl_hkdf_derive(_Inout_ EVP_PKEY_CTX *ctx, _Out_writes_opt_(*k
     SYMCRYPT_ERROR SymError = SYMCRYPT_NO_ERROR;
     SC_OSSL_HKDF_PKEY_CTX *sc_ossl_hkdf_context = (SC_OSSL_HKDF_PKEY_CTX *)EVP_PKEY_CTX_get_data(ctx);
     PCSYMCRYPT_MAC sc_ossl_mac_algo = NULL;
-    SYMCRYPT_HKDF_EXPANDED_KEY  scExpandedKey;
+    // SYMCRYPT_HKDF_EXPANDED_KEY  scExpandedKey;
 
     if (sc_ossl_hkdf_context->md == NULL) {
         SC_OSSL_LOG_ERROR("Missing Digest");
         return 0;
     }
-    sc_ossl_mac_algo = SymCryptMacAlgorithm(sc_ossl_hkdf_context->md);
+    sc_ossl_mac_algo = scossl_get_symcrypt_mac_algorithm(sc_ossl_hkdf_context->md);
     if (sc_ossl_hkdf_context->key == NULL) {
         SC_OSSL_LOG_ERROR("Missing Key");
         return 0;

--- a/SymCryptEngine/src/sc_ossl_hkdf.c
+++ b/SymCryptEngine/src/sc_ossl_hkdf.c
@@ -228,7 +228,7 @@ static PCSYMCRYPT_MAC scossl_get_symcrypt_mac_algorithm( _In_ const EVP_MD *evp_
 SCOSSL_STATUS sc_ossl_hkdf_derive(_Inout_ EVP_PKEY_CTX *ctx, _Out_writes_opt_(*keylen) unsigned char *key,
                                     _Out_ size_t *keylen)
 {
-    SYMCRYPT_ERROR SymError = SYMCRYPT_NO_ERROR;
+    SYMCRYPT_ERROR symError = SYMCRYPT_NO_ERROR;
     SC_OSSL_HKDF_PKEY_CTX *sc_ossl_hkdf_context = (SC_OSSL_HKDF_PKEY_CTX *)EVP_PKEY_CTX_get_data(ctx);
     PCSYMCRYPT_MAC sc_ossl_mac_algo = NULL;
     // SYMCRYPT_HKDF_EXPANDED_KEY  scExpandedKey;
@@ -247,7 +247,7 @@ SCOSSL_STATUS sc_ossl_hkdf_derive(_Inout_ EVP_PKEY_CTX *ctx, _Out_writes_opt_(*k
     case EVP_PKEY_HKDEF_MODE_EXTRACT_AND_EXPAND:
         if( sc_ossl_mac_algo != NULL )
         {
-            SymError = SymCryptHkdf(
+            symError = SymCryptHkdf(
                 sc_ossl_mac_algo,
                 sc_ossl_hkdf_context->key,
                 sc_ossl_hkdf_context->key_len,
@@ -257,7 +257,7 @@ SCOSSL_STATUS sc_ossl_hkdf_derive(_Inout_ EVP_PKEY_CTX *ctx, _Out_writes_opt_(*k
                 sc_ossl_hkdf_context->info_len,
                 key,
                 *keylen);
-            if (SymError != SYMCRYPT_NO_ERROR)
+            if (symError != SYMCRYPT_NO_ERROR)
             {
                 return 0;
             }
@@ -291,7 +291,7 @@ SCOSSL_STATUS sc_ossl_hkdf_derive(_Inout_ EVP_PKEY_CTX *ctx, _Out_writes_opt_(*k
         //     sc_ossl_hkdf_context->salt_len);
         // if (SymCryptError != SYMCRYPT_NO_ERROR)
         // {
-        //     SC_OSSL_LOG_SYMERROR_DEBUG("SymCryptHkdfExpandKey failed", SymError);
+        //     SC_OSSL_LOG_SYMERROR_DEBUG("SymCryptHkdfExpandKey failed", symError);
         //     return 0;
         // }
 
@@ -319,7 +319,7 @@ SCOSSL_STATUS sc_ossl_hkdf_derive(_Inout_ EVP_PKEY_CTX *ctx, _Out_writes_opt_(*k
         //                     *keylen);
         // if (SymCryptError != SYMCRYPT_NO_ERROR)
         // {
-        //     SC_OSSL_LOG_SYMERROR_DEBUG("SymCryptHkdfExpandKey failed", SymError);
+        //     SC_OSSL_LOG_SYMERROR_DEBUG("SymCryptHkdfExpandKey failed", symError);
         //     return 0;
         // }
         // return 1;

--- a/SymCryptEngine/src/sc_ossl_pkey_meths.c
+++ b/SymCryptEngine/src/sc_ossl_pkey_meths.c
@@ -83,8 +83,7 @@ static int sc_ossl_pkey_rsa_verify(_Inout_ EVP_PKEY_CTX *ctx, _In_reads_bytes_(s
 
 static EVP_PKEY_METHOD *_sc_ossl_pkey_rsa = NULL;
 
-// Returns the internal RSA method structure holding methods for RSA functions, and
-// creates that structure if it doesn't already exist.
+// Creates and returns the internal RSA method structure holding methods for RSA functions
 static EVP_PKEY_METHOD *sc_ossl_pkey_rsa(void)
 {
     int (*psign_init) (EVP_PKEY_CTX *ctx) = NULL;
@@ -112,8 +111,7 @@ static EVP_PKEY_METHOD *sc_ossl_pkey_rsa(void)
 static const EVP_PKEY_METHOD *_openssl_pkey_rsa_pss = NULL;
 static EVP_PKEY_METHOD *_sc_ossl_pkey_rsa_pss = NULL;
 
-// Returns the internal RSA PSS method structure holding methods for RSA PSS functions, and
-// creates that structure if it doesn't already exist.
+// Creates and returns the internal RSA PSS method structure holding methods for RSA PSS functions
 static EVP_PKEY_METHOD *sc_ossl_pkey_rsa_pss(void)
 {
     int (*psign_init) (EVP_PKEY_CTX *ctx) = NULL;
@@ -142,8 +140,7 @@ static EVP_PKEY_METHOD *sc_ossl_pkey_rsa_pss(void)
 static const EVP_PKEY_METHOD *_openssl_pkey_tls1_prf = NULL;
 static EVP_PKEY_METHOD *_sc_ossl_pkey_tls1_prf = NULL;
 
-// Returns the internal TLS1 PRF method structure holding methods for TLS1 PRF functions, and
-// creates that structure if it doesn't already exist.
+// Creates and returns the internal TLS1 PRF method structure holding methods for TLS1 PRF functions
 static EVP_PKEY_METHOD *sc_ossl_pkey_tls1_prf(void)
 {
     int (*pctrl) (EVP_PKEY_CTX *ctx, int type, int p1, void *p2) = NULL;
@@ -165,8 +162,7 @@ static EVP_PKEY_METHOD *sc_ossl_pkey_tls1_prf(void)
 static const EVP_PKEY_METHOD *_openssl_pkey_hkdf = NULL;
 static EVP_PKEY_METHOD *_sc_ossl_pkey_hkdf = NULL;
 
-// Returns the internal HKDF method structure holding methods for HKDF functions, and creates that structure
-// if it doesn't already exist.
+// Creates and returns the internal HKDF method structure holding methods for HKDF functions
 static EVP_PKEY_METHOD *sc_ossl_pkey_hkdf(void)
 {
     int (*pctrl) (EVP_PKEY_CTX *ctx, int type, int p1, void *p2) = NULL;

--- a/SymCryptEngine/src/sc_ossl_pkey_meths.h
+++ b/SymCryptEngine/src/sc_ossl_pkey_meths.h
@@ -3,12 +3,15 @@
 //
 
 #include "sc_ossl.h"
+#include "sc_ossl_helpers.h"
 #include <openssl/dh.h>
-#include <symcrypt.h>
 
 #ifdef __cplusplus
 extern "C" {
 #endif
+
+// Initialize all of the _hidden_* pkey method variables
+SCOSSL_STATUS scossl_pkey_methods_init_static();
 
 // Return a list of supported nids if pmeth is NULL, or a particular pkey
 // method in pmeth determined by nid. Returns number of supported nids in the first case.

--- a/SymCryptEngine/src/sc_ossl_rand.c
+++ b/SymCryptEngine/src/sc_ossl_rand.c
@@ -2,17 +2,7 @@
 // Copyright (c) Microsoft Corporation. Licensed under the MIT license.
 //
 
-#include "sc_ossl.h"
-#include "sc_ossl_ecc.h"
-#include "sc_ossl_rsa.h"
-#include "sc_ossl_dsa.h"
-#include "sc_ossl_dh.h"
-#include "sc_ossl_digests.h"
-#include "sc_ossl_ciphers.h"
-#include "sc_ossl_pkey_meths.h"
 #include "sc_ossl_rand.h"
-#include "sc_ossl_helpers.h"
-#include <symcrypt.h>
 
 #ifdef __cplusplus
 extern "C" {

--- a/SymCryptEngine/src/sc_ossl_rand.h
+++ b/SymCryptEngine/src/sc_ossl_rand.h
@@ -3,6 +3,7 @@
 //
 
 #include "sc_ossl.h"
+#include "sc_ossl_helpers.h"
 #include <openssl/rand.h>
 
 #ifdef __cplusplus

--- a/SymCryptEngine/src/sc_ossl_rsa.c
+++ b/SymCryptEngine/src/sc_ossl_rsa.c
@@ -41,7 +41,7 @@ SCOSSL_RETURNLENGTH sc_ossl_rsa_pub_enc(int flen, _In_reads_bytes_(flen) const u
     _Out_writes_bytes_(RSA_size(rsa)) unsigned char* to, _In_ RSA* rsa,
     int padding)
 {
-    SYMCRYPT_ERROR SymError = SYMCRYPT_NO_ERROR;
+    SYMCRYPT_ERROR symError = SYMCRYPT_NO_ERROR;
     BN_ULONG cbModulus = 0;
     SIZE_T cbResult = -1;
     int ret = -1;
@@ -76,7 +76,7 @@ SCOSSL_RETURNLENGTH sc_ossl_rsa_pub_enc(int flen, _In_reads_bytes_(flen) const u
         {
             goto cleanup;
         }
-        SymError = SymCryptRsaPkcs1Encrypt(
+        symError = SymCryptRsaPkcs1Encrypt(
                        keyCtx->key,
                        from,
                        flen,
@@ -85,9 +85,9 @@ SCOSSL_RETURNLENGTH sc_ossl_rsa_pub_enc(int flen, _In_reads_bytes_(flen) const u
                        to,
                        cbModulus,
                        &cbResult);
-        if( SymError != SYMCRYPT_NO_ERROR )
+        if( symError != SYMCRYPT_NO_ERROR )
         {
-            SC_OSSL_LOG_SYMERROR_ERROR("SymCryptRsaPkcs1Encrypt failed", SymError);
+            SC_OSSL_LOG_SYMERROR_ERROR("SymCryptRsaPkcs1Encrypt failed", symError);
             goto cleanup;
         }
         break;
@@ -96,7 +96,7 @@ SCOSSL_RETURNLENGTH sc_ossl_rsa_pub_enc(int flen, _In_reads_bytes_(flen) const u
         {
             goto cleanup;
         }
-        SymError = SymCryptRsaOaepEncrypt(
+        symError = SymCryptRsaOaepEncrypt(
                        keyCtx->key,
                        from,
                        flen,
@@ -108,9 +108,9 @@ SCOSSL_RETURNLENGTH sc_ossl_rsa_pub_enc(int flen, _In_reads_bytes_(flen) const u
                        to,
                        cbModulus,
                        &cbResult);
-        if( SymError != SYMCRYPT_NO_ERROR )
+        if( symError != SYMCRYPT_NO_ERROR )
         {
-            SC_OSSL_LOG_SYMERROR_ERROR("SymCryptRsaOaepEncrypt failed", SymError);
+            SC_OSSL_LOG_SYMERROR_ERROR("SymCryptRsaOaepEncrypt failed", symError);
             goto cleanup;
         }
         break;
@@ -119,7 +119,7 @@ SCOSSL_RETURNLENGTH sc_ossl_rsa_pub_enc(int flen, _In_reads_bytes_(flen) const u
         {
             goto cleanup;
         }
-        SymError = SymCryptRsaRawEncrypt(
+        symError = SymCryptRsaRawEncrypt(
                        keyCtx->key,
                        from,
                        flen,
@@ -128,9 +128,9 @@ SCOSSL_RETURNLENGTH sc_ossl_rsa_pub_enc(int flen, _In_reads_bytes_(flen) const u
                        to,
                        cbModulus);
         cbResult = cbModulus;
-        if( SymError != SYMCRYPT_NO_ERROR )
+        if( symError != SYMCRYPT_NO_ERROR )
         {
-            SC_OSSL_LOG_SYMERROR_ERROR("SymCryptRsaRawEncrypt failed", SymError);
+            SC_OSSL_LOG_SYMERROR_ERROR("SymCryptRsaRawEncrypt failed", symError);
             goto cleanup;
         }
         break;
@@ -156,7 +156,7 @@ cleanup:
 SCOSSL_RETURNLENGTH sc_ossl_rsa_priv_dec(int flen, _In_reads_bytes_(flen) const unsigned char* from,
     _Out_writes_bytes_(RSA_size(rsa)) unsigned char* to, _In_ RSA* rsa, int padding)
 {
-    SYMCRYPT_ERROR SymError = SYMCRYPT_NO_ERROR;
+    SYMCRYPT_ERROR symError = SYMCRYPT_NO_ERROR;
     BN_ULONG cbModulus = 0;
     SIZE_T cbResult = -1;
     UINT64 err = 0;
@@ -192,7 +192,7 @@ SCOSSL_RETURNLENGTH sc_ossl_rsa_priv_dec(int flen, _In_reads_bytes_(flen) const 
     switch( padding )
     {
     case RSA_PKCS1_PADDING:
-        SymError = SymCryptRsaPkcs1Decrypt(
+        symError = SymCryptRsaPkcs1Decrypt(
                        keyCtx->key,
                        from,
                        flen,
@@ -204,11 +204,11 @@ SCOSSL_RETURNLENGTH sc_ossl_rsa_priv_dec(int flen, _In_reads_bytes_(flen) const 
 
         // Constant-time error processing to avoid Bleichenbacher attack
 
-        // Set ret based on SymError and cbResult
+        // Set ret based on symError and cbResult
         // cbResult > INT_MAX               => err > 0
         err = (UINT64)cbResult >> 31;
-        // SymError != SYMCRYPT_NO_ERROR    => err > 0
-        err |= (UINT32)(SymError ^ SYMCRYPT_NO_ERROR);
+        // symError != SYMCRYPT_NO_ERROR    => err > 0
+        err |= (UINT32)(symError ^ SYMCRYPT_NO_ERROR);
         // if( err > 0 ) { ret = -1; }
         // else          { ret = 0; }
         ret = (0ll - err) >> 32;
@@ -217,7 +217,7 @@ SCOSSL_RETURNLENGTH sc_ossl_rsa_priv_dec(int flen, _In_reads_bytes_(flen) const 
         ret |= (UINT32)cbResult;
         goto cleanup;
     case RSA_PKCS1_OAEP_PADDING:
-        SymError = SymCryptRsaOaepDecrypt(
+        symError = SymCryptRsaOaepDecrypt(
                        keyCtx->key,
                        from,
                        flen,
@@ -229,14 +229,14 @@ SCOSSL_RETURNLENGTH sc_ossl_rsa_priv_dec(int flen, _In_reads_bytes_(flen) const 
                        to,
                        cbModulus - SC_OSSL_MIN_OAEP_PADDING,
                        &cbResult);
-        if( SymError != SYMCRYPT_NO_ERROR )
+        if( symError != SYMCRYPT_NO_ERROR )
         {
-            SC_OSSL_LOG_SYMERROR_ERROR("SymCryptRsaOaepDecrypt failed", SymError);
+            SC_OSSL_LOG_SYMERROR_ERROR("SymCryptRsaOaepDecrypt failed", symError);
             goto cleanup;
         }
         break;
     case RSA_NO_PADDING:
-        SymError = SymCryptRsaRawDecrypt(
+        symError = SymCryptRsaRawDecrypt(
                        keyCtx->key,
                        from,
                        flen,
@@ -245,9 +245,9 @@ SCOSSL_RETURNLENGTH sc_ossl_rsa_priv_dec(int flen, _In_reads_bytes_(flen) const 
                        to,
                        cbModulus);
         cbResult = cbModulus;
-        if( SymError != SYMCRYPT_NO_ERROR )
+        if( symError != SYMCRYPT_NO_ERROR )
         {
-            SC_OSSL_LOG_SYMERROR_ERROR("SymCryptRsaRawDecrypt failed", SymError);
+            SC_OSSL_LOG_SYMERROR_ERROR("SymCryptRsaRawDecrypt failed", symError);
             goto cleanup;
         }
         break;
@@ -310,7 +310,7 @@ SCOSSL_STATUS sc_ossl_rsa_sign(int type, _In_reads_bytes_(m_length) const unsign
     BN_ULONG cbModulus = 0;
     SIZE_T cbResult = 0;
     SCOSSL_STATUS ret = 0;
-    SYMCRYPT_ERROR SymError = SYMCRYPT_NO_ERROR;
+    SYMCRYPT_ERROR symError = SYMCRYPT_NO_ERROR;
     SC_OSSL_RSA_KEY_CONTEXT *keyCtx = RSA_get_ex_data(rsa, scossl_rsa_idx);
 
     if( keyCtx == NULL )
@@ -342,7 +342,7 @@ SCOSSL_STATUS sc_ossl_rsa_sign(int type, _In_reads_bytes_(m_length) const unsign
             goto cleanup;
         }
 
-        SymError = SymCryptRsaPkcs1Sign(
+        symError = SymCryptRsaPkcs1Sign(
                        keyCtx->key,
                        m,
                        m_length,
@@ -354,9 +354,9 @@ SCOSSL_STATUS sc_ossl_rsa_sign(int type, _In_reads_bytes_(m_length) const unsign
                        cbModulus,
                        &cbResult);
 
-        if( SymError != SYMCRYPT_NO_ERROR )
+        if( symError != SYMCRYPT_NO_ERROR )
         {
-            SC_OSSL_LOG_SYMERROR_ERROR("SymCryptRsaPkcs1Sign failed", SymError);
+            SC_OSSL_LOG_SYMERROR_ERROR("SymCryptRsaPkcs1Sign failed", symError);
             goto cleanup;
         }
         break;
@@ -367,7 +367,7 @@ SCOSSL_STATUS sc_ossl_rsa_sign(int type, _In_reads_bytes_(m_length) const unsign
             goto cleanup;
         }
 
-        SymError = SymCryptRsaPkcs1Sign(
+        symError = SymCryptRsaPkcs1Sign(
                        keyCtx->key,
                        m,
                        m_length,
@@ -379,9 +379,9 @@ SCOSSL_STATUS sc_ossl_rsa_sign(int type, _In_reads_bytes_(m_length) const unsign
                        cbModulus,
                        &cbResult);
 
-        if( SymError != SYMCRYPT_NO_ERROR )
+        if( symError != SYMCRYPT_NO_ERROR )
         {
-            SC_OSSL_LOG_SYMERROR_ERROR("SymCryptRsaPkcs1Sign failed", SymError);
+            SC_OSSL_LOG_SYMERROR_ERROR("SymCryptRsaPkcs1Sign failed", symError);
             goto cleanup;
         }
         break;
@@ -392,7 +392,7 @@ SCOSSL_STATUS sc_ossl_rsa_sign(int type, _In_reads_bytes_(m_length) const unsign
             goto cleanup;
         }
 
-        SymError = SymCryptRsaPkcs1Sign(
+        symError = SymCryptRsaPkcs1Sign(
                        keyCtx->key,
                        m,
                        m_length,
@@ -404,9 +404,9 @@ SCOSSL_STATUS sc_ossl_rsa_sign(int type, _In_reads_bytes_(m_length) const unsign
                        cbModulus,
                        &cbResult);
 
-        if( SymError != SYMCRYPT_NO_ERROR )
+        if( symError != SYMCRYPT_NO_ERROR )
         {
-            SC_OSSL_LOG_SYMERROR_ERROR("SymCryptRsaPkcs1Sign failed", SymError);
+            SC_OSSL_LOG_SYMERROR_ERROR("SymCryptRsaPkcs1Sign failed", symError);
             goto cleanup;
         }
         break;
@@ -416,7 +416,7 @@ SCOSSL_STATUS sc_ossl_rsa_sign(int type, _In_reads_bytes_(m_length) const unsign
             goto cleanup;
         }
 
-        SymError = SymCryptRsaPkcs1Sign(
+        symError = SymCryptRsaPkcs1Sign(
                        keyCtx->key,
                        m,
                        m_length,
@@ -428,9 +428,9 @@ SCOSSL_STATUS sc_ossl_rsa_sign(int type, _In_reads_bytes_(m_length) const unsign
                        cbModulus,
                        &cbResult);
 
-        if( SymError != SYMCRYPT_NO_ERROR )
+        if( symError != SYMCRYPT_NO_ERROR )
         {
-            SC_OSSL_LOG_SYMERROR_ERROR("SymCryptRsaPkcs1Sign failed", SymError);
+            SC_OSSL_LOG_SYMERROR_ERROR("SymCryptRsaPkcs1Sign failed", symError);
             goto cleanup;
         }
 
@@ -441,7 +441,7 @@ SCOSSL_STATUS sc_ossl_rsa_sign(int type, _In_reads_bytes_(m_length) const unsign
             goto cleanup;
         }
 
-        SymError = SymCryptRsaPkcs1Sign(
+        symError = SymCryptRsaPkcs1Sign(
                        keyCtx->key,
                        m,
                        m_length,
@@ -453,9 +453,9 @@ SCOSSL_STATUS sc_ossl_rsa_sign(int type, _In_reads_bytes_(m_length) const unsign
                        cbModulus,
                        &cbResult);
 
-        if( SymError != SYMCRYPT_NO_ERROR )
+        if( symError != SYMCRYPT_NO_ERROR )
         {
-            SC_OSSL_LOG_SYMERROR_ERROR("SymCryptRsaPkcs1Sign failed", SymError);
+            SC_OSSL_LOG_SYMERROR_ERROR("SymCryptRsaPkcs1Sign failed", symError);
             goto cleanup;
         }
         break;
@@ -465,7 +465,7 @@ SCOSSL_STATUS sc_ossl_rsa_sign(int type, _In_reads_bytes_(m_length) const unsign
             goto cleanup;
         }
 
-        SymError = SymCryptRsaPkcs1Sign(
+        symError = SymCryptRsaPkcs1Sign(
                        keyCtx->key,
                        m,
                        m_length,
@@ -477,9 +477,9 @@ SCOSSL_STATUS sc_ossl_rsa_sign(int type, _In_reads_bytes_(m_length) const unsign
                        cbModulus,
                        &cbResult);
 
-        if( SymError != SYMCRYPT_NO_ERROR )
+        if( symError != SYMCRYPT_NO_ERROR )
         {
-            SC_OSSL_LOG_SYMERROR_ERROR("SymCryptRsaPkcs1Sign failed", SymError);
+            SC_OSSL_LOG_SYMERROR_ERROR("SymCryptRsaPkcs1Sign failed", symError);
             goto cleanup;
         }
         break;
@@ -502,7 +502,7 @@ SCOSSL_STATUS sc_ossl_rsa_verify(int dtype, _In_reads_bytes_(m_length) const uns
 {
     BN_ULONG cbModulus = 0;
     SCOSSL_STATUS ret = 0;
-    SYMCRYPT_ERROR SymError = SYMCRYPT_NO_ERROR;
+    SYMCRYPT_ERROR symError = SYMCRYPT_NO_ERROR;
     SC_OSSL_RSA_KEY_CONTEXT *keyCtx = RSA_get_ex_data(rsa, scossl_rsa_idx);
 
     if( keyCtx == NULL )
@@ -529,7 +529,7 @@ SCOSSL_STATUS sc_ossl_rsa_verify(int dtype, _In_reads_bytes_(m_length) const uns
             goto cleanup;
         }
 
-        SymError = SymCryptRsaPkcs1Verify(
+        symError = SymCryptRsaPkcs1Verify(
                        keyCtx->key,
                        m,
                        m_length,
@@ -540,11 +540,11 @@ SCOSSL_STATUS sc_ossl_rsa_verify(int dtype, _In_reads_bytes_(m_length) const uns
                        0,
                        0);
 
-        if( SymError != SYMCRYPT_NO_ERROR )
+        if( symError != SYMCRYPT_NO_ERROR )
         {
-            if( SymError != SYMCRYPT_SIGNATURE_VERIFICATION_FAILURE )
+            if( symError != SYMCRYPT_SIGNATURE_VERIFICATION_FAILURE )
             {
-                SC_OSSL_LOG_SYMERROR_ERROR("SymCryptRsaPkcs1verify returned unexpected error", SymError);
+                SC_OSSL_LOG_SYMERROR_ERROR("SymCryptRsaPkcs1verify returned unexpected error", symError);
             }
             goto cleanup;
         }
@@ -556,7 +556,7 @@ SCOSSL_STATUS sc_ossl_rsa_verify(int dtype, _In_reads_bytes_(m_length) const uns
             goto cleanup;
         }
 
-        SymError = SymCryptRsaPkcs1Verify(
+        symError = SymCryptRsaPkcs1Verify(
                        keyCtx->key,
                        m,
                        m_length,
@@ -567,11 +567,11 @@ SCOSSL_STATUS sc_ossl_rsa_verify(int dtype, _In_reads_bytes_(m_length) const uns
                        SYMCRYPT_MD5_OID_COUNT,
                        0);
 
-        if( SymError != SYMCRYPT_NO_ERROR )
+        if( symError != SYMCRYPT_NO_ERROR )
         {
-            if( SymError != SYMCRYPT_SIGNATURE_VERIFICATION_FAILURE )
+            if( symError != SYMCRYPT_SIGNATURE_VERIFICATION_FAILURE )
             {
-                SC_OSSL_LOG_SYMERROR_ERROR("SymCryptRsaPkcs1verify returned unexpected error", SymError);
+                SC_OSSL_LOG_SYMERROR_ERROR("SymCryptRsaPkcs1verify returned unexpected error", symError);
             }
             goto cleanup;
         }
@@ -583,7 +583,7 @@ SCOSSL_STATUS sc_ossl_rsa_verify(int dtype, _In_reads_bytes_(m_length) const uns
             goto cleanup;
         }
 
-        SymError = SymCryptRsaPkcs1Verify(
+        symError = SymCryptRsaPkcs1Verify(
                        keyCtx->key,
                        m,
                        m_length,
@@ -594,11 +594,11 @@ SCOSSL_STATUS sc_ossl_rsa_verify(int dtype, _In_reads_bytes_(m_length) const uns
                        SYMCRYPT_SHA1_OID_COUNT,
                        0);
 
-        if( SymError != SYMCRYPT_NO_ERROR )
+        if( symError != SYMCRYPT_NO_ERROR )
         {
-            if( SymError != SYMCRYPT_SIGNATURE_VERIFICATION_FAILURE )
+            if( symError != SYMCRYPT_SIGNATURE_VERIFICATION_FAILURE )
             {
-                SC_OSSL_LOG_SYMERROR_ERROR("SymCryptRsaPkcs1verify returned unexpected error", SymError);
+                SC_OSSL_LOG_SYMERROR_ERROR("SymCryptRsaPkcs1verify returned unexpected error", symError);
             }
             goto cleanup;
         }
@@ -609,7 +609,7 @@ SCOSSL_STATUS sc_ossl_rsa_verify(int dtype, _In_reads_bytes_(m_length) const uns
             goto cleanup;
         }
 
-        SymError = SymCryptRsaPkcs1Verify(
+        symError = SymCryptRsaPkcs1Verify(
                        keyCtx->key,
                        m,
                        m_length,
@@ -619,11 +619,11 @@ SCOSSL_STATUS sc_ossl_rsa_verify(int dtype, _In_reads_bytes_(m_length) const uns
                        SymCryptSha256OidList,
                        SYMCRYPT_SHA256_OID_COUNT,
                        0);
-        if( SymError != SYMCRYPT_NO_ERROR )
+        if( symError != SYMCRYPT_NO_ERROR )
         {
-            if( SymError != SYMCRYPT_SIGNATURE_VERIFICATION_FAILURE )
+            if( symError != SYMCRYPT_SIGNATURE_VERIFICATION_FAILURE )
             {
-                SC_OSSL_LOG_SYMERROR_ERROR("SymCryptRsaPkcs1verify returned unexpected error", SymError);
+                SC_OSSL_LOG_SYMERROR_ERROR("SymCryptRsaPkcs1verify returned unexpected error", symError);
             }
             goto cleanup;
         }
@@ -634,7 +634,7 @@ SCOSSL_STATUS sc_ossl_rsa_verify(int dtype, _In_reads_bytes_(m_length) const uns
             goto cleanup;
         }
 
-        SymError = SymCryptRsaPkcs1Verify(
+        symError = SymCryptRsaPkcs1Verify(
                        keyCtx->key,
                        m,
                        m_length,
@@ -645,11 +645,11 @@ SCOSSL_STATUS sc_ossl_rsa_verify(int dtype, _In_reads_bytes_(m_length) const uns
                        SYMCRYPT_SHA384_OID_COUNT,
                        0);
 
-        if( SymError != SYMCRYPT_NO_ERROR )
+        if( symError != SYMCRYPT_NO_ERROR )
         {
-            if( SymError != SYMCRYPT_SIGNATURE_VERIFICATION_FAILURE )
+            if( symError != SYMCRYPT_SIGNATURE_VERIFICATION_FAILURE )
             {
-                SC_OSSL_LOG_SYMERROR_ERROR("SymCryptRsaPkcs1verify returned unexpected error", SymError);
+                SC_OSSL_LOG_SYMERROR_ERROR("SymCryptRsaPkcs1verify returned unexpected error", symError);
             }
             goto cleanup;
         }
@@ -660,7 +660,7 @@ SCOSSL_STATUS sc_ossl_rsa_verify(int dtype, _In_reads_bytes_(m_length) const uns
             goto cleanup;
         }
 
-        SymError = SymCryptRsaPkcs1Verify(
+        symError = SymCryptRsaPkcs1Verify(
                        keyCtx->key,
                        m,
                        m_length,
@@ -671,11 +671,11 @@ SCOSSL_STATUS sc_ossl_rsa_verify(int dtype, _In_reads_bytes_(m_length) const uns
                        SYMCRYPT_SHA512_OID_COUNT,
                        0);
 
-        if( SymError != SYMCRYPT_NO_ERROR )
+        if( symError != SYMCRYPT_NO_ERROR )
         {
-            if( SymError != SYMCRYPT_SIGNATURE_VERIFICATION_FAILURE )
+            if( symError != SYMCRYPT_SIGNATURE_VERIFICATION_FAILURE )
             {
-                SC_OSSL_LOG_SYMERROR_ERROR("SymCryptRsaPkcs1verify returned unexpected error", SymError);
+                SC_OSSL_LOG_SYMERROR_ERROR("SymCryptRsaPkcs1verify returned unexpected error", symError);
             }
             goto cleanup;
         }
@@ -712,7 +712,7 @@ SCOSSL_STATUS sc_ossl_rsa_keygen(_Out_ RSA* rsa, int bits, _In_ BIGNUM* e,
     PBYTE   pbData = NULL;
     SIZE_T  cbData = 0;
     SYMCRYPT_RSA_PARAMS SymcryptRsaParam;
-    SYMCRYPT_ERROR SymError = SYMCRYPT_NO_ERROR;
+    SYMCRYPT_ERROR symError = SYMCRYPT_NO_ERROR;
     int     ret = 0;
     SC_OSSL_RSA_KEY_CONTEXT *keyCtx = RSA_get_ex_data(rsa, scossl_rsa_idx);
     BIGNUM *rsa_n = NULL;
@@ -754,10 +754,10 @@ SCOSSL_STATUS sc_ossl_rsa_keygen(_Out_ RSA* rsa, int bits, _In_ BIGNUM* e,
         SC_OSSL_LOG_ERROR("SymCryptLoadMsbFirstUint64 failed");
         goto cleanup;
     }
-    SymError = SymCryptRsakeyGenerate(keyCtx->key, &pubExp64, 1, 0);
-    if( SymError != SYMCRYPT_NO_ERROR )
+    symError = SymCryptRsakeyGenerate(keyCtx->key, &pubExp64, 1, 0);
+    if( symError != SYMCRYPT_NO_ERROR )
     {
-        SC_OSSL_LOG_SYMERROR_ERROR("SymCryptRsakeyGenerate failed", SymError);
+        SC_OSSL_LOG_SYMERROR_ERROR("SymCryptRsakeyGenerate failed", symError);
         goto cleanup;
     }
 
@@ -814,7 +814,7 @@ SCOSSL_STATUS sc_ossl_rsa_keygen(_Out_ RSA* rsa, int bits, _In_ BIGNUM* e,
     pbPrivateExponent = pbCurrent;
     cbPrivateExponent = cbModulus;
 
-    SymError = SymCryptRsakeyGetValue(
+    symError = SymCryptRsakeyGetValue(
                    keyCtx->key,
                    pbModulus,
                    cbModulus,
@@ -825,13 +825,13 @@ SCOSSL_STATUS sc_ossl_rsa_keygen(_Out_ RSA* rsa, int bits, _In_ BIGNUM* e,
                    nPrimes,
                    SYMCRYPT_NUMBER_FORMAT_MSB_FIRST,
                    0);
-    if( SymError != SYMCRYPT_NO_ERROR )
+    if( symError != SYMCRYPT_NO_ERROR )
     {
-        SC_OSSL_LOG_SYMERROR_ERROR("SymCryptRsakeyGetValue failed", SymError);
+        SC_OSSL_LOG_SYMERROR_ERROR("SymCryptRsakeyGetValue failed", symError);
         goto cleanup;
     }
 
-    SymError = SymCryptRsakeyGetCrtValue(
+    symError = SymCryptRsakeyGetCrtValue(
                     keyCtx->key,
                     ppbCrtExponents,
                     pcbCrtExponents,
@@ -842,9 +842,9 @@ SCOSSL_STATUS sc_ossl_rsa_keygen(_Out_ RSA* rsa, int bits, _In_ BIGNUM* e,
                     cbPrivateExponent,
                     SYMCRYPT_NUMBER_FORMAT_MSB_FIRST,
                     0);
-    if( SymError != SYMCRYPT_NO_ERROR )
+    if( symError != SYMCRYPT_NO_ERROR )
     {
-        SC_OSSL_LOG_SYMERROR_ERROR("SymCryptRsakeyGetCrtValue failed", SymError);
+        SC_OSSL_LOG_SYMERROR_ERROR("SymCryptRsakeyGetCrtValue failed", symError);
         goto cleanup;
     }
 
@@ -915,7 +915,7 @@ SCOSSL_STATUS sc_ossl_initialize_rsa_key(_In_ RSA* rsa, _Out_ SC_OSSL_RSA_KEY_CO
     SIZE_T  cbPrime2 = 0;
     SIZE_T  nPrimes = 0;
     SYMCRYPT_RSA_PARAMS SymcryptRsaParam;
-    SYMCRYPT_ERROR SymError = SYMCRYPT_NO_ERROR;
+    SYMCRYPT_ERROR symError = SYMCRYPT_NO_ERROR;
     PBYTE   pbData = NULL;
     SIZE_T  cbData = 0;
     PBYTE   pbCurrent = NULL;
@@ -1020,7 +1020,7 @@ SCOSSL_STATUS sc_ossl_initialize_rsa_key(_In_ RSA* rsa, _Out_ SC_OSSL_RSA_KEY_CO
         goto cleanup;
     }
 
-    SymError = SymCryptRsakeySetValue(
+    symError = SymCryptRsakeySetValue(
                    pbModulus,
                    cbModulus,
                    &pubExp64,
@@ -1031,9 +1031,9 @@ SCOSSL_STATUS sc_ossl_initialize_rsa_key(_In_ RSA* rsa, _Out_ SC_OSSL_RSA_KEY_CO
                    SYMCRYPT_NUMBER_FORMAT_MSB_FIRST,
                    0,
                    keyCtx->key);
-    if( SymError != SYMCRYPT_NO_ERROR )
+    if( symError != SYMCRYPT_NO_ERROR )
     {
-        SC_OSSL_LOG_SYMERROR_ERROR("SymCryptRsakeySetValue failed", SymError);
+        SC_OSSL_LOG_SYMERROR_ERROR("SymCryptRsakeySetValue failed", symError);
         goto cleanup;
     }
 

--- a/SymCryptEngine/src/sc_ossl_rsa.c
+++ b/SymCryptEngine/src/sc_ossl_rsa.c
@@ -3,14 +3,12 @@
 //
 
 #include "sc_ossl_rsa.h"
-#include "sc_ossl_helpers.h"
-#include <symcrypt.h>
 
 #ifdef __cplusplus
 extern "C" {
 #endif
 
-int rsa_sc_ossl_idx = -1;
+int scossl_rsa_idx = -1;
 
 typedef int (*PFN_RSA_meth_pub_enc)(int flen, const unsigned char* from,
                          unsigned char* to, RSA* rsa,
@@ -49,7 +47,7 @@ SCOSSL_RETURNLENGTH sc_ossl_rsa_pub_enc(int flen, _In_reads_bytes_(flen) const u
     int ret = -1;
     const RSA_METHOD *ossl_rsa_meth = NULL;
     PFN_RSA_meth_pub_enc pfn_rsa_meth_pub_enc = NULL;
-    SC_OSSL_RSA_KEY_CONTEXT *keyCtx = RSA_get_ex_data(rsa, rsa_sc_ossl_idx);
+    SC_OSSL_RSA_KEY_CONTEXT *keyCtx = RSA_get_ex_data(rsa, scossl_rsa_idx);
 
     if( keyCtx == NULL )
     {
@@ -74,7 +72,7 @@ SCOSSL_RETURNLENGTH sc_ossl_rsa_pub_enc(int flen, _In_reads_bytes_(flen) const u
     switch( padding )
     {
     case RSA_PKCS1_PADDING:
-        if( flen > cbModulus - SC_OSSL_MIN_PKCS1_PADDING )
+        if( flen > (int) cbModulus - SC_OSSL_MIN_PKCS1_PADDING )
         {
             goto cleanup;
         }
@@ -94,7 +92,7 @@ SCOSSL_RETURNLENGTH sc_ossl_rsa_pub_enc(int flen, _In_reads_bytes_(flen) const u
         }
         break;
     case RSA_PKCS1_OAEP_PADDING:
-        if( flen > cbModulus - SC_OSSL_MIN_OAEP_PADDING )
+        if( flen > (int) cbModulus - SC_OSSL_MIN_OAEP_PADDING )
         {
             goto cleanup;
         }
@@ -117,7 +115,7 @@ SCOSSL_RETURNLENGTH sc_ossl_rsa_pub_enc(int flen, _In_reads_bytes_(flen) const u
         }
         break;
     case RSA_NO_PADDING:
-        if( flen != cbModulus )
+        if( flen != (int) cbModulus )
         {
             goto cleanup;
         }
@@ -136,30 +134,8 @@ SCOSSL_RETURNLENGTH sc_ossl_rsa_pub_enc(int flen, _In_reads_bytes_(flen) const u
             goto cleanup;
         }
         break;
-    case RSA_SSLV23_PADDING:
-        SC_OSSL_LOG_INFO("RSA_SSLV23_PADDING equivalent not found in SymCrypt. Forwarding to OpenSSL. Size: %d.", flen);
-        ossl_rsa_meth = RSA_PKCS1_OpenSSL();
-        pfn_rsa_meth_pub_enc = RSA_meth_get_pub_enc(ossl_rsa_meth);
-        if( !pfn_rsa_meth_pub_enc )
-        {
-            SC_OSSL_LOG_ERROR("RSA_meth_set_pub_enc failed");
-            goto cleanup;
-        }
-        cbResult = pfn_rsa_meth_pub_enc(flen, from, to, rsa, padding);
-        break;
-    case RSA_X931_PADDING:
-        SC_OSSL_LOG_INFO("RSA_X931_PADDING equivalent not found in SymCrypt. Forwarding to OpenSSL. Size: %d.", flen);
-        ossl_rsa_meth = RSA_PKCS1_OpenSSL();
-        pfn_rsa_meth_pub_enc = RSA_meth_get_pub_enc(ossl_rsa_meth);
-        if( !pfn_rsa_meth_pub_enc )
-        {
-            SC_OSSL_LOG_ERROR("RSA_meth_set_pub_enc failed");
-            goto cleanup;
-        }
-        cbResult = pfn_rsa_meth_pub_enc(flen, from, to, rsa, padding);
-        break;
     default:
-        SC_OSSL_LOG_INFO("Unknown Padding: %d. Forwarding to OpenSSL. Size: %d.", padding, flen);
+        SC_OSSL_LOG_INFO("Unsupported Padding: %d. Forwarding to OpenSSL. Size: %d.", padding, flen);
         ossl_rsa_meth = RSA_PKCS1_OpenSSL();
         pfn_rsa_meth_pub_enc = RSA_meth_get_pub_enc(ossl_rsa_meth);
         if( !pfn_rsa_meth_pub_enc )
@@ -187,7 +163,7 @@ SCOSSL_RETURNLENGTH sc_ossl_rsa_priv_dec(int flen, _In_reads_bytes_(flen) const 
     int ret = -1;
     const RSA_METHOD *ossl_rsa_meth = NULL;
     PFN_RSA_meth_priv_dec pfn_rsa_meth_priv_dec = NULL;
-    SC_OSSL_RSA_KEY_CONTEXT *keyCtx = RSA_get_ex_data(rsa, rsa_sc_ossl_idx);
+    SC_OSSL_RSA_KEY_CONTEXT *keyCtx = RSA_get_ex_data(rsa, scossl_rsa_idx);
 
     if( keyCtx == NULL )
     {
@@ -208,7 +184,7 @@ SCOSSL_RETURNLENGTH sc_ossl_rsa_priv_dec(int flen, _In_reads_bytes_(flen) const 
     {
         goto cleanup;
     }
-    if( flen > cbModulus )
+    if( flen > (int) cbModulus )
     {
         goto cleanup;
     }
@@ -275,30 +251,8 @@ SCOSSL_RETURNLENGTH sc_ossl_rsa_priv_dec(int flen, _In_reads_bytes_(flen) const 
             goto cleanup;
         }
         break;
-    case RSA_SSLV23_PADDING:
-        SC_OSSL_LOG_INFO("RSA_SSLV23_PADDING equivalent not found in SymCrypt. Forwarding to OpenSSL. Size: %d.", flen);
-        ossl_rsa_meth = RSA_PKCS1_OpenSSL();
-        pfn_rsa_meth_priv_dec = RSA_meth_get_priv_dec(ossl_rsa_meth);
-        if( !pfn_rsa_meth_priv_dec )
-        {
-            SC_OSSL_LOG_ERROR("RSA_meth_get_priv_dec failed");
-            goto cleanup;
-        }
-        cbResult = pfn_rsa_meth_priv_dec(flen, from, to, rsa, padding);
-        break;
-    case RSA_X931_PADDING:
-        SC_OSSL_LOG_INFO("RSA_X931_PADDING equivalent not found in SymCrypt. Forwarding to OpenSSL. Size: %d.", flen);
-        ossl_rsa_meth = RSA_PKCS1_OpenSSL();
-        pfn_rsa_meth_priv_dec = RSA_meth_get_priv_dec(ossl_rsa_meth);
-        if( !pfn_rsa_meth_priv_dec )
-        {
-            SC_OSSL_LOG_ERROR("RSA_meth_get_priv_dec failed");
-            goto cleanup;
-        }
-        cbResult = pfn_rsa_meth_priv_dec(flen, from, to, rsa, padding);
-        break;
     default:
-        SC_OSSL_LOG_INFO("Unknown Padding: %d. Forwarding to OpenSSL. Size: %d.", padding, flen);
+        SC_OSSL_LOG_INFO("Unsupported Padding: %d. Forwarding to OpenSSL. Size: %d.", padding, flen);
         ossl_rsa_meth = RSA_PKCS1_OpenSSL();
         pfn_rsa_meth_priv_dec = RSA_meth_get_priv_dec(ossl_rsa_meth);
         if( !pfn_rsa_meth_priv_dec )
@@ -357,7 +311,7 @@ SCOSSL_STATUS sc_ossl_rsa_sign(int type, _In_reads_bytes_(m_length) const unsign
     SIZE_T cbResult = 0;
     SCOSSL_STATUS ret = 0;
     SYMCRYPT_ERROR SymError = SYMCRYPT_NO_ERROR;
-    SC_OSSL_RSA_KEY_CONTEXT *keyCtx = RSA_get_ex_data(rsa, rsa_sc_ossl_idx);
+    SC_OSSL_RSA_KEY_CONTEXT *keyCtx = RSA_get_ex_data(rsa, scossl_rsa_idx);
 
     if( keyCtx == NULL )
     {
@@ -391,7 +345,7 @@ SCOSSL_STATUS sc_ossl_rsa_sign(int type, _In_reads_bytes_(m_length) const unsign
         SymError = SymCryptRsaPkcs1Sign(
                        keyCtx->key,
                        m,
-                       m_length > cbModulus ? cbModulus : m_length,
+                       m_length,
                        NULL,
                        0,
                        SYMCRYPT_FLAG_RSA_PKCS1_NO_ASN1,
@@ -416,7 +370,7 @@ SCOSSL_STATUS sc_ossl_rsa_sign(int type, _In_reads_bytes_(m_length) const unsign
         SymError = SymCryptRsaPkcs1Sign(
                        keyCtx->key,
                        m,
-                       m_length > cbModulus ? cbModulus : m_length,
+                       m_length,
                        SymCryptMd5OidList,
                        SYMCRYPT_MD5_OID_COUNT,
                        0,
@@ -441,7 +395,7 @@ SCOSSL_STATUS sc_ossl_rsa_sign(int type, _In_reads_bytes_(m_length) const unsign
         SymError = SymCryptRsaPkcs1Sign(
                        keyCtx->key,
                        m,
-                       m_length > cbModulus ? cbModulus : m_length,
+                       m_length,
                        SymCryptSha1OidList,
                        SYMCRYPT_SHA1_OID_COUNT,
                        0,
@@ -465,7 +419,7 @@ SCOSSL_STATUS sc_ossl_rsa_sign(int type, _In_reads_bytes_(m_length) const unsign
         SymError = SymCryptRsaPkcs1Sign(
                        keyCtx->key,
                        m,
-                       m_length > cbModulus ? cbModulus : m_length,
+                       m_length,
                        SymCryptSha256OidList,
                        SYMCRYPT_SHA256_OID_COUNT,
                        0,
@@ -490,7 +444,7 @@ SCOSSL_STATUS sc_ossl_rsa_sign(int type, _In_reads_bytes_(m_length) const unsign
         SymError = SymCryptRsaPkcs1Sign(
                        keyCtx->key,
                        m,
-                       m_length > cbModulus ? cbModulus : m_length,
+                       m_length,
                        SymCryptSha384OidList,
                        SYMCRYPT_SHA384_OID_COUNT,
                        0,
@@ -514,7 +468,7 @@ SCOSSL_STATUS sc_ossl_rsa_sign(int type, _In_reads_bytes_(m_length) const unsign
         SymError = SymCryptRsaPkcs1Sign(
                        keyCtx->key,
                        m,
-                       m_length > cbModulus ? cbModulus : m_length,
+                       m_length,
                        SymCryptSha512OidList,
                        SYMCRYPT_SHA512_OID_COUNT,
                        0,
@@ -549,7 +503,7 @@ SCOSSL_STATUS sc_ossl_rsa_verify(int dtype, _In_reads_bytes_(m_length) const uns
     BN_ULONG cbModulus = 0;
     SCOSSL_STATUS ret = 0;
     SYMCRYPT_ERROR SymError = SYMCRYPT_NO_ERROR;
-    SC_OSSL_RSA_KEY_CONTEXT *keyCtx = RSA_get_ex_data(rsa, rsa_sc_ossl_idx);
+    SC_OSSL_RSA_KEY_CONTEXT *keyCtx = RSA_get_ex_data(rsa, scossl_rsa_idx);
 
     if( keyCtx == NULL )
     {
@@ -578,7 +532,7 @@ SCOSSL_STATUS sc_ossl_rsa_verify(int dtype, _In_reads_bytes_(m_length) const uns
         SymError = SymCryptRsaPkcs1Verify(
                        keyCtx->key,
                        m,
-                       m_length > cbModulus ? cbModulus : m_length,
+                       m_length,
                        sigbuf,
                        siglen,
                        SYMCRYPT_NUMBER_FORMAT_MSB_FIRST,
@@ -588,7 +542,10 @@ SCOSSL_STATUS sc_ossl_rsa_verify(int dtype, _In_reads_bytes_(m_length) const uns
 
         if( SymError != SYMCRYPT_NO_ERROR )
         {
-            SC_OSSL_LOG_SYMERROR_ERROR("SymCryptRsaPkcs1verify failed", SymError);
+            if( SymError != SYMCRYPT_SIGNATURE_VERIFICATION_FAILURE )
+            {
+                SC_OSSL_LOG_SYMERROR_ERROR("SymCryptRsaPkcs1verify returned unexpected error", SymError);
+            }
             goto cleanup;
         }
         break;
@@ -602,7 +559,7 @@ SCOSSL_STATUS sc_ossl_rsa_verify(int dtype, _In_reads_bytes_(m_length) const uns
         SymError = SymCryptRsaPkcs1Verify(
                        keyCtx->key,
                        m,
-                       m_length > cbModulus ? cbModulus : m_length,
+                       m_length,
                        sigbuf,
                        siglen,
                        SYMCRYPT_NUMBER_FORMAT_MSB_FIRST,
@@ -612,7 +569,10 @@ SCOSSL_STATUS sc_ossl_rsa_verify(int dtype, _In_reads_bytes_(m_length) const uns
 
         if( SymError != SYMCRYPT_NO_ERROR )
         {
-            SC_OSSL_LOG_SYMERROR_ERROR("SymCryptRsaPkcs1verify failed", SymError);
+            if( SymError != SYMCRYPT_SIGNATURE_VERIFICATION_FAILURE )
+            {
+                SC_OSSL_LOG_SYMERROR_ERROR("SymCryptRsaPkcs1verify returned unexpected error", SymError);
+            }
             goto cleanup;
         }
         break;
@@ -626,7 +586,7 @@ SCOSSL_STATUS sc_ossl_rsa_verify(int dtype, _In_reads_bytes_(m_length) const uns
         SymError = SymCryptRsaPkcs1Verify(
                        keyCtx->key,
                        m,
-                       m_length > cbModulus ? cbModulus : m_length,
+                       m_length,
                        sigbuf,
                        siglen,
                        SYMCRYPT_NUMBER_FORMAT_MSB_FIRST,
@@ -636,7 +596,10 @@ SCOSSL_STATUS sc_ossl_rsa_verify(int dtype, _In_reads_bytes_(m_length) const uns
 
         if( SymError != SYMCRYPT_NO_ERROR )
         {
-            SC_OSSL_LOG_SYMERROR_ERROR("SymCryptRsaPkcs1verify failed", SymError);
+            if( SymError != SYMCRYPT_SIGNATURE_VERIFICATION_FAILURE )
+            {
+                SC_OSSL_LOG_SYMERROR_ERROR("SymCryptRsaPkcs1verify returned unexpected error", SymError);
+            }
             goto cleanup;
         }
         break;
@@ -649,7 +612,7 @@ SCOSSL_STATUS sc_ossl_rsa_verify(int dtype, _In_reads_bytes_(m_length) const uns
         SymError = SymCryptRsaPkcs1Verify(
                        keyCtx->key,
                        m,
-                       m_length > cbModulus ? cbModulus : m_length,
+                       m_length,
                        sigbuf,
                        siglen,
                        SYMCRYPT_NUMBER_FORMAT_MSB_FIRST,
@@ -658,7 +621,10 @@ SCOSSL_STATUS sc_ossl_rsa_verify(int dtype, _In_reads_bytes_(m_length) const uns
                        0);
         if( SymError != SYMCRYPT_NO_ERROR )
         {
-            SC_OSSL_LOG_SYMERROR_ERROR("SymCryptRsaPkcs1verify failed", SymError);
+            if( SymError != SYMCRYPT_SIGNATURE_VERIFICATION_FAILURE )
+            {
+                SC_OSSL_LOG_SYMERROR_ERROR("SymCryptRsaPkcs1verify returned unexpected error", SymError);
+            }
             goto cleanup;
         }
         break;
@@ -671,7 +637,7 @@ SCOSSL_STATUS sc_ossl_rsa_verify(int dtype, _In_reads_bytes_(m_length) const uns
         SymError = SymCryptRsaPkcs1Verify(
                        keyCtx->key,
                        m,
-                       m_length > cbModulus ? cbModulus : m_length,
+                       m_length,
                        sigbuf,
                        siglen,
                        SYMCRYPT_NUMBER_FORMAT_MSB_FIRST,
@@ -681,7 +647,10 @@ SCOSSL_STATUS sc_ossl_rsa_verify(int dtype, _In_reads_bytes_(m_length) const uns
 
         if( SymError != SYMCRYPT_NO_ERROR )
         {
-            SC_OSSL_LOG_SYMERROR_ERROR("SymCryptRsaPkcs1verify failed", SymError);
+            if( SymError != SYMCRYPT_SIGNATURE_VERIFICATION_FAILURE )
+            {
+                SC_OSSL_LOG_SYMERROR_ERROR("SymCryptRsaPkcs1verify returned unexpected error", SymError);
+            }
             goto cleanup;
         }
         break;
@@ -694,7 +663,7 @@ SCOSSL_STATUS sc_ossl_rsa_verify(int dtype, _In_reads_bytes_(m_length) const uns
         SymError = SymCryptRsaPkcs1Verify(
                        keyCtx->key,
                        m,
-                       m_length > cbModulus ? cbModulus : m_length,
+                       m_length,
                        sigbuf,
                        siglen,
                        SYMCRYPT_NUMBER_FORMAT_MSB_FIRST,
@@ -704,7 +673,10 @@ SCOSSL_STATUS sc_ossl_rsa_verify(int dtype, _In_reads_bytes_(m_length) const uns
 
         if( SymError != SYMCRYPT_NO_ERROR )
         {
-            SC_OSSL_LOG_SYMERROR_ERROR("SymCryptRsaPkcs1verify failed", SymError);
+            if( SymError != SYMCRYPT_SIGNATURE_VERIFICATION_FAILURE )
+            {
+                SC_OSSL_LOG_SYMERROR_ERROR("SymCryptRsaPkcs1verify returned unexpected error", SymError);
+            }
             goto cleanup;
         }
         break;
@@ -723,30 +695,26 @@ SCOSSL_STATUS sc_ossl_rsa_keygen(_Out_ RSA* rsa, int bits, _In_ BIGNUM* e,
     _In_opt_ BN_GENCB* cb)
 {
     UINT64  pubExp64;
-    PUINT64 pPubExp64 = &pubExp64;
-    BN_ULONG publicExponent = 0;
-    PBYTE   pbPublicExp = NULL;
-    size_t  cbPublicExp = 0;
     PBYTE   pbModulus = NULL;
-    size_t  cbModulus = 0;
+    SIZE_T  cbModulus = 0;
     PBYTE   ppbPrimes[2] = { 0 };
-    size_t  pcbPrimes[2] = { 0 };
-    size_t  cbPrime1 = 0;
-    size_t  cbPrime2 = 0;
+    SIZE_T  pcbPrimes[2] = { 0 };
+    SIZE_T  cbPrime1 = 0;
+    SIZE_T  cbPrime2 = 0;
     PBYTE   ppbCrtExponents[2] = { 0 };
-    size_t  pcbCrtExponents[2] = { 0 };
+    SIZE_T  pcbCrtExponents[2] = { 0 };
     PBYTE   pbCrtCoefficient = NULL;
-    size_t  cbCrtCoefficient = 0;
+    SIZE_T  cbCrtCoefficient = 0;
     PBYTE   pbPrivateExponent = NULL;
-    size_t  cbPrivateExponent = 0;
-    size_t  nPrimes = 2; // Constant for SymCrypt
+    SIZE_T  cbPrivateExponent = 0;
+    SIZE_T  nPrimes = 2; // Constant for SymCrypt
     PBYTE   pbCurrent = NULL;
-    size_t  cbAllocSize = 0;
-    PBYTE   pbFullPrivateKey = NULL;
+    PBYTE   pbData = NULL;
+    SIZE_T  cbData = 0;
     SYMCRYPT_RSA_PARAMS SymcryptRsaParam;
     SYMCRYPT_ERROR SymError = SYMCRYPT_NO_ERROR;
     int     ret = 0;
-    SC_OSSL_RSA_KEY_CONTEXT *keyCtx = RSA_get_ex_data(rsa, rsa_sc_ossl_idx);
+    SC_OSSL_RSA_KEY_CONTEXT *keyCtx = RSA_get_ex_data(rsa, scossl_rsa_idx);
     BIGNUM *rsa_n = NULL;
     BIGNUM *rsa_e = NULL;
     BIGNUM *rsa_p = NULL;
@@ -776,11 +744,20 @@ SCOSSL_STATUS sc_ossl_rsa_keygen(_Out_ RSA* rsa, int bits, _In_ BIGNUM* e,
         SC_OSSL_LOG_ERROR("SymCryptRsakeyAllocate failed");
         goto cleanup;
     }
-    pubExp64 = BN_get_word(e);
-    SymError = SymCryptRsakeyGenerate(keyCtx->key, pPubExp64, 1, 0);
+    if( BN_bn2binpad(e, (PBYTE) &pubExp64, sizeof(pubExp64)) != sizeof(pubExp64) )
+    {
+        SC_OSSL_LOG_ERROR("BN_bn2binpad failed - Probably Public Exponent larger than maximum supported size (8 bytes)");
+        goto cleanup;
+    }
+    if( SymCryptLoadMsbFirstUint64((PBYTE) &pubExp64, sizeof(pubExp64), &pubExp64) != SYMCRYPT_NO_ERROR )
+    {
+        SC_OSSL_LOG_ERROR("SymCryptLoadMsbFirstUint64 failed");
+        goto cleanup;
+    }
+    SymError = SymCryptRsakeyGenerate(keyCtx->key, &pubExp64, 1, 0);
     if( SymError != SYMCRYPT_NO_ERROR )
     {
-        SC_OSSL_LOG_SYMERROR_ERROR("SymCryptRsakeyAllocate failed", SymError);
+        SC_OSSL_LOG_SYMERROR_ERROR("SymCryptRsakeyGenerate failed", SymError);
         goto cleanup;
     }
 
@@ -790,13 +767,11 @@ SCOSSL_STATUS sc_ossl_rsa_keygen(_Out_ RSA* rsa, int bits, _In_ BIGNUM* e,
     // CNG format for reference:
     // https://docs.microsoft.com/en-us/windows/win32/api/bcrypt/ns-bcrypt-bcrypt_rsakey_blob
     //
-    cbPublicExp = SymCryptRsakeySizeofPublicExponent(keyCtx->key, 0);
     cbModulus = SymCryptRsakeySizeofModulus(keyCtx->key);
     cbPrime1 = SymCryptRsakeySizeofPrime(keyCtx->key, 0);
     cbPrime2 = SymCryptRsakeySizeofPrime(keyCtx->key, 1);
 
-    cbAllocSize =
-        cbPublicExp +   // PublicExponent[cbPublicExp] // Big-endian.
+    cbData =
         cbModulus +     // Modulus[cbModulus] // Big-endian.
         cbPrime1 +      // Prime1[cbPrime1] // Big-endian.
         cbPrime2 +      // Prime2[cbPrime2] // Big-endian.
@@ -805,17 +780,13 @@ SCOSSL_STATUS sc_ossl_rsa_keygen(_Out_ RSA* rsa, int bits, _In_ BIGNUM* e,
         cbPrime1 +      // Coefficient[cbPrime1] // Big-endian.
         cbModulus;      // PrivateExponent[cbModulus] // Big-endian.
 
-    keyCtx->cbData = cbAllocSize;
-    keyCtx->data = OPENSSL_zalloc(cbAllocSize);
-    if( keyCtx->data == NULL )
+    pbData = OPENSSL_zalloc(cbData);
+    if( pbData == NULL )
     {
         SC_OSSL_LOG_ERROR("OPENSSL_zalloc failed");
         goto cleanup;
     }
-    pbCurrent = keyCtx->data;
-
-    pbPublicExp = pbCurrent;
-    pbCurrent += cbPublicExp;
+    pbCurrent = pbData;
 
     pbModulus = pbCurrent;
     pbCurrent += cbModulus;
@@ -847,8 +818,8 @@ SCOSSL_STATUS sc_ossl_rsa_keygen(_Out_ RSA* rsa, int bits, _In_ BIGNUM* e,
                    keyCtx->key,
                    pbModulus,
                    cbModulus,
-                   &pubExp64,
-                   1,
+                   NULL,
+                   0,
                    ppbPrimes,
                    pcbPrimes,
                    nPrimes,
@@ -857,13 +828,6 @@ SCOSSL_STATUS sc_ossl_rsa_keygen(_Out_ RSA* rsa, int bits, _In_ BIGNUM* e,
     if( SymError != SYMCRYPT_NO_ERROR )
     {
         SC_OSSL_LOG_SYMERROR_ERROR("SymCryptRsakeyGetValue failed", SymError);
-        goto cleanup;
-    }
-
-    SymError = SymCryptStoreMsbFirstUint64(pubExp64, pbPublicExp, cbPublicExp);
-    if( SymError != SYMCRYPT_NO_ERROR )
-    {
-        SC_OSSL_LOG_SYMERROR_ERROR("SymCryptStoreMsbFirstUint64 failed", SymError);
         goto cleanup;
     }
 
@@ -886,7 +850,7 @@ SCOSSL_STATUS sc_ossl_rsa_keygen(_Out_ RSA* rsa, int bits, _In_ BIGNUM* e,
 
     // Set these values
     if( ((rsa_n = BN_new()) == NULL ) ||
-        ((rsa_e = BN_new()) == NULL) ||
+        ((rsa_e = BN_dup(e)) == NULL) ||
         ((rsa_p = BN_secure_new()) == NULL) ||
         ((rsa_q = BN_secure_new()) == NULL) ||
         ((rsa_dmp1 = BN_secure_new()) == NULL) ||
@@ -894,17 +858,21 @@ SCOSSL_STATUS sc_ossl_rsa_keygen(_Out_ RSA* rsa, int bits, _In_ BIGNUM* e,
         ((rsa_iqmp = BN_secure_new()) == NULL) ||
         ((rsa_d = BN_secure_new()) == NULL))
     {
+        SC_OSSL_LOG_ERROR("BN_new returned NULL.");
         goto cleanup;
     }
 
-    BN_bin2bn(pbPublicExp, cbPublicExp, rsa_e);
-    BN_bin2bn(pbModulus, cbModulus, rsa_n);
-    BN_bin2bn(ppbPrimes[0], cbPrime1, rsa_p);
-    BN_bin2bn(ppbPrimes[1], cbPrime2, rsa_q);
-    BN_bin2bn(ppbCrtExponents[0], cbPrime1, rsa_dmp1);
-    BN_bin2bn(ppbCrtExponents[1], cbPrime2, rsa_dmq1);
-    BN_bin2bn(pbCrtCoefficient, cbPrime1, rsa_iqmp);
-    BN_bin2bn(pbPrivateExponent, cbPrivateExponent, rsa_d);
+    if( (BN_bin2bn(pbModulus, cbModulus, rsa_n) == NULL) ||
+        (BN_bin2bn(ppbPrimes[0], cbPrime1, rsa_p) == NULL) ||
+        (BN_bin2bn(ppbPrimes[1], cbPrime2, rsa_q) == NULL) ||
+        (BN_bin2bn(ppbCrtExponents[0], cbPrime1, rsa_dmp1) == NULL) ||
+        (BN_bin2bn(ppbCrtExponents[1], cbPrime2, rsa_dmq1) == NULL) ||
+        (BN_bin2bn(pbCrtCoefficient, cbPrime1, rsa_iqmp) == NULL) ||
+        (BN_bin2bn(pbPrivateExponent, cbPrivateExponent, rsa_d) == NULL) )
+    {
+        SC_OSSL_LOG_ERROR("BN_bin2bn failed.");
+        goto cleanup;
+    }
 
     RSA_set0_key(rsa, rsa_n, rsa_e, rsa_d);
     RSA_set0_factors(rsa, rsa_p, rsa_q);
@@ -917,6 +885,19 @@ cleanup:
     if( ret != 1 )
     {
         sc_ossl_rsa_free_key_context(keyCtx);
+        BN_free(rsa_n);
+        BN_free(rsa_e);
+        BN_clear_free(rsa_p);
+        BN_clear_free(rsa_q);
+        BN_clear_free(rsa_dmp1);
+        BN_clear_free(rsa_dmq1);
+        BN_clear_free(rsa_iqmp);
+        BN_clear_free(rsa_d);
+    }
+
+    if( pbData )
+    {
+        OPENSSL_clear_free( pbData, cbData );
     }
 
     return ret;
@@ -926,37 +907,23 @@ SCOSSL_STATUS sc_ossl_initialize_rsa_key(_In_ RSA* rsa, _Out_ SC_OSSL_RSA_KEY_CO
 {
     int ret = 0;
     UINT64  pubExp64;
-    PBYTE   pbPublicExp = NULL;
-    size_t  cbPublicExp = 0;
     PBYTE   pbModulus = NULL;
-    size_t  cbModulus = 0;
+    SIZE_T  cbModulus = 0;
     PBYTE   ppbPrimes[2] = { 0 };
-    size_t  pcbPrimes[2] = { 0 };
-    size_t  cbPrime1 = 0;
-    size_t  cbPrime2 = 0;
-    PBYTE   ppbCrtExponents[2] = { 0 };
-    size_t  pcbCrtExponents[2] = { 0 };
-    PBYTE   pbCrtCoefficient = NULL;
-    size_t  cbCrtCoefficient = 0;
-    PBYTE   pbPrivateExponent = NULL;
-    size_t  cbPrivateExponent = 0;
-    size_t  nPrimes = 0;
+    SIZE_T  pcbPrimes[2] = { 0 };
+    SIZE_T  cbPrime1 = 0;
+    SIZE_T  cbPrime2 = 0;
+    SIZE_T  nPrimes = 0;
     SYMCRYPT_RSA_PARAMS SymcryptRsaParam;
-    int     allocSize = 0;
     SYMCRYPT_ERROR SymError = SYMCRYPT_NO_ERROR;
-    size_t  cbAllocSize = 0;
+    PBYTE   pbData = NULL;
+    SIZE_T  cbData = 0;
     PBYTE   pbCurrent = NULL;
     const BIGNUM *rsa_n = NULL;
     const BIGNUM *rsa_e = NULL;
     const BIGNUM *rsa_p = NULL;
     const BIGNUM *rsa_q = NULL;
-    const BIGNUM *rsa_d = NULL;
-    const BIGNUM *rsa_dmp1 = NULL;
-    const BIGNUM *rsa_dmq1 = NULL;
-    const BIGNUM *rsa_iqmp = NULL;
-
-    cbAllocSize =
-        cbPublicExp +   // PublicExponent[cbPublicExp] // Big-endian.
+    cbData =
         cbModulus +     // Modulus[cbModulus] // Big-endian.
         cbPrime1 +      // Prime1[cbPrime1] // Big-endian.
         cbPrime2 +      // Prime2[cbPrime2] // Big-endian.
@@ -972,73 +939,51 @@ SCOSSL_STATUS sc_ossl_initialize_rsa_key(_In_ RSA* rsa, _Out_ SC_OSSL_RSA_KEY_CO
         goto cleanup;
     }
 
-    RSA_get0_key(rsa, &rsa_n, &rsa_e, &rsa_d);
+    RSA_get0_key(rsa, &rsa_n, &rsa_e, NULL);
     RSA_get0_factors(rsa, &rsa_p, &rsa_q);
-    RSA_get0_crt_params(rsa, &rsa_dmp1, &rsa_dmq1, &rsa_iqmp);
 
     if( rsa_n == NULL || rsa_e == NULL )
     {
         SC_OSSL_LOG_ERROR("Not enough Parameters");
         goto cleanup;
     }
-    // PublicExponent
-    cbPublicExp = BN_num_bytes(rsa_e);
-    cbAllocSize += cbPublicExp;
     // Modulus
     cbModulus = BN_num_bytes(rsa_n);
-    cbAllocSize += cbModulus;
+    cbData += cbModulus;
     // Prime1 - May not be present
     if( rsa_p )
     {
         pcbPrimes[0] = BN_num_bytes(rsa_p);
-        cbAllocSize += pcbPrimes[0];
+        cbData += pcbPrimes[0];
         nPrimes++;
     }
     // Prime2 - May not be present
     if( rsa_q )
     {
         pcbPrimes[1] = BN_num_bytes(rsa_q);
-        cbAllocSize += pcbPrimes[1];
+        cbData += pcbPrimes[1];
         nPrimes++;
     }
-    // Exponent1 - May not be present
-    if( rsa_dmp1 )
-    {
-        pcbCrtExponents[0] = BN_num_bytes(rsa_dmp1);
-        cbAllocSize += pcbCrtExponents[0];
-    }
-    // Exponent2 - May not be present
-    if( rsa_dmq1 )
-    {
-        pcbCrtExponents[1] = BN_num_bytes(rsa_dmq1);
-        cbAllocSize += pcbCrtExponents[1];
-    }
-    // Coefficient - May not be present
-    if( rsa_iqmp )
-    {
-        cbCrtCoefficient = BN_num_bytes(rsa_iqmp);
-        cbAllocSize += cbCrtCoefficient;
-    }
-    // PrivateExponent - May not be present
-    if( rsa_d )
-    {
-        cbPrivateExponent = BN_num_bytes(rsa_d);
-        cbAllocSize += cbPrivateExponent;
-    }
 
-    keyCtx->cbData = cbAllocSize;
-    keyCtx->data = OPENSSL_zalloc(cbAllocSize);
-    if( keyCtx->data == NULL )
+    pbData = OPENSSL_zalloc(cbData);
+    if( pbData == NULL )
     {
         SC_OSSL_LOG_ERROR("OPENSSL_zalloc failed");
         goto cleanup;
     }
 
-    pbCurrent = keyCtx->data;
+    pbCurrent = pbData;
 
-    pbPublicExp = pbCurrent;
-    pbCurrent += cbPublicExp;
-    BN_bn2bin(rsa_e, pbPublicExp);
+    if( BN_bn2binpad(rsa_e, (PBYTE) &pubExp64, sizeof(pubExp64)) != sizeof(pubExp64) )
+    {
+        SC_OSSL_LOG_ERROR("BN_bn2binpad failed - Probably Public Exponent larger than maximum supported size (8 bytes)");
+        goto cleanup;
+    }
+    if( SymCryptLoadMsbFirstUint64((PBYTE) &pubExp64, sizeof(pubExp64), &pubExp64) != SYMCRYPT_NO_ERROR )
+    {
+        SC_OSSL_LOG_ERROR("SymCryptLoadMsbFirstUint64 failed");
+        goto cleanup;
+    }
 
     pbModulus = pbCurrent;
     pbCurrent += cbModulus;
@@ -1056,30 +1001,6 @@ SCOSSL_STATUS sc_ossl_initialize_rsa_key(_In_ RSA* rsa, _Out_ SC_OSSL_RSA_KEY_CO
         pbCurrent += pcbPrimes[1];
         BN_bn2bin(rsa_q, ppbPrimes[1]);
     }
-    if( rsa_dmp1 )
-    {
-        ppbCrtExponents[0] = pbCurrent;
-        pbCurrent += pcbCrtExponents[0];
-        BN_bn2bin(rsa_dmp1, ppbCrtExponents[0]);
-    }
-    if( rsa_dmq1 )
-    {
-        ppbCrtExponents[1] = pbCurrent;
-        pbCurrent += pcbCrtExponents[1];
-        BN_bn2bin(rsa_dmq1, ppbCrtExponents[1]);
-    }
-    if( rsa_iqmp )
-    {
-        pbCrtCoefficient = pbCurrent;
-        pbCurrent += cbCrtCoefficient;
-        BN_bn2bin(rsa_iqmp, pbCrtCoefficient);
-    }
-    if( rsa_d )
-    {
-        pbPrivateExponent = pbCurrent;
-        pbCurrent += cbPrivateExponent;
-        BN_bn2bin(rsa_d, pbPrivateExponent);
-    }
 
     if( nPrimes != 0 && nPrimes != 2 )
     {
@@ -1096,13 +1017,6 @@ SCOSSL_STATUS sc_ossl_initialize_rsa_key(_In_ RSA* rsa, _Out_ SC_OSSL_RSA_KEY_CO
     if( keyCtx->key == NULL )
     {
         SC_OSSL_LOG_ERROR("SymCryptRsakeyAllocate failed");
-        goto cleanup;
-    }
-
-    SymError = SymCryptLoadMsbFirstUint64(pbPublicExp, cbPublicExp, &pubExp64);
-    if( SymError != SYMCRYPT_NO_ERROR )
-    {
-        SC_OSSL_LOG_SYMERROR_ERROR("SymCryptLoadMsbFirstUint64 failed", SymError);
         goto cleanup;
     }
 
@@ -1133,7 +1047,12 @@ cleanup:
         SC_OSSL_LOG_ERROR("sc_ossl_initialize_rsa_key failed.");
         sc_ossl_rsa_free_key_context(keyCtx);
     }
-    
+
+    if( pbData )
+    {
+        OPENSSL_clear_free(pbData, cbData);
+    }
+
     return ret;
 }
 
@@ -1154,7 +1073,7 @@ SCOSSL_STATUS sc_ossl_rsa_mod_exp(_Out_ BIGNUM* r0, _In_ const BIGNUM* i, _In_ R
 typedef int (*PFN_RSA_meth_bn_mod_exp) (
         BIGNUM* r, const BIGNUM* a, const BIGNUM* p, const BIGNUM* m, BN_CTX* ctx, BN_MONT_CTX* m_ctx);
 
-SCOSSL_STATUS sc_ossl_rsa_bn_mod_exp(_Out_ BIGNUM* r, _In_ const BIGNUM* a, _In_ const BIGNUM* p, 
+SCOSSL_STATUS sc_ossl_rsa_bn_mod_exp(_Out_ BIGNUM* r, _In_ const BIGNUM* a, _In_ const BIGNUM* p,
         _In_ const BIGNUM* m, _In_ BN_CTX* ctx, _In_ BN_MONT_CTX* m_ctx)
 {
     const RSA_METHOD* ossl_rsa_meth = RSA_PKCS1_OpenSSL();
@@ -1176,9 +1095,10 @@ SCOSSL_STATUS sc_ossl_rsa_init(_Inout_ RSA *rsa)
         return 0;
     }
 
-    if( RSA_set_ex_data(rsa, rsa_sc_ossl_idx, keyCtx) == 0 )
+    if( RSA_set_ex_data(rsa, scossl_rsa_idx, keyCtx) == 0 )
     {
         SC_OSSL_LOG_ERROR("RSA_set_ex_data failed");
+        OPENSSL_free(keyCtx);
         return 0;
     }
 
@@ -1187,13 +1107,10 @@ SCOSSL_STATUS sc_ossl_rsa_init(_Inout_ RSA *rsa)
 
 void sc_ossl_rsa_free_key_context(_In_ SC_OSSL_RSA_KEY_CONTEXT *keyCtx)
 {
-    if( keyCtx->data )
-    {
-        OPENSSL_clear_free(keyCtx->data, keyCtx->cbData);
-    }
     if( keyCtx->key )
     {
         SymCryptRsakeyFree(keyCtx->key);
+        keyCtx->key = NULL;
     }
     keyCtx->initialized = 0;
     return;
@@ -1201,7 +1118,7 @@ void sc_ossl_rsa_free_key_context(_In_ SC_OSSL_RSA_KEY_CONTEXT *keyCtx)
 
 SCOSSL_STATUS sc_ossl_rsa_finish(_Inout_ RSA *rsa)
 {
-    SC_OSSL_RSA_KEY_CONTEXT *keyCtx = RSA_get_ex_data(rsa, rsa_sc_ossl_idx);
+    SC_OSSL_RSA_KEY_CONTEXT *keyCtx = RSA_get_ex_data(rsa, scossl_rsa_idx);
     if( keyCtx )
     {
         if( keyCtx->initialized == 1 )
@@ -1209,7 +1126,7 @@ SCOSSL_STATUS sc_ossl_rsa_finish(_Inout_ RSA *rsa)
             sc_ossl_rsa_free_key_context(keyCtx);
         }
         OPENSSL_free(keyCtx);
-        RSA_set_ex_data(rsa, rsa_sc_ossl_idx, NULL);
+        RSA_set_ex_data(rsa, scossl_rsa_idx, NULL);
     }
     return 1;
 }

--- a/SymCryptEngine/src/sc_ossl_rsa.h
+++ b/SymCryptEngine/src/sc_ossl_rsa.h
@@ -5,13 +5,12 @@
 #include "sc_ossl.h"
 #include "sc_ossl_helpers.h"
 #include <openssl/rsa.h>
-#include <symcrypt.h>
 
 #ifdef __cplusplus
 extern "C" {
 #endif
 
-extern int rsa_sc_ossl_idx;
+extern int scossl_rsa_idx;
 
 // Public Encryption
 // Encrypts flen bytes at from using public key rsa and stores ciphertext in to.
@@ -57,7 +56,7 @@ SCOSSL_STATUS sc_ossl_rsa_mod_exp(_Out_ BIGNUM* r0, _In_ const BIGNUM* i, _In_ R
 // r = a ^ p mod m
 // ctx is a temporary BIGNUM variable, while m_ctx is a Montgomery multiplication structure
 // Returns 1 on success, or 0 on error
-SCOSSL_STATUS sc_ossl_rsa_bn_mod_exp(_Out_ BIGNUM* r, _In_ const BIGNUM* a, _In_ const BIGNUM* p, 
+SCOSSL_STATUS sc_ossl_rsa_bn_mod_exp(_Out_ BIGNUM* r, _In_ const BIGNUM* a, _In_ const BIGNUM* p,
                                       _In_ const BIGNUM* m, _In_ BN_CTX* ctx, _In_ BN_MONT_CTX* m_ctx);
 
 // Signs the message digest m of size m_len using private key rsa using PKCS1-v1_5 and stores signature in sigret and
@@ -92,11 +91,6 @@ SCOSSL_STATUS sc_ossl_rsa_finish(_Inout_ RSA *rsa);
 
 typedef struct _SC_OSSL_RSA_KEY_CONTEXT {
     int initialized;
-    // Pointer to memory buffer holding private/public key data as it is transferred between OpenSSL
-    // and SymCrypt formats
-    // Must be cleared before freeing (using OPENSSL_clear_free)
-    PBYTE data;
-    SIZE_T cbData;
     PSYMCRYPT_RSAKEY key;
 } SC_OSSL_RSA_KEY_CONTEXT;
 

--- a/SymCryptEngine/src/sc_ossl_rsapss.c
+++ b/SymCryptEngine/src/sc_ossl_rsapss.c
@@ -49,7 +49,7 @@ SCOSSL_STATUS sc_ossl_rsapss_sign(_Inout_ EVP_PKEY_CTX *ctx, _Out_writes_opt_(*s
     EVP_PKEY* pkey = NULL;
     RSA* rsa = NULL;
     size_t cbResult = 0;
-    SYMCRYPT_ERROR SymError = SYMCRYPT_NO_ERROR;
+    SYMCRYPT_ERROR symError = SYMCRYPT_NO_ERROR;
     int ret = -1;
     SC_OSSL_RSA_KEY_CONTEXT *keyCtx = NULL;
     PCSYMCRYPT_HASH sc_ossl_mac_algo = NULL;
@@ -153,7 +153,7 @@ SCOSSL_STATUS sc_ossl_rsapss_sign(_Inout_ EVP_PKEY_CTX *ctx, _Out_writes_opt_(*s
         goto cleanup;
     }
 
-    SymError = SymCryptRsaPssSign(
+    symError = SymCryptRsaPssSign(
                 keyCtx->key,
                 tbs,
                 tbslen,
@@ -164,9 +164,9 @@ SCOSSL_STATUS sc_ossl_rsapss_sign(_Inout_ EVP_PKEY_CTX *ctx, _Out_writes_opt_(*s
                 sig,
                 siglen != NULL ? (*siglen) : 0,
                 &cbResult);
-    if( SymError != SYMCRYPT_NO_ERROR )
+    if( symError != SYMCRYPT_NO_ERROR )
     {
-        SC_OSSL_LOG_SYMERROR_ERROR("SymCryptRsaPssSign failed", SymError);
+        SC_OSSL_LOG_SYMERROR_ERROR("SymCryptRsaPssSign failed", symError);
         goto cleanup;
     }
 
@@ -183,7 +183,7 @@ SCOSSL_STATUS sc_ossl_rsapss_verify(_Inout_ EVP_PKEY_CTX *ctx, _In_reads_bytes_(
     EVP_PKEY* pkey = NULL;
     RSA* rsa = NULL;
     size_t ret = 0;
-    SYMCRYPT_ERROR SymError = SYMCRYPT_NO_ERROR;
+    SYMCRYPT_ERROR symError = SYMCRYPT_NO_ERROR;
     SC_OSSL_RSA_KEY_CONTEXT *keyCtx = NULL;
     PCSYMCRYPT_HASH sc_ossl_mac_algo = NULL;
     size_t expectedTbsLength = -1;
@@ -286,7 +286,7 @@ SCOSSL_STATUS sc_ossl_rsapss_verify(_Inout_ EVP_PKEY_CTX *ctx, _In_reads_bytes_(
         goto cleanup;
     }
 
-    SymError = SymCryptRsaPssVerify(
+    symError = SymCryptRsaPssVerify(
                 keyCtx->key,
                 tbs,
                 tbslen,
@@ -297,11 +297,11 @@ SCOSSL_STATUS sc_ossl_rsapss_verify(_Inout_ EVP_PKEY_CTX *ctx, _In_reads_bytes_(
                 cbSalt,
                 0);
 
-    if( SymError != SYMCRYPT_NO_ERROR )
+    if( symError != SYMCRYPT_NO_ERROR )
     {
-        if( SymError != SYMCRYPT_SIGNATURE_VERIFICATION_FAILURE )
+        if( symError != SYMCRYPT_SIGNATURE_VERIFICATION_FAILURE )
         {
-            SC_OSSL_LOG_SYMERROR_ERROR("SymCryptRsaPssverify returned unexpected error", SymError);
+            SC_OSSL_LOG_SYMERROR_ERROR("SymCryptRsaPssverify returned unexpected error", symError);
         }
         goto cleanup;
     }

--- a/SymCryptEngine/src/sc_ossl_tls1prf.c
+++ b/SymCryptEngine/src/sc_ossl_tls1prf.c
@@ -114,7 +114,7 @@ SCOSSL_STATUS sc_ossl_tls1prf_derive(_Inout_ EVP_PKEY_CTX *ctx, _Out_writes_opt_
 {
     SC_OSSL_TLS1_PRF_PKEY_CTX *key_context = (SC_OSSL_TLS1_PRF_PKEY_CTX *)EVP_PKEY_CTX_get_data(ctx);
     PCSYMCRYPT_MAC sc_ossl_mac_algo = NULL;
-    SYMCRYPT_ERROR SymError = SYMCRYPT_NO_ERROR;
+    SYMCRYPT_ERROR symError = SYMCRYPT_NO_ERROR;
 
     if (key_context->md == NULL) {
         SC_OSSL_LOG_ERROR("Missing Digest");
@@ -130,7 +130,7 @@ SCOSSL_STATUS sc_ossl_tls1prf_derive(_Inout_ EVP_PKEY_CTX *ctx, _Out_writes_opt_
     {
         // Special case to use TlsPrf1_1 to handle md5_sha1
         SC_OSSL_LOG_INFO("Using Mac algorithm MD5+SHA1 which is not FIPS compliant");
-        SymError = SymCryptTlsPrf1_1(
+        symError = SymCryptTlsPrf1_1(
             key_context->secret,
             key_context->secret_length,
             NULL,
@@ -148,7 +148,7 @@ SCOSSL_STATUS sc_ossl_tls1prf_derive(_Inout_ EVP_PKEY_CTX *ctx, _Out_writes_opt_
             return 0;
         }
 
-        SymError = SymCryptTlsPrf1_2(
+        symError = SymCryptTlsPrf1_2(
             sc_ossl_mac_algo,
             key_context->secret,
             key_context->secret_length,
@@ -160,9 +160,9 @@ SCOSSL_STATUS sc_ossl_tls1prf_derive(_Inout_ EVP_PKEY_CTX *ctx, _Out_writes_opt_
             *keylen);
     }
 
-    if (SymError != SYMCRYPT_NO_ERROR)
+    if (symError != SYMCRYPT_NO_ERROR)
     {
-        SC_OSSL_LOG_SYMERROR_ERROR("SymCryptTlsPrf1_2 failed", SymError);
+        SC_OSSL_LOG_SYMERROR_ERROR("SymCryptTlsPrf1_2 failed", symError);
         return 0;
     }
     return 1;

--- a/SymCryptEngine/src/sc_ossl_tls1prf.c
+++ b/SymCryptEngine/src/sc_ossl_tls1prf.c
@@ -2,9 +2,7 @@
 // Copyright (c) Microsoft Corporation. Licensed under the MIT license.
 //
 
-#include "sc_ossl.h"
-#include "sc_ossl_helpers.h"
-#include <symcrypt.h>
+#include "sc_ossl_tls1prf.h"
 #include <openssl/kdf.h>
 
 #ifdef __cplusplus
@@ -92,8 +90,7 @@ SCOSSL_STATUS sc_ossl_tls1prf_derive_init(_Inout_ EVP_PKEY_CTX *ctx)
     return 1;
 }
 
-PCSYMCRYPT_MAC
-GetSymCryptMacAlgorithm(
+static PCSYMCRYPT_MAC scossl_get_symcrypt_mac_algorithm(
     const EVP_MD *evp_md)
 {
     int type = EVP_MD_type(evp_md);
@@ -145,7 +142,7 @@ SCOSSL_STATUS sc_ossl_tls1prf_derive(_Inout_ EVP_PKEY_CTX *ctx, _Out_writes_opt_
     }
     else
     {
-        sc_ossl_mac_algo = GetSymCryptMacAlgorithm(key_context->md);
+        sc_ossl_mac_algo = scossl_get_symcrypt_mac_algorithm(key_context->md);
         if( sc_ossl_mac_algo == NULL )
         {
             return 0;

--- a/SymCryptEngine/src/sc_ossl_tls1prf.h
+++ b/SymCryptEngine/src/sc_ossl_tls1prf.h
@@ -3,6 +3,7 @@
 //
 
 #include "sc_ossl.h"
+#include "sc_ossl_helpers.h"
 
 #ifdef __cplusplus
 extern "C" {

--- a/SymCryptEngine/static/CMakeLists.txt
+++ b/SymCryptEngine/static/CMakeLists.txt
@@ -6,6 +6,7 @@ set(DEFAULT_BUILD_TYPE "Release")
 
 include(GNUInstallDirs)
 
+set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wall -Wextra -Wno-unused-parameter -Wno-unknown-pragmas")
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++1y -Wall -Wextra -Wno-unused-parameter")
 
 find_package(OpenSSL REQUIRED)


### PR DESCRIPTION
+ Enable compiler warnings for C source files
+ Fix various compiler warnings (unsigned/signed comparison, unused
  variables, etc.)
+ Remove redundant information from SCOSSL data structures
+ Remove redundant includes
+ Initialize long-lived static variables once at Engine load time,
  rather than on demand to avoid race conditions when algorithms are
  called concurrently without needing to introduce locking.
+ Check various returns for OpenSSL functions (e.g. BN_bin2bn et. al)
  and gracefully error rather than potentially failing in unexpected
  ways in low memory conditions
+ Fix memory leaks in new FFC DH implementation
+ Ensure all externally visible symbols have a scossl or sc_ossl prefix
  (should settle on a single prefix in a followup PR)
+ Fallback to OpenSSL for ECDSA signatures with a specific kinv or r
+ Use stderr rather than stdout for error messages in debug build
+ Correctly set verify_init function in PKEY rsa method!
+ Only log error messages on signature verification error, rather than
  expected signature verification failure
+ Remove a lot of useless work in RSA key setup
+ Error in RSA key import/generation if the requested public exponent is
  larger than 2^64-1