### PR TITLE
CMake compilation fixes for embedded platforms

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -26,5 +26,3 @@ endif()
 add_subdirectory (SymCryptEngine/static)
 add_subdirectory (SymCryptEngine/dynamic)
 add_subdirectory (SslPlay)
-
-

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -26,3 +26,5 @@ endif()
 add_subdirectory (SymCryptEngine/static)
 add_subdirectory (SymCryptEngine/dynamic)
 add_subdirectory (SslPlay)
+
+

--- a/SymCryptEngine/dynamic/CMakeLists.txt
+++ b/SymCryptEngine/dynamic/CMakeLists.txt
@@ -41,7 +41,23 @@ target_link_directories(scossl_dynamic PUBLIC ${CMAKE_SOURCE_DIR})
 target_link_libraries(scossl_dynamic PUBLIC symcrypt)
 target_link_libraries(scossl_dynamic PUBLIC ${OPENSSL_CRYPTO_LIBRARY})
 
-install(TARGETS scossl_dynamic
-    LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+# Get the OpenSSL engines directory from the host
+execute_process(
+    COMMAND openssl version -e
+    OUTPUT_VARIABLE OPENSSL_ENGINESDIR
+)
+
+# Parse the output of the above command to get just the directory
+# ENGINESDIR: /usr/lib/engines -> /usr/lib/engines
+string(
+    REGEX REPLACE "ENGINESDIR: \"(.*)\""
+    "\\1"
+    OPENSSL_ENGINESDIR # Output
+    ${OPENSSL_ENGINESDIR} # Input
+)
+
+install(
+    TARGETS scossl_dynamic
+    LIBRARY DESTINATION ${OPENSSL_ENGINESDIR}
     PUBLIC_HEADER DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
 

--- a/SymCryptEngine/dynamic/CMakeLists.txt
+++ b/SymCryptEngine/dynamic/CMakeLists.txt
@@ -41,23 +41,11 @@ target_link_directories(scossl_dynamic PUBLIC ${CMAKE_SOURCE_DIR})
 target_link_libraries(scossl_dynamic PUBLIC symcrypt)
 target_link_libraries(scossl_dynamic PUBLIC ${OPENSSL_CRYPTO_LIBRARY})
 
-# Get the OpenSSL engines directory from the host
-execute_process(
-    COMMAND openssl version -e
-    OUTPUT_VARIABLE OPENSSL_ENGINESDIR
-)
-
-# Parse the output of the above command to get just the directory
-# ENGINESDIR: /usr/lib/engines -> /usr/lib/engines
-string(
-    REGEX REPLACE "ENGINESDIR: \"(.*)\""
-    "\\1"
-    OPENSSL_ENGINESDIR # Output
-    ${OPENSSL_ENGINESDIR} # Input
-)
-
+# Install the engine to the OpenSSL engines directory
+# NB: this won't work if the distro has a custom engines directory that doesn't match
+# the OpenSSL default.
 install(
     TARGETS scossl_dynamic
-    LIBRARY DESTINATION ${OPENSSL_ENGINESDIR}
+    LIBRARY DESTINATION "${CMAKE_INSTALL_LIBDIR}/engines-1.1"
     PUBLIC_HEADER DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
 

--- a/cmake-toolchain/LinuxUserMode-ARM64.cmake
+++ b/cmake-toolchain/LinuxUserMode-ARM64.cmake
@@ -5,18 +5,19 @@
 set(CMAKE_SYSTEM_NAME Linux)
 set(CMAKE_SYSTEM_PROCESSOR ARM64)
 
-set(TARGET_TRIPLE aarch64-linux-gnu)
-
-# Currently only use clang as it makes cross-compilation easier
-set(CMAKE_ASM_COMPILER_TARGET ${TARGET_TRIPLE})
-set(CMAKE_C_COMPILER clang)
-set(CMAKE_C_COMPILER_TARGET ${TARGET_TRIPLE})
-set(CMAKE_CXX_COMPILER clang++)
-set(CMAKE_CXX_COMPILER_TARGET ${TARGET_TRIPLE})
-
 # Point clang sysroot to cross compilation toolchain when cross compiling
 if(NOT CMAKE_HOST_SYSTEM_PROCESSOR MATCHES ARM64|aarch64)
     message(STATUS "Using cross compilation toolchain")
+
+    set(TARGET_TRIPLE aarch64-linux-gnu)
+
+    # Currently only use clang as it makes cross-compilation easier
+    set(CMAKE_ASM_COMPILER_TARGET ${TARGET_TRIPLE})
+    set(CMAKE_C_COMPILER clang)
+    set(CMAKE_C_COMPILER_TARGET ${TARGET_TRIPLE})
+    set(CMAKE_CXX_COMPILER clang++)
+    set(CMAKE_CXX_COMPILER_TARGET ${TARGET_TRIPLE})
+
     # C/C++ toolchain (installed on Ubuntu using apt-get gcc-aarch64-linux-gnu g++-aarch64-linux-gnu)
     set(CMAKE_SYSROOT_COMPILE /usr/${TARGET_TRIPLE})
 
@@ -27,14 +28,12 @@ if(NOT CMAKE_HOST_SYSTEM_PROCESSOR MATCHES ARM64|aarch64)
     # Seems like there should be a better way to install cross-compilation tools, or specify search paths to clang
     find_path(CXX_CROSS_INCLUDE_DIR NAMES ${TARGET_TRIPLE} PATHS /usr/${TARGET_TRIPLE}/include/c++/ PATH_SUFFIXES 15 14 13 12 11 10 9 8 7 6 5 NO_DEFAULT_PATH)
     add_compile_options(-I${CXX_CROSS_INCLUDE_DIR}/${TARGET_TRIPLE})
+    
+    # Enable a baseline of features for the compiler to support everywhere
+    # Assumes that the compiler will not emit crypto instructions as a result of normal C code
+    set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -march=armv8a+simd+crypto")
 endif()
 
 # Define _ARM64_ to set up the correct SymCrypt macros, e.g. SYMCRYPT_CPU_ARM64
 add_compile_options(-D_ARM64_)
 add_compile_options(-O3)
-
-# Enable a baseline of features for the compiler to support everywhere
-# Assumes that the compiler will not emit crypto instructions as a result of normal C code
-set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -march=armv8a+simd+crypto")
-
-# set(CMAKE_ASM_FLAGS "-x assembler-with-cpp")

--- a/cmake-toolchain/LinuxUserMode-ARM64.cmake
+++ b/cmake-toolchain/LinuxUserMode-ARM64.cmake
@@ -6,7 +6,7 @@ set(CMAKE_SYSTEM_NAME Linux)
 set(CMAKE_SYSTEM_PROCESSOR ARM64)
 
 # Point clang sysroot to cross compilation toolchain when cross compiling
-if(NOT CMAKE_HOST_SYSTEM_PROCESSOR MATCHES ARM64|aarch64)
+if(NOT CMAKE_HOST_SYSTEM_PROCESSOR MATCHES ARM64|aarch64 AND NOT SCOSSL_USE_DEFAULT_COMPILER)
     message(STATUS "Using cross compilation toolchain")
 
     set(TARGET_TRIPLE aarch64-linux-gnu)

--- a/cmake-toolchain/LinuxUserMode-ARM64.cmake
+++ b/cmake-toolchain/LinuxUserMode-ARM64.cmake
@@ -28,10 +28,6 @@ if(NOT CMAKE_HOST_SYSTEM_PROCESSOR MATCHES ARM64|aarch64 AND NOT SCOSSL_USE_DEFA
     # Seems like there should be a better way to install cross-compilation tools, or specify search paths to clang
     find_path(CXX_CROSS_INCLUDE_DIR NAMES ${TARGET_TRIPLE} PATHS /usr/${TARGET_TRIPLE}/include/c++/ PATH_SUFFIXES 15 14 13 12 11 10 9 8 7 6 5 NO_DEFAULT_PATH)
     add_compile_options(-I${CXX_CROSS_INCLUDE_DIR}/${TARGET_TRIPLE})
-    
-    # Enable a baseline of features for the compiler to support everywhere
-    # Assumes that the compiler will not emit crypto instructions as a result of normal C code
-    set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -march=armv8a+simd+crypto")
 endif()
 
 # Define _ARM64_ to set up the correct SymCrypt macros, e.g. SYMCRYPT_CPU_ARM64


### PR DESCRIPTION
- Only set cross-compilation options when cross-compiling
- Install engine to OpenSSL ENGINESDIR