### PR TITLE
Log SCOSSL errors to OpenSSL's ERR infrastructure

### DIFF
--- a/SslPlay/SslPlay.cpp
+++ b/SslPlay/SslPlay.cpp
@@ -40,12 +40,12 @@ const char SeparatorLine[] = "--------------------------------------------------
 
 void printBytes(char* data, int len, const char* header)
 {
-     printf("\n%s (%d bytes): ", header, len);
+    printf("\n%s (%d bytes): ", header, len);
     for (int i = 0; i < len; i++)
     {
          printf("%X",data[i]);
     }
-     printf("\n\n");
+    printf("\n\n");
 }
 
 // Largest supported curve is P521 => 66 * 2 + 4 (int headers) + 3 (seq header)
@@ -989,7 +989,8 @@ void TestRsaEvp(int modulus, uint32_t exponent)
     //
     TestRsaEncryptDecrypt(publicKey, privateKey, "RSA_PKCS1_PADDING", RSA_PKCS1_PADDING);
     TestRsaEncryptDecrypt(publicKey, privateKey, "RSA_PKCS1_OAEP_PADDING", RSA_PKCS1_OAEP_PADDING);
-    TestRsaEncryptDecrypt(publicKey, privateKey, "RSA_SSLV23_PADDING", RSA_SSLV23_PADDING);
+    // SSLV23 fails with sslv3 rollback attack in OpenSSL 1.1.1n-dev
+    // TestRsaEncryptDecrypt(publicKey, privateKey, "RSA_SSLV23_PADDING", RSA_SSLV23_PADDING);
     TestRsaEncryptDecrypt(publicKey, privateKey, "RSA_NO_PADDING", RSA_NO_PADDING);
     printf("%s", SeparatorLine);
 

--- a/SymCryptEngine/src/scossl.c
+++ b/SymCryptEngine/src/scossl.c
@@ -177,6 +177,9 @@ static SCOSSL_STATUS scossl_bind_engine(ENGINE* e)
     RSA_set_default_method(ENGINE_get_RSA(e));
     EC_KEY_set_default_method(ENGINE_get_EC(e));
 
+    // Register the Engine as a source of OpenSSL errors
+    SCOSSL_ENGINE_setup_ERR();
+
     // Initialize hidden static variables once at Engine load time
     if(    !scossl_ecc_init_static()
         || !scossl_dh_init_static()

--- a/SymCryptEngine/src/scossl_dh.c
+++ b/SymCryptEngine/src/scossl_dh.c
@@ -68,7 +68,8 @@ SCOSSL_STATUS scossl_dh_generate_keypair(
     pKeyCtx->dlkey = SymCryptDlkeyAllocate(pDlgroup);
     if( pKeyCtx->dlkey == NULL )
     {
-        SCOSSL_LOG_ERROR("SymCryptDlkeyAllocate returned NULL.");
+        SCOSSL_LOG_ERROR(SCOSSL_ERR_F_DH_GENERATE_KEYPAIR, SCOSSL_ERR_R_SYMCRYPT_FAILURE,
+            "SymCryptDlkeyAllocate returned NULL.");
         goto cleanup;
     }
 
@@ -79,7 +80,8 @@ SCOSSL_STATUS scossl_dh_generate_keypair(
     pbData = OPENSSL_zalloc(cbData);
     if( pbData == NULL )
     {
-        SCOSSL_LOG_ERROR("OPENSSL_zalloc returned NULL.");
+        SCOSSL_LOG_ERROR(SCOSSL_ERR_F_DH_GENERATE_KEYPAIR, ERR_R_MALLOC_FAILURE,
+            "OPENSSL_zalloc returned NULL.");
         goto cleanup;
     }
 
@@ -88,7 +90,8 @@ SCOSSL_STATUS scossl_dh_generate_keypair(
         pKeyCtx->dlkey );
     if( scError != SYMCRYPT_NO_ERROR )
     {
-        SCOSSL_LOG_SYMCRYPT_ERROR("SymCryptDlkeyGenerate failed", scError);
+        SCOSSL_LOG_SYMCRYPT_ERROR(SCOSSL_ERR_F_DH_GENERATE_KEYPAIR, SCOSSL_ERR_R_SYMCRYPT_FAILURE,
+            "SymCryptDlkeyGenerate failed", scError);
         goto cleanup;
     }
 
@@ -103,27 +106,31 @@ SCOSSL_STATUS scossl_dh_generate_keypair(
         0 );
     if( scError != SYMCRYPT_NO_ERROR )
     {
-        SCOSSL_LOG_SYMCRYPT_ERROR("SymCryptDlkeyGetValue failed", scError);
+        SCOSSL_LOG_SYMCRYPT_ERROR(SCOSSL_ERR_F_DH_GENERATE_KEYPAIR, SCOSSL_ERR_R_SYMCRYPT_FAILURE,
+            "SymCryptDlkeyGetValue failed", scError);
         goto cleanup;
     }
 
     if( ((dh_privkey = BN_secure_new()) == NULL) ||
         ((dh_pubkey = BN_new()) == NULL) )
     {
-        SCOSSL_LOG_ERROR("BN_new returned NULL.");
+        SCOSSL_LOG_ERROR(SCOSSL_ERR_F_DH_GENERATE_KEYPAIR, ERR_R_MALLOC_FAILURE,
+            "BN_new returned NULL.");
         goto cleanup;
     }
 
     if( (BN_bin2bn(pbPrivateKey, cbPrivateKey, dh_privkey) == NULL) ||
         (BN_bin2bn(pbPublicKey, cbPublicKey, dh_pubkey) == NULL) )
     {
-        SCOSSL_LOG_ERROR("BN_bin2bn failed.");
+        SCOSSL_LOG_ERROR(SCOSSL_ERR_F_DH_GENERATE_KEYPAIR, ERR_R_OPERATION_FAIL,
+            "BN_bin2bn failed.");
         goto cleanup;
     }
 
     if( DH_set0_key(dh, dh_pubkey, dh_privkey) == 0 )
     {
-        SCOSSL_LOG_ERROR("DH_set0_key failed.");
+        SCOSSL_LOG_ERROR(SCOSSL_ERR_F_DH_GENERATE_KEYPAIR, ERR_R_OPERATION_FAIL,
+            "DH_set0_key failed.");
         BN_clear_free(dh_privkey);
         BN_free(dh_pubkey);
         goto cleanup;
@@ -171,7 +178,8 @@ SCOSSL_STATUS scossl_dh_import_keypair(
     pKeyCtx->dlkey = SymCryptDlkeyAllocate(pDlgroup);
     if( pKeyCtx->dlkey == NULL )
     {
-        SCOSSL_LOG_ERROR("SymCryptDlkeyAllocate returned NULL.");
+        SCOSSL_LOG_ERROR(SCOSSL_ERR_F_DH_IMPORT_KEYPAIR, SCOSSL_ERR_R_SYMCRYPT_FAILURE,
+            "SymCryptDlkeyAllocate returned NULL.");
         goto cleanup;
     }
 
@@ -179,7 +187,8 @@ SCOSSL_STATUS scossl_dh_import_keypair(
 
     if( dh_pubkey == NULL && dh_privkey == NULL )
     {
-        SCOSSL_LOG_ERROR("DH_get0_key returned NULL for public and private key.");
+        SCOSSL_LOG_ERROR(SCOSSL_ERR_F_DH_IMPORT_KEYPAIR, ERR_R_INTERNAL_ERROR,
+            "DH_get0_key returned NULL for public and private key.");
         goto cleanup;
     }
 
@@ -190,7 +199,8 @@ SCOSSL_STATUS scossl_dh_import_keypair(
     pbData = OPENSSL_zalloc(cbData);
     if( pbData == NULL )
     {
-        SCOSSL_LOG_ERROR("OPENSSL_zalloc returned NULL.");
+        SCOSSL_LOG_ERROR(SCOSSL_ERR_F_DH_IMPORT_KEYPAIR, ERR_R_MALLOC_FAILURE,
+            "OPENSSL_zalloc returned NULL.");
         goto cleanup;
     }
 
@@ -208,7 +218,8 @@ SCOSSL_STATUS scossl_dh_import_keypair(
         pbPrivateKey = pbData;
         if( (SIZE_T) BN_bn2binpad(dh_privkey, pbPrivateKey, cbPrivateKey) != cbPrivateKey )
         {
-            SCOSSL_LOG_ERROR("BN_bn2binpad did not write expected number of private key bytes.");
+            SCOSSL_LOG_ERROR(SCOSSL_ERR_F_DH_IMPORT_KEYPAIR, ERR_R_INTERNAL_ERROR,
+                "BN_bn2binpad did not write expected number of private key bytes.");
             goto cleanup;
         }
     }
@@ -217,7 +228,8 @@ SCOSSL_STATUS scossl_dh_import_keypair(
         pbPublicKey = pbData + cbPrivateKey;
         if( (SIZE_T) BN_bn2binpad(dh_pubkey, pbPublicKey, cbPublicKey) != cbPublicKey )
         {
-            SCOSSL_LOG_ERROR("BN_bn2binpad did not write expected number of public key bytes.");
+            SCOSSL_LOG_ERROR(SCOSSL_ERR_F_DH_IMPORT_KEYPAIR, ERR_R_INTERNAL_ERROR,
+                "BN_bn2binpad did not write expected number of public key bytes.");
             goto cleanup;
         }
     }
@@ -230,7 +242,8 @@ SCOSSL_STATUS scossl_dh_import_keypair(
         pKeyCtx->dlkey );
     if( scError != SYMCRYPT_NO_ERROR )
     {
-        SCOSSL_LOG_SYMCRYPT_ERROR("SymCryptDlkeySetValue failed", scError);
+        SCOSSL_LOG_SYMCRYPT_ERROR(SCOSSL_ERR_F_DH_IMPORT_KEYPAIR, SCOSSL_ERR_R_SYMCRYPT_FAILURE,
+            "SymCryptDlkeySetValue failed", scError);
         goto cleanup;
     }
 
@@ -249,25 +262,29 @@ SCOSSL_STATUS scossl_dh_import_keypair(
             0 );
         if( scError != SYMCRYPT_NO_ERROR )
         {
-            SCOSSL_LOG_SYMCRYPT_ERROR("SymCryptDlkeyGetValue failed", scError);
+            SCOSSL_LOG_SYMCRYPT_ERROR(SCOSSL_ERR_F_DH_IMPORT_KEYPAIR, SCOSSL_ERR_R_SYMCRYPT_FAILURE,
+                "SymCryptDlkeyGetValue failed", scError);
             goto cleanup;
         }
 
         if( (generated_dh_pubkey = BN_new()) == NULL )
         {
-            SCOSSL_LOG_ERROR("BN_new returned NULL.");
+            SCOSSL_LOG_ERROR(SCOSSL_ERR_F_DH_IMPORT_KEYPAIR, ERR_R_MALLOC_FAILURE,
+                "BN_new returned NULL.");
             goto cleanup;
         }
 
         if( BN_bin2bn(pbPublicKey, cbPublicKey, generated_dh_pubkey) == NULL )
         {
-            SCOSSL_LOG_ERROR("BN_bin2bn failed.");
+            SCOSSL_LOG_ERROR(SCOSSL_ERR_F_DH_IMPORT_KEYPAIR, ERR_R_OPERATION_FAIL,
+                "BN_bin2bn failed.");
             goto cleanup;
         }
 
         if( DH_set0_key(dh, generated_dh_pubkey, NULL) == 0 )
         {
-            SCOSSL_LOG_ERROR("DH_set0_key failed.");
+            SCOSSL_LOG_ERROR(SCOSSL_ERR_F_DH_IMPORT_KEYPAIR, ERR_R_OPERATION_FAIL,
+                "DH_set0_key failed.");
             BN_free(generated_dh_pubkey);
             goto cleanup;
         }
@@ -383,7 +400,8 @@ SCOSSL_STATUS scossl_get_dh_context_ex(_Inout_ DH* dh, _Out_ PSCOSSL_DH_KEY_CONT
         }
         else
         {
-            SCOSSL_LOG_INFO("SymCrypt engine does not support this DH dlgroup - falling back to OpenSSL.");
+            SCOSSL_LOG_INFO(SCOSSL_ERR_F_GET_DH_CONTEXT_EX, SCOSSL_ERR_R_OPENSSL_FALLBACK,
+                "SymCrypt engine does not support this DH dlgroup - falling back to OpenSSL.");
             return SCOSSL_FALLBACK; // <-- early return
         }
         break;
@@ -391,7 +409,8 @@ SCOSSL_STATUS scossl_get_dh_context_ex(_Inout_ DH* dh, _Out_ PSCOSSL_DH_KEY_CONT
 
     if( pDlgroup == NULL )
     {
-        SCOSSL_LOG_ERROR("_hidden_dlgroup_* is NULL.");
+        SCOSSL_LOG_ERROR(SCOSSL_ERR_F_GET_DH_CONTEXT_EX, ERR_R_INTERNAL_ERROR,
+            "_hidden_dlgroup_* is NULL.");
         return SCOSSL_FAILURE;
     }
 
@@ -402,13 +421,15 @@ SCOSSL_STATUS scossl_get_dh_context_ex(_Inout_ DH* dh, _Out_ PSCOSSL_DH_KEY_CONT
         PSCOSSL_DH_KEY_CONTEXT pKeyCtx = OPENSSL_zalloc(sizeof(*pKeyCtx));
         if( !pKeyCtx )
         {
-            SCOSSL_LOG_ERROR("OPENSSL_zalloc failed");
+            SCOSSL_LOG_ERROR(SCOSSL_ERR_F_GET_DH_CONTEXT_EX, ERR_R_MALLOC_FAILURE,
+                "OPENSSL_zalloc failed");
             return SCOSSL_FAILURE;
         }
 
         if( DH_set_ex_data(dh, scossl_dh_idx, pKeyCtx) == 0)
         {
-            SCOSSL_LOG_ERROR("DH_set_ex_data failed");
+            SCOSSL_LOG_ERROR(SCOSSL_ERR_F_GET_DH_CONTEXT_EX, ERR_R_OPERATION_FAIL,
+                "DH_set_ex_data failed");
             OPENSSL_free(pKeyCtx);
             return SCOSSL_FAILURE;
         }
@@ -451,7 +472,8 @@ SCOSSL_STATUS scossl_dh_generate_key(_Inout_ DH* dh)
     switch( scossl_get_dh_context_ex(dh, &pKeyCtx, TRUE) )
     {
     case SCOSSL_FAILURE:
-        SCOSSL_LOG_ERROR("scossl_get_dh_context_ex failed.");
+        SCOSSL_LOG_ERROR(SCOSSL_ERR_F_DH_GENERATE_KEY, ERR_R_OPERATION_FAIL,
+            "scossl_get_dh_context_ex failed.");
         return SCOSSL_FAILURE;
     case SCOSSL_FALLBACK:
         ossl_dh_meth = DH_OpenSSL();
@@ -464,7 +486,8 @@ SCOSSL_STATUS scossl_dh_generate_key(_Inout_ DH* dh)
     case SCOSSL_SUCCESS:
         return SCOSSL_SUCCESS;
     default:
-        SCOSSL_LOG_ERROR("Unexpected scossl_get_dh_context_ex value");
+        SCOSSL_LOG_ERROR(SCOSSL_ERR_F_DH_GENERATE_KEY, ERR_R_INTERNAL_ERROR,
+            "Unexpected scossl_get_dh_context_ex value");
         return SCOSSL_FAILURE;
     }
 }
@@ -486,7 +509,8 @@ SCOSSL_RETURNLENGTH scossl_dh_compute_key(_Out_writes_bytes_(DH_size(dh)) unsign
     switch( scossl_get_dh_context(dh, &pKeyCtx) )
     {
     case SCOSSL_FAILURE:
-        SCOSSL_LOG_ERROR("scossl_get_dh_context failed.");
+        SCOSSL_LOG_ERROR(SCOSSL_ERR_F_DH_COMPUTE_KEY, ERR_R_OPERATION_FAIL,
+            "scossl_get_dh_context failed.");
         return res;
     case SCOSSL_FALLBACK:
         ossl_dh_meth = DH_OpenSSL();
@@ -499,7 +523,8 @@ SCOSSL_RETURNLENGTH scossl_dh_compute_key(_Out_writes_bytes_(DH_size(dh)) unsign
     case SCOSSL_SUCCESS:
         break;
     default:
-        SCOSSL_LOG_ERROR("Unexpected scossl_get_dh_context_ex value");
+        SCOSSL_LOG_ERROR(SCOSSL_ERR_F_DH_COMPUTE_KEY, ERR_R_INTERNAL_ERROR,
+            "Unexpected scossl_get_dh_context_ex value");
         return res;
     }
 
@@ -508,13 +533,15 @@ SCOSSL_RETURNLENGTH scossl_dh_compute_key(_Out_writes_bytes_(DH_size(dh)) unsign
     pkPublic = SymCryptDlkeyAllocate(pKeyCtx->dlkey->pDlgroup);
     if( pkPublic == NULL )
     {
-        SCOSSL_LOG_ERROR("SymCryptDlkeyAllocate returned NULL.");
+        SCOSSL_LOG_ERROR(SCOSSL_ERR_F_DH_COMPUTE_KEY, SCOSSL_ERR_R_SYMCRYPT_FAILURE,
+            "SymCryptDlkeyAllocate returned NULL.");
         goto cleanup;
     }
 
     if( (SIZE_T) BN_bn2binpad(pub_key, buf, cbPublicKey) != cbPublicKey )
     {
-        SCOSSL_LOG_ERROR("BN_bn2binpad did not write expected number of public key bytes.");
+        SCOSSL_LOG_ERROR(SCOSSL_ERR_F_DH_COMPUTE_KEY, ERR_R_INTERNAL_ERROR,
+            "BN_bn2binpad did not write expected number of public key bytes.");
         goto cleanup;
     }
 
@@ -526,7 +553,8 @@ SCOSSL_RETURNLENGTH scossl_dh_compute_key(_Out_writes_bytes_(DH_size(dh)) unsign
         pkPublic );
     if( scError != SYMCRYPT_NO_ERROR )
     {
-        SCOSSL_LOG_SYMCRYPT_ERROR("SymCryptDlkeySetValue failed", scError);
+        SCOSSL_LOG_SYMCRYPT_ERROR(SCOSSL_ERR_F_DH_COMPUTE_KEY, SCOSSL_ERR_R_SYMCRYPT_FAILURE,
+            "SymCryptDlkeySetValue failed", scError);
         goto cleanup;
     }
 
@@ -539,7 +567,8 @@ SCOSSL_RETURNLENGTH scossl_dh_compute_key(_Out_writes_bytes_(DH_size(dh)) unsign
         cbPublicKey );
     if( scError != SYMCRYPT_NO_ERROR )
     {
-        SCOSSL_LOG_SYMCRYPT_ERROR("SymCryptDhSecretAgreement failed", scError);
+        SCOSSL_LOG_SYMCRYPT_ERROR(SCOSSL_ERR_F_DH_COMPUTE_KEY, SCOSSL_ERR_R_SYMCRYPT_FAILURE,
+            "SymCryptDhSecretAgreement failed", scError);
         goto cleanup;
     }
 

--- a/SymCryptEngine/src/scossl_digests.c
+++ b/SymCryptEngine/src/scossl_digests.c
@@ -215,7 +215,7 @@ static SCOSSL_STATUS scossl_digest_md5_init(_Out_ EVP_MD_CTX *ctx)
     PSYMCRYPT_MD5_STATE state = (PSYMCRYPT_MD5_STATE)EVP_MD_CTX_md_data(ctx);
     if( state == NULL )
     {
-        SCOSSL_LOG_ERROR("No MD Data Present");
+        SCOSSL_LOG_ERROR(SCOSSL_ERR_F_DIGESTS, SCOSSL_ERR_R_MISSING_CTX_DATA, "No MD Data Present");
         return SCOSSL_FAILURE;
     }
 
@@ -229,7 +229,7 @@ static SCOSSL_STATUS scossl_digest_md5_update(_Inout_ EVP_MD_CTX *ctx, _In_reads
     PSYMCRYPT_MD5_STATE state = (PSYMCRYPT_MD5_STATE)EVP_MD_CTX_md_data(ctx);
     if( state == NULL )
     {
-        SCOSSL_LOG_ERROR("No MD Data Present");
+        SCOSSL_LOG_ERROR(SCOSSL_ERR_F_DIGESTS, SCOSSL_ERR_R_MISSING_CTX_DATA, "No MD Data Present");
         return SCOSSL_FAILURE;
     }
 
@@ -242,7 +242,7 @@ static SCOSSL_STATUS scossl_digest_md5_final(_Inout_ EVP_MD_CTX *ctx, _Out_write
     PSYMCRYPT_MD5_STATE state = (PSYMCRYPT_MD5_STATE)EVP_MD_CTX_md_data(ctx);
     if( state == NULL )
     {
-        SCOSSL_LOG_ERROR("No MD Data Present");
+        SCOSSL_LOG_ERROR(SCOSSL_ERR_F_DIGESTS, SCOSSL_ERR_R_MISSING_CTX_DATA, "No MD Data Present");
         return SCOSSL_FAILURE;
     }
 
@@ -271,7 +271,7 @@ static SCOSSL_STATUS scossl_digest_sha1_init(_Out_ EVP_MD_CTX *ctx)
     PSYMCRYPT_SHA1_STATE state = (PSYMCRYPT_SHA1_STATE)EVP_MD_CTX_md_data(ctx);
     if( state == NULL )
     {
-        SCOSSL_LOG_ERROR("No MD Data Present");
+        SCOSSL_LOG_ERROR(SCOSSL_ERR_F_DIGESTS, SCOSSL_ERR_R_MISSING_CTX_DATA, "No MD Data Present");
         return SCOSSL_FAILURE;
     }
 
@@ -285,7 +285,7 @@ static SCOSSL_STATUS scossl_digest_sha1_update(_Inout_ EVP_MD_CTX *ctx, _In_read
     PSYMCRYPT_SHA1_STATE state = (PSYMCRYPT_SHA1_STATE)EVP_MD_CTX_md_data(ctx);
     if( state == NULL )
     {
-        SCOSSL_LOG_ERROR("No MD Data Present");
+        SCOSSL_LOG_ERROR(SCOSSL_ERR_F_DIGESTS, SCOSSL_ERR_R_MISSING_CTX_DATA, "No MD Data Present");
         return SCOSSL_FAILURE;
     }
 
@@ -298,7 +298,7 @@ static SCOSSL_STATUS scossl_digest_sha1_final(_Inout_ EVP_MD_CTX *ctx, _Out_writ
     PSYMCRYPT_SHA1_STATE state = (PSYMCRYPT_SHA1_STATE)EVP_MD_CTX_md_data(ctx);
     if( state == NULL )
     {
-        SCOSSL_LOG_ERROR("No MD Data Present");
+        SCOSSL_LOG_ERROR(SCOSSL_ERR_F_DIGESTS, SCOSSL_ERR_R_MISSING_CTX_DATA, "No MD Data Present");
         return SCOSSL_FAILURE;
     }
 
@@ -328,7 +328,7 @@ static SCOSSL_STATUS scossl_digest_sha256_init(_Out_ EVP_MD_CTX *ctx)
     PSYMCRYPT_SHA256_STATE state = (PSYMCRYPT_SHA256_STATE)EVP_MD_CTX_md_data(ctx);
     if( state == NULL )
     {
-        SCOSSL_LOG_ERROR("No MD Data Present");
+        SCOSSL_LOG_ERROR(SCOSSL_ERR_F_DIGESTS, SCOSSL_ERR_R_MISSING_CTX_DATA, "No MD Data Present");
         return SCOSSL_FAILURE;
     }
 
@@ -342,7 +342,7 @@ static SCOSSL_STATUS scossl_digest_sha256_update(_Inout_ EVP_MD_CTX *ctx, _In_re
     PSYMCRYPT_SHA256_STATE state = (PSYMCRYPT_SHA256_STATE)EVP_MD_CTX_md_data(ctx);
     if( state == NULL )
     {
-        SCOSSL_LOG_ERROR("No MD Data Present");
+        SCOSSL_LOG_ERROR(SCOSSL_ERR_F_DIGESTS, SCOSSL_ERR_R_MISSING_CTX_DATA, "No MD Data Present");
         return SCOSSL_FAILURE;
     }
 
@@ -355,7 +355,7 @@ static SCOSSL_STATUS scossl_digest_sha256_final(_Inout_ EVP_MD_CTX *ctx, _Out_wr
     PSYMCRYPT_SHA256_STATE state = (PSYMCRYPT_SHA256_STATE)EVP_MD_CTX_md_data(ctx);
     if( state == NULL )
     {
-        SCOSSL_LOG_ERROR("No MD Data Present");
+        SCOSSL_LOG_ERROR(SCOSSL_ERR_F_DIGESTS, SCOSSL_ERR_R_MISSING_CTX_DATA, "No MD Data Present");
         return SCOSSL_FAILURE;
     }
 
@@ -384,7 +384,7 @@ static SCOSSL_STATUS scossl_digest_sha384_init(_Out_ EVP_MD_CTX *ctx)
     PSYMCRYPT_SHA384_STATE state = (PSYMCRYPT_SHA384_STATE)EVP_MD_CTX_md_data(ctx);
     if( state == NULL )
     {
-        SCOSSL_LOG_ERROR("No MD Data Present");
+        SCOSSL_LOG_ERROR(SCOSSL_ERR_F_DIGESTS, SCOSSL_ERR_R_MISSING_CTX_DATA, "No MD Data Present");
         return SCOSSL_FAILURE;
     }
 
@@ -398,7 +398,7 @@ static SCOSSL_STATUS scossl_digest_sha384_update(_Inout_ EVP_MD_CTX *ctx, _In_re
     PSYMCRYPT_SHA384_STATE state = (PSYMCRYPT_SHA384_STATE)EVP_MD_CTX_md_data(ctx);
     if( state == NULL )
     {
-        SCOSSL_LOG_ERROR("No MD Data Present");
+        SCOSSL_LOG_ERROR(SCOSSL_ERR_F_DIGESTS, SCOSSL_ERR_R_MISSING_CTX_DATA, "No MD Data Present");
         return SCOSSL_FAILURE;
     }
 
@@ -411,7 +411,7 @@ static SCOSSL_STATUS scossl_digest_sha384_final(_Inout_ EVP_MD_CTX *ctx, _Out_wr
     PSYMCRYPT_SHA384_STATE state = (PSYMCRYPT_SHA384_STATE)EVP_MD_CTX_md_data(ctx);
     if( state == NULL )
     {
-        SCOSSL_LOG_ERROR("No MD Data Present");
+        SCOSSL_LOG_ERROR(SCOSSL_ERR_F_DIGESTS, SCOSSL_ERR_R_MISSING_CTX_DATA, "No MD Data Present");
         return SCOSSL_FAILURE;
     }
 
@@ -440,7 +440,7 @@ static SCOSSL_STATUS scossl_digest_sha512_init(_Out_ EVP_MD_CTX *ctx)
     PSYMCRYPT_SHA512_STATE state = (PSYMCRYPT_SHA512_STATE)EVP_MD_CTX_md_data(ctx);
     if( state == NULL )
     {
-        SCOSSL_LOG_ERROR("No MD Data Present");
+        SCOSSL_LOG_ERROR(SCOSSL_ERR_F_DIGESTS, SCOSSL_ERR_R_MISSING_CTX_DATA, "No MD Data Present");
         return SCOSSL_FAILURE;
     }
 
@@ -454,7 +454,7 @@ static SCOSSL_STATUS scossl_digest_sha512_update(_Inout_ EVP_MD_CTX *ctx, _In_re
     PSYMCRYPT_SHA512_STATE state = (PSYMCRYPT_SHA512_STATE)EVP_MD_CTX_md_data(ctx);
     if( state == NULL )
     {
-        SCOSSL_LOG_ERROR("No MD Data Present");
+        SCOSSL_LOG_ERROR(SCOSSL_ERR_F_DIGESTS, SCOSSL_ERR_R_MISSING_CTX_DATA, "No MD Data Present");
         return SCOSSL_FAILURE;
     }
 
@@ -467,7 +467,7 @@ static SCOSSL_STATUS scossl_digest_sha512_final(_Inout_ EVP_MD_CTX *ctx, _Out_wr
     PSYMCRYPT_SHA512_STATE state = (PSYMCRYPT_SHA512_STATE)EVP_MD_CTX_md_data(ctx);
     if( state == NULL )
     {
-        SCOSSL_LOG_ERROR("No MD Data Present");
+        SCOSSL_LOG_ERROR(SCOSSL_ERR_F_DIGESTS, SCOSSL_ERR_R_MISSING_CTX_DATA, "No MD Data Present");
         return SCOSSL_FAILURE;
     }
 

--- a/SymCryptEngine/src/scossl_ecc.c
+++ b/SymCryptEngine/src/scossl_ecc.c
@@ -65,7 +65,8 @@ static SCOSSL_STATUS scossl_ecdsa_der_check_tag_and_get_value_and_length(
     // Check for tag
     if( pbDerField[0] != expectedTag )
     {
-        SCOSSL_LOG_ERROR("pbDerField[0] != 0x%x", expectedTag);
+        SCOSSL_LOG_ERROR(SCOSSL_ERR_F_ECDSA_DER_CHECK_TAG_AND_GET_VALUE_AND_LENGTH, ERR_R_PASSED_INVALID_ARGUMENT,
+            "pbDerField[0] != 0x%x", expectedTag);
         goto cleanup;
     }
 
@@ -84,21 +85,24 @@ static SCOSSL_STATUS scossl_ecdsa_der_check_tag_and_get_value_and_length(
             }
             else
             {
-                SCOSSL_LOG_ERROR("Der element length field is not minimal");
+                SCOSSL_LOG_ERROR(SCOSSL_ERR_F_ECDSA_DER_CHECK_TAG_AND_GET_VALUE_AND_LENGTH, ERR_R_PASSED_INVALID_ARGUMENT,
+                    "Der element length field is not minimal");
                 goto cleanup;
             }
         }
         else
         {
-            SCOSSL_LOG_ERROR("Unexpected length field encoding. pbDerField[1] == 0x%x", cbContent);
+            SCOSSL_LOG_ERROR(SCOSSL_ERR_F_ECDSA_DER_CHECK_TAG_AND_GET_VALUE_AND_LENGTH, ERR_R_PASSED_INVALID_ARGUMENT,
+                "Unexpected length field encoding. pbDerField[1] == 0x%x", cbContent);
             goto cleanup;
         }
     }
 
     if( pbContent + cbContent > pbDerField + cbDerField  )
     {
-        SCOSSL_LOG_ERROR("Decoded content length does not fit in derField buffer. pbDerField [0x%lx, 0x%lx), pbContent [0x%lx, 0x%lx)",
-                            pbDerField, pbDerField+cbDerField, pbContent, pbContent+cbContent);
+        SCOSSL_LOG_ERROR(SCOSSL_ERR_F_ECDSA_DER_CHECK_TAG_AND_GET_VALUE_AND_LENGTH, ERR_R_PASSED_INVALID_ARGUMENT,
+            "Decoded content length does not fit in derField buffer. pbDerField [0x%lx, 0x%lx), pbContent [0x%lx, 0x%lx)",
+            pbDerField, pbDerField+cbDerField, pbContent, pbContent+cbContent);
         goto cleanup;
     }
 
@@ -132,10 +136,11 @@ static SCOSSL_STATUS scossl_ecdsa_remove_der(_In_reads_bytes_(cbDerSignature) PC
         (cbSymCryptSignature > SCOSSL_ECDSA_MAX_SYMCRYPT_SIGNATURE_LEN) ||
         (cbSymCryptSignature % 2 == 1) )
     {
-        SCOSSL_LOG_ERROR("Incorrect size: cbDerSignature %d should be in range [%d, %d]\n" \
-                           "                cbSymCryptSignature %d should be even integer in range [%d, %d]",
-                           cbDerSignature, SCOSSL_ECDSA_MIN_DER_SIGNATURE_LEN, SCOSSL_ECDSA_MAX_DER_SIGNATURE_LEN,
-                           cbSymCryptSignature, SCOSSL_ECDSA_MIN_SYMCRYPT_SIGNATURE_LEN, SCOSSL_ECDSA_MAX_SYMCRYPT_SIGNATURE_LEN );
+        SCOSSL_LOG_ERROR(SCOSSL_ERR_F_ECDSA_REMOVE_DER, ERR_R_PASSED_INVALID_ARGUMENT,
+            "Incorrect size: cbDerSignature %d should be in range [%d, %d]\n" \
+            "                cbSymCryptSignature %d should be even integer in range [%d, %d]",
+            cbDerSignature, SCOSSL_ECDSA_MIN_DER_SIGNATURE_LEN, SCOSSL_ECDSA_MAX_DER_SIGNATURE_LEN,
+            cbSymCryptSignature, SCOSSL_ECDSA_MIN_SYMCRYPT_SIGNATURE_LEN, SCOSSL_ECDSA_MAX_SYMCRYPT_SIGNATURE_LEN );
         goto cleanup;
     }
 
@@ -148,8 +153,10 @@ static SCOSSL_STATUS scossl_ecdsa_remove_der(_In_reads_bytes_(cbDerSignature) PC
 
     if( pbSeq + cbSeq != pbDerSignature + cbDerSignature )
     {
-        SCOSSL_LOG_ERROR("Sequence length field (0x%x) does not match cbDerSignature (0x%x)", cbSeq, cbDerSignature);
-        SCOSSL_LOG_BYTES_ERROR("pbDerSignature", pbDerSignature, cbDerSignature);
+        SCOSSL_LOG_ERROR(SCOSSL_ERR_F_ECDSA_REMOVE_DER, ERR_R_PASSED_INVALID_ARGUMENT,
+            "Sequence length field (0x%x) does not match cbDerSignature (0x%x)", cbSeq, cbDerSignature);
+        SCOSSL_LOG_BYTES_DEBUG(SCOSSL_ERR_F_ECDSA_REMOVE_DER, ERR_R_PASSED_INVALID_ARGUMENT,
+            "pbDerSignature", pbDerSignature, cbDerSignature);
         goto cleanup;
     }
 
@@ -161,8 +168,10 @@ static SCOSSL_STATUS scossl_ecdsa_remove_der(_In_reads_bytes_(cbDerSignature) PC
 
     if( cbR > cbSeq - 3 )
     {
-        SCOSSL_LOG_ERROR("cbR = pbSeq[1] > cbSeq - 3");
-        SCOSSL_LOG_BYTES_ERROR("pbDerSignature", pbDerSignature, cbDerSignature);
+        SCOSSL_LOG_ERROR(SCOSSL_ERR_F_ECDSA_REMOVE_DER, ERR_R_PASSED_INVALID_ARGUMENT,
+            "cbR = pbSeq[1] > cbSeq - 3");
+        SCOSSL_LOG_BYTES_DEBUG(SCOSSL_ERR_F_ECDSA_REMOVE_DER, ERR_R_PASSED_INVALID_ARGUMENT,
+            "pbDerSignature", pbDerSignature, cbDerSignature);
         goto cleanup;
     }
 
@@ -176,8 +185,10 @@ static SCOSSL_STATUS scossl_ecdsa_remove_der(_In_reads_bytes_(cbDerSignature) PC
     if( ((pbR[0] & 0x80) == 0x80) || // R is negative
         ((cbR > 1) && (pbR[0] == 0x00) && ((pbR[1] & 0x80) != 0x80)) ) // R is non-zero, and has a redundant leading 0 byte
     {
-        SCOSSL_LOG_ERROR("pbR is not strict DER encoded non-negative integer");
-        SCOSSL_LOG_BYTES_ERROR("pbR", pbR, cbR);
+        SCOSSL_LOG_ERROR(SCOSSL_ERR_F_ECDSA_REMOVE_DER, ERR_R_PASSED_INVALID_ARGUMENT,
+            "pbR is not strict DER encoded non-negative integer");
+        SCOSSL_LOG_BYTES_DEBUG(SCOSSL_ERR_F_ECDSA_REMOVE_DER, ERR_R_PASSED_INVALID_ARGUMENT,
+            "pbR", pbR, cbR);
         goto cleanup;
     }
     // Trim leading 0 from R
@@ -190,8 +201,10 @@ static SCOSSL_STATUS scossl_ecdsa_remove_der(_In_reads_bytes_(cbDerSignature) PC
     if( ((pbS[0] & 0x80) == 0x80) || // S is negative
         ((cbS > 1) && (pbS[0] == 0x00) && ((pbS[1] & 0x80) != 0x80)) ) // S is non-zero, and has a redundant leading 0 byte
     {
-        SCOSSL_LOG_ERROR("pbS is not strict DER encoded non-negative integer");
-        SCOSSL_LOG_BYTES_ERROR("pbS", pbS, cbS);
+        SCOSSL_LOG_ERROR(SCOSSL_ERR_F_ECDSA_REMOVE_DER, ERR_R_PASSED_INVALID_ARGUMENT,
+            "pbS is not strict DER encoded non-negative integer");
+        SCOSSL_LOG_BYTES_DEBUG(SCOSSL_ERR_F_ECDSA_REMOVE_DER, ERR_R_PASSED_INVALID_ARGUMENT,
+            "pbS", pbS, cbS);
         goto cleanup;
     }
     // Trim leading 0 from S
@@ -203,7 +216,8 @@ static SCOSSL_STATUS scossl_ecdsa_remove_der(_In_reads_bytes_(cbDerSignature) PC
 
     if( (cbSymCryptSignature < 2*cbR) || (cbSymCryptSignature < 2*cbS) )
     {
-        SCOSSL_LOG_ERROR("cbR (%d) or cbS (%d) too big for cbSymCryptSignature (%d)", cbR, cbS, cbSymCryptSignature);
+        SCOSSL_LOG_ERROR(SCOSSL_ERR_F_ECDSA_REMOVE_DER, ERR_R_PASSED_INVALID_ARGUMENT,
+            "cbR (%d) or cbS (%d) too big for cbSymCryptSignature (%d)", cbR, cbS, cbSymCryptSignature);
         goto cleanup;
     }
 
@@ -239,8 +253,9 @@ static SCOSSL_STATUS scossl_ecdsa_apply_der(_In_reads_bytes_(cbSymCryptSignature
         (cbSymCryptSignature > SCOSSL_ECDSA_MAX_SYMCRYPT_SIGNATURE_LEN) ||
         (cbSymCryptSignature % 2 == 1) )
     {
-        SCOSSL_LOG_ERROR("Incorrect size: cbSymCryptSignature %d should be even integer in range [%d, %d]",
-                           cbSymCryptSignature, SCOSSL_ECDSA_MIN_SYMCRYPT_SIGNATURE_LEN, SCOSSL_ECDSA_MAX_SYMCRYPT_SIGNATURE_LEN );
+        SCOSSL_LOG_ERROR(SCOSSL_ERR_F_ECDSA_APPLY_DER, ERR_R_PASSED_INVALID_ARGUMENT,
+            "Incorrect size: cbSymCryptSignature %d should be even integer in range [%d, %d]",
+            cbSymCryptSignature, SCOSSL_ECDSA_MIN_SYMCRYPT_SIGNATURE_LEN, SCOSSL_ECDSA_MAX_SYMCRYPT_SIGNATURE_LEN );
         goto cleanup;
     }
 
@@ -373,7 +388,8 @@ SCOSSL_STATUS scossl_ecc_generate_keypair(_Inout_ SCOSSL_ECC_KEY_CONTEXT* pKeyCt
     pKeyCtx->key = SymCryptEckeyAllocate(pCurve);
     if( pKeyCtx->key == NULL )
     {
-        SCOSSL_LOG_ERROR("SymCryptEckeyAllocate returned NULL.");
+        SCOSSL_LOG_ERROR(SCOSSL_ERR_F_ECC_GENERATE_KEYPAIR, SCOSSL_ERR_R_SYMCRYPT_FAILURE,
+            "SymCryptEckeyAllocate returned NULL.");
         goto cleanup;
     }
 
@@ -384,7 +400,8 @@ SCOSSL_STATUS scossl_ecc_generate_keypair(_Inout_ SCOSSL_ECC_KEY_CONTEXT* pKeyCt
     pbData = OPENSSL_zalloc(cbData);
     if( pbData == NULL )
     {
-        SCOSSL_LOG_ERROR("OPENSSL_zalloc returned NULL.");
+        SCOSSL_LOG_ERROR(SCOSSL_ERR_F_ECC_GENERATE_KEYPAIR, ERR_R_MALLOC_FAILURE,
+            "OPENSSL_zalloc returned NULL.");
         goto cleanup;
     }
 
@@ -393,7 +410,8 @@ SCOSSL_STATUS scossl_ecc_generate_keypair(_Inout_ SCOSSL_ECC_KEY_CONTEXT* pKeyCt
         pKeyCtx->key );
     if( scError != SYMCRYPT_NO_ERROR )
     {
-        SCOSSL_LOG_SYMCRYPT_ERROR("SymCryptEckeySetRandom failed", scError);
+        SCOSSL_LOG_SYMCRYPT_ERROR(SCOSSL_ERR_F_ECC_GENERATE_KEYPAIR, SCOSSL_ERR_R_SYMCRYPT_FAILURE,
+            "SymCryptEckeySetRandom failed", scError);
         goto cleanup;
     }
 
@@ -409,7 +427,8 @@ SCOSSL_STATUS scossl_ecc_generate_keypair(_Inout_ SCOSSL_ECC_KEY_CONTEXT* pKeyCt
         0 );
     if( scError != SYMCRYPT_NO_ERROR )
     {
-        SCOSSL_LOG_SYMCRYPT_ERROR("SymCryptEckeyGetValue failed", scError);
+        SCOSSL_LOG_SYMCRYPT_ERROR(SCOSSL_ERR_F_ECC_GENERATE_KEYPAIR, SCOSSL_ERR_R_SYMCRYPT_FAILURE,
+            "SymCryptEckeyGetValue failed", scError);
         goto cleanup;
     }
 
@@ -417,7 +436,8 @@ SCOSSL_STATUS scossl_ecc_generate_keypair(_Inout_ SCOSSL_ECC_KEY_CONTEXT* pKeyCt
         ((ec_pub_x = BN_new()) == NULL) ||
         ((ec_pub_y = BN_new()) == NULL) )
     {
-        SCOSSL_LOG_ERROR("BN_new returned NULL.");
+        SCOSSL_LOG_ERROR(SCOSSL_ERR_F_ECC_GENERATE_KEYPAIR, ERR_R_MALLOC_FAILURE,
+            "BN_new returned NULL.");
         goto cleanup;
     }
 
@@ -425,18 +445,21 @@ SCOSSL_STATUS scossl_ecc_generate_keypair(_Inout_ SCOSSL_ECC_KEY_CONTEXT* pKeyCt
         (BN_bin2bn(pbPublicKey, cbPublicKey/2, ec_pub_x) == NULL) ||
         (BN_bin2bn(pbPublicKey + (cbPublicKey/2), cbPublicKey/2, ec_pub_y) == NULL) )
     {
-        SCOSSL_LOG_ERROR("BN_bin2bn failed.");
+        SCOSSL_LOG_ERROR(SCOSSL_ERR_F_ECC_GENERATE_KEYPAIR, ERR_R_OPERATION_FAIL,
+            "BN_bin2bn failed.");
         goto cleanup;
     }
 
     if( EC_KEY_set_private_key(eckey, ec_privkey) == 0)
     {
-        SCOSSL_LOG_ERROR("EC_KEY_set_private_key failed.");
+        SCOSSL_LOG_ERROR(SCOSSL_ERR_F_ECC_GENERATE_KEYPAIR, ERR_R_OPERATION_FAIL,
+            "EC_KEY_set_private_key failed.");
         goto cleanup;
     }
     if( EC_KEY_set_public_key_affine_coordinates(eckey, ec_pub_x, ec_pub_y) == 0 )
     {
-        SCOSSL_LOG_ERROR("EC_KEY_set_public_key_affine_coordinates failed.");
+        SCOSSL_LOG_ERROR(SCOSSL_ERR_F_ECC_GENERATE_KEYPAIR, ERR_R_OPERATION_FAIL,
+            "EC_KEY_set_public_key_affine_coordinates failed.");
         goto cleanup;
     }
 
@@ -486,7 +509,8 @@ SCOSSL_STATUS scossl_ecc_import_keypair(_In_ const EC_KEY* eckey, _In_ const EC_
     pKeyCtx->key = SymCryptEckeyAllocate(pCurve);
     if( pKeyCtx->key == NULL )
     {
-        SCOSSL_LOG_ERROR("SymCryptEckeyAllocate returned NULL.");
+        SCOSSL_LOG_ERROR(SCOSSL_ERR_F_ECC_IMPORT_KEYPAIR, SCOSSL_ERR_R_SYMCRYPT_FAILURE,
+            "SymCryptEckeyAllocate returned NULL.");
         goto cleanup;
     }
 
@@ -498,7 +522,8 @@ SCOSSL_STATUS scossl_ecc_import_keypair(_In_ const EC_KEY* eckey, _In_ const EC_
 
     if( ec_pubkey == NULL )
     {
-        SCOSSL_LOG_ERROR("EC_KEY_get0_public_key returned NULL.");
+        SCOSSL_LOG_ERROR(SCOSSL_ERR_F_ECC_IMPORT_KEYPAIR, ERR_R_OPERATION_FAIL,
+            "EC_KEY_get0_public_key returned NULL.");
         goto cleanup;
     }
 
@@ -509,7 +534,8 @@ SCOSSL_STATUS scossl_ecc_import_keypair(_In_ const EC_KEY* eckey, _In_ const EC_
 
     if( (bn_ctx = BN_CTX_new()) == NULL )
     {
-        SCOSSL_LOG_ERROR("BN_CTX_new returned NULL.");
+        SCOSSL_LOG_ERROR(SCOSSL_ERR_F_ECC_IMPORT_KEYPAIR, ERR_R_OPERATION_FAIL,
+            "BN_CTX_new returned NULL.");
         goto cleanup;
     }
     BN_CTX_start(bn_ctx);
@@ -517,13 +543,15 @@ SCOSSL_STATUS scossl_ecc_import_keypair(_In_ const EC_KEY* eckey, _In_ const EC_
     if( ((ec_pub_x = BN_new()) == NULL) ||
         ((ec_pub_y = BN_new()) == NULL) )
     {
-        SCOSSL_LOG_ERROR("BN_new returned NULL.");
+        SCOSSL_LOG_ERROR(SCOSSL_ERR_F_ECC_IMPORT_KEYPAIR, ERR_R_MALLOC_FAILURE,
+            "BN_new returned NULL.");
         goto cleanup;
     }
 
     if( EC_POINT_get_affine_coordinates(ecgroup, ec_pubkey, ec_pub_x, ec_pub_y, bn_ctx) == 0 )
     {
-        SCOSSL_LOG_ERROR("EC_POINT_get_affine_coordinates failed.");
+        SCOSSL_LOG_ERROR(SCOSSL_ERR_F_ECC_IMPORT_KEYPAIR, ERR_R_OPERATION_FAIL,
+            "EC_POINT_get_affine_coordinates failed.");
         goto cleanup;
     }
 
@@ -531,7 +559,8 @@ SCOSSL_STATUS scossl_ecc_import_keypair(_In_ const EC_KEY* eckey, _In_ const EC_
     pbData = OPENSSL_zalloc(cbData);
     if( pbData == NULL )
     {
-        SCOSSL_LOG_ERROR("OPENSSL_zalloc returned NULL.");
+        SCOSSL_LOG_ERROR(SCOSSL_ERR_F_ECC_IMPORT_KEYPAIR, ERR_R_MALLOC_FAILURE,
+            "OPENSSL_zalloc returned NULL.");
         goto cleanup;
     }
 
@@ -540,7 +569,8 @@ SCOSSL_STATUS scossl_ecc_import_keypair(_In_ const EC_KEY* eckey, _In_ const EC_
         pbPrivateKey = pbData;
         if( (SIZE_T) BN_bn2binpad(ec_privkey, pbPrivateKey, cbPrivateKey) != cbPrivateKey )
         {
-            SCOSSL_LOG_ERROR("BN_bn2binpad did not write expected number of private key bytes.");
+            SCOSSL_LOG_ERROR(SCOSSL_ERR_F_ECC_IMPORT_KEYPAIR, ERR_R_OPERATION_FAIL,
+                "BN_bn2binpad did not write expected number of private key bytes.");
             goto cleanup;
         }
     }
@@ -549,7 +579,8 @@ SCOSSL_STATUS scossl_ecc_import_keypair(_In_ const EC_KEY* eckey, _In_ const EC_
     if( ((SIZE_T) BN_bn2binpad(ec_pub_x, pbPublicKey, cbPublicKey/2) != cbPublicKey/2) ||
         ((SIZE_T) BN_bn2binpad(ec_pub_y, pbPublicKey + (cbPublicKey/2), cbPublicKey/2) != cbPublicKey/2) )
     {
-        SCOSSL_LOG_ERROR("BN_bn2binpad did not write expected number of public key bytes.");
+        SCOSSL_LOG_ERROR(SCOSSL_ERR_F_ECC_IMPORT_KEYPAIR, ERR_R_OPERATION_FAIL,
+            "BN_bn2binpad did not write expected number of public key bytes.");
         goto cleanup;
     }
 
@@ -562,7 +593,8 @@ SCOSSL_STATUS scossl_ecc_import_keypair(_In_ const EC_KEY* eckey, _In_ const EC_
         pKeyCtx->key );
     if( scError != SYMCRYPT_NO_ERROR )
     {
-        SCOSSL_LOG_SYMCRYPT_ERROR("SymCryptEckeySetValue failed", scError);
+        SCOSSL_LOG_SYMCRYPT_ERROR(SCOSSL_ERR_F_ECC_IMPORT_KEYPAIR, SCOSSL_ERR_R_SYMCRYPT_FAILURE,
+            "SymCryptEckeySetValue failed", scError);
         goto cleanup;
     }
 
@@ -632,13 +664,15 @@ SCOSSL_STATUS scossl_get_ecc_context_ex(_Inout_ EC_KEY* eckey, _Out_ SCOSSL_ECC_
         pCurve = _hidden_curve_P521;
         break;
     default:
-        SCOSSL_LOG_INFO("SymCrypt engine does not yet support this group (nid %d) - falling back to OpenSSL.", groupNid);
+        SCOSSL_LOG_INFO(SCOSSL_ERR_F_GET_ECC_CONTEXT_EX, SCOSSL_ERR_R_OPENSSL_FALLBACK,
+            "SymCrypt engine does not yet support this group (nid %d) - falling back to OpenSSL.", groupNid);
         return SCOSSL_FALLBACK;
     }
 
     if( pCurve == NULL )
     {
-        SCOSSL_LOG_ERROR("SymCryptEcurveAllocate failed.");
+        SCOSSL_LOG_ERROR(SCOSSL_ERR_F_GET_ECC_CONTEXT_EX, ERR_R_INTERNAL_ERROR,
+            "SymCryptEcurveAllocate failed.");
         return SCOSSL_FAILURE;
     }
 
@@ -649,13 +683,15 @@ SCOSSL_STATUS scossl_get_ecc_context_ex(_Inout_ EC_KEY* eckey, _Out_ SCOSSL_ECC_
         SCOSSL_ECC_KEY_CONTEXT *keyCtx = OPENSSL_zalloc(sizeof(*keyCtx));
         if( !keyCtx )
         {
-            SCOSSL_LOG_ERROR("OPENSSL_zalloc failed");
+            SCOSSL_LOG_ERROR(SCOSSL_ERR_F_GET_ECC_CONTEXT_EX, ERR_R_MALLOC_FAILURE,
+                "OPENSSL_zalloc failed");
             return SCOSSL_FAILURE;
         }
 
         if( EC_KEY_set_ex_data(eckey, scossl_eckey_idx, keyCtx) == 0)
         {
-            SCOSSL_LOG_ERROR("EC_KEY_set_ex_data failed");
+            SCOSSL_LOG_ERROR(SCOSSL_ERR_F_GET_ECC_CONTEXT_EX, ERR_R_OPERATION_FAIL,
+                "EC_KEY_set_ex_data failed");
             OPENSSL_free(keyCtx);
             return SCOSSL_FAILURE;
         }
@@ -704,7 +740,8 @@ SCOSSL_STATUS scossl_eckey_sign(int type,
     switch( scossl_get_ecc_context(eckey, &keyCtx) )
     {
     case SCOSSL_FAILURE:
-        SCOSSL_LOG_ERROR("scossl_get_ecc_context failed.");
+        SCOSSL_LOG_ERROR(SCOSSL_ERR_F_ECKEY_SIGN, ERR_R_OPERATION_FAIL,
+            "scossl_get_ecc_context failed.");
         return SCOSSL_FAILURE;
     case SCOSSL_FALLBACK:
         ossl_eckey_method = EC_KEY_OpenSSL();
@@ -718,14 +755,16 @@ SCOSSL_STATUS scossl_eckey_sign(int type,
     case SCOSSL_SUCCESS:
         break;
     default:
-        SCOSSL_LOG_ERROR("Unexpected scossl_get_ecc_context value");
+        SCOSSL_LOG_ERROR(SCOSSL_ERR_F_ECKEY_SIGN, ERR_R_INTERNAL_ERROR,
+            "Unexpected scossl_get_ecc_context value");
         return SCOSSL_FAILURE;
     }
 
     // SymCrypt does not support taking kinv or r parameters. Fallback to OpenSSL.
     if( kinv != NULL || r != NULL )
     {
-        SCOSSL_LOG_INFO("SymCrypt engine does not yet support explicit setting kinv or r parameters. Falling back to OpenSSL");
+        SCOSSL_LOG_INFO(SCOSSL_ERR_F_ECKEY_SIGN, SCOSSL_ERR_R_OPENSSL_FALLBACK,
+            "SymCrypt engine does not yet support explicit setting kinv or r parameters. Falling back to OpenSSL");
         ossl_eckey_method = EC_KEY_OpenSSL();
         PFN_eckey_sign pfn_eckey_sign = NULL;
         EC_KEY_METHOD_get_sign(ossl_eckey_method, &pfn_eckey_sign, NULL, NULL);
@@ -747,13 +786,15 @@ SCOSSL_STATUS scossl_eckey_sign(int type,
         cbSymCryptSig);
     if( scError != SYMCRYPT_NO_ERROR )
     {
-        SCOSSL_LOG_SYMCRYPT_ERROR("SymCryptEcDsaSign failed", scError);
+        SCOSSL_LOG_SYMCRYPT_ERROR(SCOSSL_ERR_F_ECKEY_SIGN, SCOSSL_ERR_R_SYMCRYPT_FAILURE,
+            "SymCryptEcDsaSign failed", scError);
         return SCOSSL_FAILURE;
     }
 
     if( scossl_ecdsa_apply_der(buf, cbSymCryptSig, sig, siglen) == 0 )
     {
-        SCOSSL_LOG_ERROR("scossl_ecdsa_apply_der failed");
+        SCOSSL_LOG_ERROR(SCOSSL_ERR_F_ECKEY_SIGN, ERR_R_OPERATION_FAIL,
+            "scossl_ecdsa_apply_der failed");
         return SCOSSL_FAILURE;
     }
 
@@ -769,11 +810,13 @@ SCOSSL_STATUS scossl_eckey_sign_setup(_In_ EC_KEY* eckey, _In_ BN_CTX* ctx_in, _
     switch( scossl_get_ecc_context(eckey, &keyCtx) )
     {
     case SCOSSL_FAILURE:
-        SCOSSL_LOG_ERROR("scossl_get_ecc_context failed.");
+        SCOSSL_LOG_ERROR(SCOSSL_ERR_F_ECKEY_SIGN_SETUP, ERR_R_OPERATION_FAIL,
+            "scossl_get_ecc_context failed.");
         return SCOSSL_FAILURE;
     case SCOSSL_FALLBACK:
     case SCOSSL_SUCCESS:
-        SCOSSL_LOG_INFO("SymCrypt engine does not yet support explicit getting kinv or r parameters. Falling back to OpenSSL");
+        SCOSSL_LOG_INFO(SCOSSL_ERR_F_ECKEY_SIGN_SETUP, SCOSSL_ERR_R_OPENSSL_FALLBACK,
+            "SymCrypt engine does not yet support explicit getting kinv or r parameters. Falling back to OpenSSL");
         EC_KEY_METHOD_get_sign(ossl_eckey_method, NULL, &pfn_eckey_sign_setup, NULL);
         if( !pfn_eckey_sign_setup )
         {
@@ -781,7 +824,8 @@ SCOSSL_STATUS scossl_eckey_sign_setup(_In_ EC_KEY* eckey, _In_ BN_CTX* ctx_in, _
         }
         return pfn_eckey_sign_setup(eckey, ctx_in, kinvp, rp);
     default:
-        SCOSSL_LOG_ERROR("Unexpected scossl_get_ecc_context value");
+        SCOSSL_LOG_ERROR(SCOSSL_ERR_F_ECKEY_SIGN_SETUP, ERR_R_INTERNAL_ERROR,
+            "Unexpected scossl_get_ecc_context value");
         return SCOSSL_FAILURE;
     }
 }
@@ -802,7 +846,8 @@ ECDSA_SIG* scossl_eckey_sign_sig(_In_reads_bytes_(dgstlen) const unsigned char* 
     switch( scossl_get_ecc_context(eckey, &keyCtx) )
     {
     case SCOSSL_FAILURE:
-        SCOSSL_LOG_ERROR("scossl_get_ecc_context failed.");
+        SCOSSL_LOG_ERROR(SCOSSL_ERR_F_ECKEY_SIGN_SIG, ERR_R_OPERATION_FAIL,
+            "scossl_get_ecc_context failed.");
         return NULL;
     case SCOSSL_FALLBACK:
         ossl_eckey_method = EC_KEY_OpenSSL();
@@ -816,7 +861,8 @@ ECDSA_SIG* scossl_eckey_sign_sig(_In_reads_bytes_(dgstlen) const unsigned char* 
     case SCOSSL_SUCCESS:
         break;
     default:
-        SCOSSL_LOG_ERROR("Unexpected scossl_get_ecc_context value");
+        SCOSSL_LOG_ERROR(SCOSSL_ERR_F_ECKEY_SIGN_SIG, ERR_R_INTERNAL_ERROR,
+            "Unexpected scossl_get_ecc_context value");
         return NULL;
     }
 
@@ -831,14 +877,16 @@ ECDSA_SIG* scossl_eckey_sign_sig(_In_reads_bytes_(dgstlen) const unsigned char* 
         cbSymCryptSig);
     if( scError != SYMCRYPT_NO_ERROR )
     {
-        SCOSSL_LOG_SYMCRYPT_ERROR("SymCryptEcDsaSign failed", scError);
+        SCOSSL_LOG_SYMCRYPT_ERROR(SCOSSL_ERR_F_ECKEY_SIGN_SIG, SCOSSL_ERR_R_SYMCRYPT_FAILURE,
+            "SymCryptEcDsaSign failed", scError);
         return NULL;
     }
 
     returnSignature = ECDSA_SIG_new();
     if( returnSignature == NULL )
     {
-        SCOSSL_LOG_ERROR("ECDSA_SIG_new returned NULL.");
+        SCOSSL_LOG_ERROR(SCOSSL_ERR_F_ECKEY_SIGN_SIG, ERR_R_MALLOC_FAILURE,
+            "ECDSA_SIG_new returned NULL.");
         return NULL;
     }
 
@@ -847,14 +895,16 @@ ECDSA_SIG* scossl_eckey_sign_sig(_In_reads_bytes_(dgstlen) const unsigned char* 
     {
         BN_free(r);
         BN_free(s);
-        SCOSSL_LOG_ERROR("BN_new returned NULL.");
+        SCOSSL_LOG_ERROR(SCOSSL_ERR_F_ECKEY_SIGN_SIG, ERR_R_MALLOC_FAILURE,
+            "BN_new returned NULL.");
         return NULL;
     }
 
     if( (BN_bin2bn(buf, cbSymCryptSig/2, r) == NULL) ||
         (BN_bin2bn(buf + cbSymCryptSig/2, cbSymCryptSig/2, s) == NULL) )
     {
-        SCOSSL_LOG_ERROR("BN_bin2bn failed.");
+        SCOSSL_LOG_ERROR(SCOSSL_ERR_F_ECKEY_SIGN_SIG, ERR_R_OPERATION_FAIL,
+            "BN_bin2bn failed.");
         BN_free(r);
         BN_free(s);
         return NULL;
@@ -889,7 +939,8 @@ SCOSSL_STATUS scossl_eckey_verify(int type, _In_reads_bytes_(dgst_len) const uns
     switch( scossl_get_ecc_context(eckey, &keyCtx) )
     {
     case SCOSSL_FAILURE:
-        SCOSSL_LOG_ERROR("scossl_get_ecc_context failed.");
+        SCOSSL_LOG_ERROR(SCOSSL_ERR_F_ECKEY_VERIFY, ERR_R_OPERATION_FAIL,
+            "scossl_get_ecc_context failed.");
         return SCOSSL_FAILURE;
     case SCOSSL_FALLBACK:
         ossl_eckey_method = EC_KEY_OpenSSL();
@@ -903,14 +954,16 @@ SCOSSL_STATUS scossl_eckey_verify(int type, _In_reads_bytes_(dgst_len) const uns
     case SCOSSL_SUCCESS:
         break;
     default:
-        SCOSSL_LOG_ERROR("Unexpected scossl_get_ecc_context value");
+        SCOSSL_LOG_ERROR(SCOSSL_ERR_F_ECKEY_VERIFY, ERR_R_INTERNAL_ERROR,
+            "Unexpected scossl_get_ecc_context value");
         return SCOSSL_FAILURE;
     }
 
     cbSymCryptSig = 2*SymCryptEcurveSizeofFieldElement( keyCtx->key->pCurve );
     if( scossl_ecdsa_remove_der(sigbuf, sig_len, &buf[0], cbSymCryptSig) == 0 )
     {
-        SCOSSL_LOG_ERROR("scossl_ecdsa_remove_der failed");
+        SCOSSL_LOG_ERROR(SCOSSL_ERR_F_ECKEY_VERIFY, ERR_R_OPERATION_FAIL,
+            "scossl_ecdsa_remove_der failed");
         return SCOSSL_FAILURE;
     }
 
@@ -924,7 +977,11 @@ SCOSSL_STATUS scossl_eckey_verify(int type, _In_reads_bytes_(dgst_len) const uns
         0);
     if( scError != SYMCRYPT_NO_ERROR )
     {
-        SCOSSL_LOG_SYMCRYPT_ERROR("SymCryptEcDsaVerify failed", scError);
+        if( scError != SYMCRYPT_SIGNATURE_VERIFICATION_FAILURE )
+        {
+            SCOSSL_LOG_SYMCRYPT_ERROR(SCOSSL_ERR_F_ECKEY_VERIFY, SCOSSL_ERR_R_SYMCRYPT_FAILURE,
+                "SymCryptEcDsaVerify returned unexpected error", scError);
+        }
         return SCOSSL_FAILURE;
     }
 
@@ -946,7 +1003,8 @@ SCOSSL_STATUS scossl_eckey_verify_sig(_In_reads_bytes_(dgst_len) const unsigned 
     switch( scossl_get_ecc_context(eckey, &keyCtx) )
     {
     case SCOSSL_FAILURE:
-        SCOSSL_LOG_ERROR("scossl_get_ecc_context failed.");
+        SCOSSL_LOG_ERROR(SCOSSL_ERR_F_ECKEY_VERIFY_SIG, ERR_R_OPERATION_FAIL,
+            "scossl_get_ecc_context failed.");
         return SCOSSL_FAILURE;
     case SCOSSL_FALLBACK:
         ossl_eckey_method = EC_KEY_OpenSSL();
@@ -960,7 +1018,8 @@ SCOSSL_STATUS scossl_eckey_verify_sig(_In_reads_bytes_(dgst_len) const unsigned 
     case SCOSSL_SUCCESS:
         break;
     default:
-        SCOSSL_LOG_ERROR("Unexpected scossl_get_ecc_context value");
+        SCOSSL_LOG_ERROR(SCOSSL_ERR_F_ECKEY_VERIFY_SIG, ERR_R_INTERNAL_ERROR,
+            "Unexpected scossl_get_ecc_context value");
         return SCOSSL_FAILURE;
     }
 
@@ -982,7 +1041,8 @@ SCOSSL_STATUS scossl_eckey_verify_sig(_In_reads_bytes_(dgst_len) const unsigned 
     {
         if( scError != SYMCRYPT_SIGNATURE_VERIFICATION_FAILURE )
         {
-            SCOSSL_LOG_SYMCRYPT_ERROR("SymCryptEcDsaVerify returned unexpected error", scError);
+            SCOSSL_LOG_SYMCRYPT_ERROR(SCOSSL_ERR_F_ECKEY_VERIFY_SIG, SCOSSL_ERR_R_SYMCRYPT_FAILURE,
+                "SymCryptEcDsaVerify returned unexpected error", scError);
         }
         return SCOSSL_FAILURE;
     }
@@ -998,7 +1058,8 @@ SCOSSL_STATUS scossl_eckey_keygen(_Inout_ EC_KEY *key)
     switch( scossl_get_ecc_context_ex(key, &keyCtx, TRUE) )
     {
     case SCOSSL_FAILURE:
-        SCOSSL_LOG_ERROR("scossl_get_ecc_context_ex failed.");
+        SCOSSL_LOG_ERROR(SCOSSL_ERR_F_ECKEY_KEYGEN, ERR_R_OPERATION_FAIL,
+            "scossl_get_ecc_context_ex failed.");
         return SCOSSL_FAILURE;
     case SCOSSL_FALLBACK:
         ossl_eckey_method = EC_KEY_OpenSSL();
@@ -1012,7 +1073,8 @@ SCOSSL_STATUS scossl_eckey_keygen(_Inout_ EC_KEY *key)
     case SCOSSL_SUCCESS:
         return SCOSSL_SUCCESS;
     default:
-        SCOSSL_LOG_ERROR("Unexpected scossl_get_ecc_context_ex value");
+        SCOSSL_LOG_ERROR(SCOSSL_ERR_F_ECKEY_KEYGEN, ERR_R_INTERNAL_ERROR,
+            "Unexpected scossl_get_ecc_context_ex value");
         return SCOSSL_FAILURE;
     }
 }
@@ -1039,7 +1101,8 @@ SCOSSL_RETURNLENGTH scossl_eckey_compute_key(_Out_writes_bytes_(*pseclen) unsign
     switch( scossl_get_ecc_context((EC_KEY*)ecdh, &keyCtx) ) // removing const cast as code path in this instance will not alter ecdh. TODO: refactor scossl_get_ecc_context
     {
     case SCOSSL_FAILURE:
-        SCOSSL_LOG_ERROR("scossl_get_ecc_context failed.");
+        SCOSSL_LOG_ERROR(SCOSSL_ERR_F_ECKEY_COMPUTE_KEY, ERR_R_OPERATION_FAIL,
+            "scossl_get_ecc_context failed.");
         return -1;
     case SCOSSL_FALLBACK:
         ossl_eckey_method = EC_KEY_OpenSSL();
@@ -1053,14 +1116,16 @@ SCOSSL_RETURNLENGTH scossl_eckey_compute_key(_Out_writes_bytes_(*pseclen) unsign
     case SCOSSL_SUCCESS:
         break;
     default:
-        SCOSSL_LOG_ERROR("Unexpected scossl_get_ecc_context value");
+        SCOSSL_LOG_ERROR(SCOSSL_ERR_F_ECKEY_COMPUTE_KEY, ERR_R_INTERNAL_ERROR,
+            "Unexpected scossl_get_ecc_context value");
         return -1;
     }
 
     ecgroup = EC_KEY_get0_group(ecdh);
     if( ecgroup == NULL )
     {
-        SCOSSL_LOG_ERROR("EC_KEY_get0_group returned NULL.");
+        SCOSSL_LOG_ERROR(SCOSSL_ERR_F_ECKEY_COMPUTE_KEY, ERR_R_OPERATION_FAIL,
+            "EC_KEY_get0_group returned NULL.");
         goto cleanup;
     }
 
@@ -1068,13 +1133,15 @@ SCOSSL_RETURNLENGTH scossl_eckey_compute_key(_Out_writes_bytes_(*pseclen) unsign
     pkPublic = SymCryptEckeyAllocate(keyCtx->key->pCurve);
     if( pkPublic == NULL )
     {
-        SCOSSL_LOG_ERROR("SymCryptEckeyAllocate returned NULL.");
+        SCOSSL_LOG_ERROR(SCOSSL_ERR_F_ECKEY_COMPUTE_KEY, SCOSSL_ERR_R_SYMCRYPT_FAILURE,
+            "SymCryptEckeyAllocate returned NULL.");
         goto cleanup;
     }
 
     if( (bn_ctx = BN_CTX_new()) == NULL )
     {
-        SCOSSL_LOG_ERROR("BN_CTX_new returned NULL.");
+        SCOSSL_LOG_ERROR(SCOSSL_ERR_F_ECKEY_COMPUTE_KEY, ERR_R_OPERATION_FAIL,
+            "BN_CTX_new returned NULL.");
         goto cleanup;
     }
     BN_CTX_start(bn_ctx);
@@ -1082,20 +1149,23 @@ SCOSSL_RETURNLENGTH scossl_eckey_compute_key(_Out_writes_bytes_(*pseclen) unsign
     if( ((ec_pub_x = BN_new()) == NULL) ||
         ((ec_pub_y = BN_new()) == NULL) )
     {
-        SCOSSL_LOG_ERROR("BN_new returned NULL.");
+        SCOSSL_LOG_ERROR(SCOSSL_ERR_F_ECKEY_COMPUTE_KEY, ERR_R_MALLOC_FAILURE,
+            "BN_new returned NULL.");
         goto cleanup;
     }
 
     if( EC_POINT_get_affine_coordinates(ecgroup, pub_key, ec_pub_x, ec_pub_y, bn_ctx) == 0 )
     {
-        SCOSSL_LOG_ERROR("EC_POINT_get_affine_coordinates failed.");
+        SCOSSL_LOG_ERROR(SCOSSL_ERR_F_ECKEY_COMPUTE_KEY, ERR_R_OPERATION_FAIL,
+            "EC_POINT_get_affine_coordinates failed.");
         goto cleanup;
     }
 
     if( (BN_bn2binpad(ec_pub_x, buf, cbPublicKey/2) != cbPublicKey/2) ||
         (BN_bn2binpad(ec_pub_y, buf + (cbPublicKey/2), cbPublicKey/2) != cbPublicKey/2) )
     {
-        SCOSSL_LOG_ERROR("BN_bn2binpad did not write expected number of public key bytes.");
+        SCOSSL_LOG_ERROR(SCOSSL_ERR_F_ECKEY_COMPUTE_KEY, ERR_R_OPERATION_FAIL,
+            "BN_bn2binpad did not write expected number of public key bytes.");
         goto cleanup;
     }
 
@@ -1108,7 +1178,8 @@ SCOSSL_RETURNLENGTH scossl_eckey_compute_key(_Out_writes_bytes_(*pseclen) unsign
         pkPublic );
     if( scError != SYMCRYPT_NO_ERROR )
     {
-        SCOSSL_LOG_SYMCRYPT_ERROR("SymCryptEckeySetValue failed", scError);
+        SCOSSL_LOG_SYMCRYPT_ERROR(SCOSSL_ERR_F_ECKEY_COMPUTE_KEY, SCOSSL_ERR_R_SYMCRYPT_FAILURE,
+            "SymCryptEckeySetValue failed", scError);
         goto cleanup;
     }
 
@@ -1116,7 +1187,8 @@ SCOSSL_RETURNLENGTH scossl_eckey_compute_key(_Out_writes_bytes_(*pseclen) unsign
     *psec = OPENSSL_zalloc(*pseclen);
     if( *psec == NULL )
     {
-        SCOSSL_LOG_ERROR("OPENSSL_zalloc failed");
+        SCOSSL_LOG_ERROR(SCOSSL_ERR_F_ECKEY_COMPUTE_KEY, ERR_R_MALLOC_FAILURE,
+            "OPENSSL_zalloc failed");
         goto cleanup;
     }
 
@@ -1129,7 +1201,8 @@ SCOSSL_RETURNLENGTH scossl_eckey_compute_key(_Out_writes_bytes_(*pseclen) unsign
         *pseclen );
     if( scError != SYMCRYPT_NO_ERROR )
     {
-        SCOSSL_LOG_SYMCRYPT_ERROR("SymCryptEcDhSecretAgreement failed", scError);
+        SCOSSL_LOG_SYMCRYPT_ERROR(SCOSSL_ERR_F_ECKEY_COMPUTE_KEY, SCOSSL_ERR_R_SYMCRYPT_FAILURE,
+            "SymCryptEcDhSecretAgreement failed", scError);
         goto cleanup;
     }
 

--- a/SymCryptEngine/src/scossl_helpers.c
+++ b/SymCryptEngine/src/scossl_helpers.c
@@ -19,17 +19,78 @@ extern "C" {
 static int _traceLogLevel = SCOSSL_LOG_LEVEL_INFO;
 static char *_traceLogFilename = NULL;
 
-#define SCOSSL_ERR_UNKNOWN_FUNC_CODE        (1)
-#define SCOSSL_ERR_UNKNOWN_REASON_CODE      (1)
-
 static int _scossl_err_library_code = 0;
 
-static ERR_STRING_DATA SCOSSL_ERR_strings[] = {
-    {0,                                             "SCOSSL"},  // library name
-    {ERR_PACK(0, SCOSSL_ERR_UNKNOWN_FUNC_CODE, 0),  ""},        // unknown function name
-    {ERR_PACK(0, 0, SCOSSL_ERR_UNKNOWN_REASON_CODE),"Error"},   // unknown reason name
+static ERR_STRING_DATA SCOSSL_ERR_library_string[] = {
+    {0, "SCOSSL"},  // library name
     {0, NULL}
 };
+
+static ERR_STRING_DATA SCOSSL_ERR_function_strings[] = {
+    {ERR_PACK(0, SCOSSL_ERR_F_AES_CCM_CIPHER, 0), "scossl_aes_ccm_cipher"},
+    {ERR_PACK(0, SCOSSL_ERR_F_AES_CCM_CTRL, 0), "scossl_aes_ccm_ctrl"},
+    {ERR_PACK(0, SCOSSL_ERR_F_AES_CCM_TLS, 0), "scossl_aes_ccm_tls"},
+    {ERR_PACK(0, SCOSSL_ERR_F_AES_GCM_CTRL, 0), "scossl_aes_gcm_ctrl"},
+    {ERR_PACK(0, SCOSSL_ERR_F_AES_GCM_TLS, 0), "scossl_aes_gcm_tls"},
+    {ERR_PACK(0, SCOSSL_ERR_F_AES_XTS_CIPHER, 0), "scossl_aes_xts_cipher"},
+    {ERR_PACK(0, SCOSSL_ERR_F_AES_XTS_CTRL, 0), "scossl_aes_xts_ctrl"},
+    {ERR_PACK(0, SCOSSL_ERR_F_DH_COMPUTE_KEY, 0), "scossl_dh_compute_key"},
+    {ERR_PACK(0, SCOSSL_ERR_F_DH_GENERATE_KEY, 0), "scossl_dh_generate_key"},
+    {ERR_PACK(0, SCOSSL_ERR_F_DH_GENERATE_KEYPAIR, 0), "scossl_dh_generate_keypair"},
+    {ERR_PACK(0, SCOSSL_ERR_F_DH_IMPORT_KEYPAIR, 0), "scossl_dh_import_keypair"},
+    {ERR_PACK(0, SCOSSL_ERR_F_DIGESTS, 0), "scossl_digests"},
+    {ERR_PACK(0, SCOSSL_ERR_F_ECC_GENERATE_KEYPAIR, 0), "scossl_ecc_generate_keypair"},
+    {ERR_PACK(0, SCOSSL_ERR_F_ECC_IMPORT_KEYPAIR, 0), "scossl_ecc_import_keypair"},
+    {ERR_PACK(0, SCOSSL_ERR_F_ECDSA_APPLY_DER, 0), "scossl_ecdsa_apply_der"},
+    {ERR_PACK(0, SCOSSL_ERR_F_ECDSA_DER_CHECK_TAG_AND_GET_VALUE_AND_LENGTH, 0), "scossl_ecdsa_der_check_tag_and_get_value_and_length"},
+    {ERR_PACK(0, SCOSSL_ERR_F_ECDSA_REMOVE_DER, 0), "scossl_ecdsa_remove_der"},
+    {ERR_PACK(0, SCOSSL_ERR_F_ECKEY_COMPUTE_KEY, 0), "scossl_eckey_compute_key"},
+    {ERR_PACK(0, SCOSSL_ERR_F_ECKEY_KEYGEN, 0), "scossl_eckey_keygen"},
+    {ERR_PACK(0, SCOSSL_ERR_F_ECKEY_SIGN, 0), "scossl_eckey_sign"},
+    {ERR_PACK(0, SCOSSL_ERR_F_ECKEY_SIGN_SETUP, 0), "scossl_eckey_sign_setup"},
+    {ERR_PACK(0, SCOSSL_ERR_F_ECKEY_SIGN_SIG, 0), "scossl_eckey_sign_sig"},
+    {ERR_PACK(0, SCOSSL_ERR_F_ECKEY_VERIFY, 0), "scossl_eckey_verify"},
+    {ERR_PACK(0, SCOSSL_ERR_F_ECKEY_VERIFY_SIG, 0), "scossl_eckey_verify_sig"},
+    {ERR_PACK(0, SCOSSL_ERR_F_GET_DH_CONTEXT_EX, 0), "scossl_get_dh_context_ex"},
+    {ERR_PACK(0, SCOSSL_ERR_F_GET_ECC_CONTEXT_EX, 0), "scossl_get_ecc_context_ex"},
+    {ERR_PACK(0, SCOSSL_ERR_F_GET_SYMCRYPT_HASH_ALGORITHM, 0), "scossl_get_symcrypt_hash_algorithm"},
+    {ERR_PACK(0, SCOSSL_ERR_F_GET_SYMCRYPT_MAC_ALGORITHM, 0), "scossl_get_symcrypt_mac_algorithm"},
+    {ERR_PACK(0, SCOSSL_ERR_F_HKDF_CTRL, 0), "scossl_hkdf_ctrl"},
+    {ERR_PACK(0, SCOSSL_ERR_F_HKDF_DERIVE, 0), "scossl_hkdf_derive"},
+    {ERR_PACK(0, SCOSSL_ERR_F_HKDF_INIT, 0), "scossl_hkdf_init"},
+    {ERR_PACK(0, SCOSSL_ERR_F_INITIALIZE_RSA_KEY, 0), "scossl_initialize_rsa_key"},
+    {ERR_PACK(0, SCOSSL_ERR_F_PKEY_METHODS, 0), "scossl_pkey_methods"},
+    {ERR_PACK(0, SCOSSL_ERR_F_PKEY_RSA_SIGN, 0), "scossl_pkey_rsa_sign"},
+    {ERR_PACK(0, SCOSSL_ERR_F_PKEY_RSA_VERIFY, 0), "scossl_pkey_rsa_verify"},
+    {ERR_PACK(0, SCOSSL_ERR_F_RSA_INIT, 0), "scossl_rsa_init"},
+    {ERR_PACK(0, SCOSSL_ERR_F_RSA_KEYGEN, 0), "scossl_rsa_keygen"},
+    {ERR_PACK(0, SCOSSL_ERR_F_RSA_PRIV_DEC, 0), "scossl_rsa_priv_dec"},
+    {ERR_PACK(0, SCOSSL_ERR_F_RSA_PRIV_ENC, 0), "scossl_rsa_priv_enc"},
+    {ERR_PACK(0, SCOSSL_ERR_F_RSA_PUB_DEC, 0), "scossl_rsa_pub_dec"},
+    {ERR_PACK(0, SCOSSL_ERR_F_RSA_PUB_ENC, 0), "scossl_rsa_pub_enc"},
+    {ERR_PACK(0, SCOSSL_ERR_F_RSA_SIGN, 0), "scossl_rsa_sign"},
+    {ERR_PACK(0, SCOSSL_ERR_F_RSA_VERIFY, 0), "scossl_rsa_verify"},
+    {ERR_PACK(0, SCOSSL_ERR_F_RSAPSS_SIGN, 0), "scossl_rsapss_sign"},
+    {ERR_PACK(0, SCOSSL_ERR_F_RSAPSS_VERIFY, 0), "scossl_rsapss_verify"},
+    {ERR_PACK(0, SCOSSL_ERR_F_TLS1PRF_CTRL, 0), "scossl_tls1prf_ctrl"},
+    {ERR_PACK(0, SCOSSL_ERR_F_TLS1PRF_DERIVE, 0), "scossl_tls1prf_derive"},
+    {ERR_PACK(0, SCOSSL_ERR_F_TLS1PRF_INIT, 0), "scossl_tls1prf_init"},
+    {0, NULL}
+};
+
+C_ASSERT( (sizeof(SCOSSL_ERR_function_strings) / sizeof(ERR_STRING_DATA)) == SCOSSL_ERR_F_ENUM_END-SCOSSL_ERR_F_ENUM_START );
+
+
+static ERR_STRING_DATA SCOSSL_ERR_reason_strings[] = {
+    {ERR_PACK(0, 0, SCOSSL_ERR_R_MISSING_CTX_DATA), "Missing data in context"},
+    {ERR_PACK(0, 0, SCOSSL_ERR_R_NOT_IMPLEMENTED), "Algorithm not supported by SCOSSL"},
+    {ERR_PACK(0, 0, SCOSSL_ERR_R_NOT_FIPS_ALGORITHM), "Algorithm not FIPS certifiable"},
+    {ERR_PACK(0, 0, SCOSSL_ERR_R_OPENSSL_FALLBACK), "SCOSSL falling back to OpenSSL"},
+    {ERR_PACK(0, 0, SCOSSL_ERR_R_SYMCRYPT_FAILURE), "SCOSSL triggered SymCrypt failure"},
+    {0, NULL}
+};
+
+C_ASSERT( (sizeof(SCOSSL_ERR_reason_strings) / sizeof(ERR_STRING_DATA)) == SCOSSL_ERR_R_ENUM_END-SCOSSL_ERR_R_ENUM_START );
 
 void SCOSSL_ENGINE_setup_ERR()
 {
@@ -38,8 +99,10 @@ void SCOSSL_ENGINE_setup_ERR()
         _scossl_err_library_code = ERR_get_next_error_library();
 
         // Bind the library name "SCOSSL" to the library code
-        SCOSSL_ERR_strings[0].error = ERR_PACK(_scossl_err_library_code, 0, 0);
-        ERR_load_strings(_scossl_err_library_code, SCOSSL_ERR_strings);
+        SCOSSL_ERR_library_string[0].error = ERR_PACK(_scossl_err_library_code, 0, 0);
+        ERR_load_strings(_scossl_err_library_code, SCOSSL_ERR_library_string);
+        ERR_load_strings(_scossl_err_library_code, SCOSSL_ERR_function_strings);
+        ERR_load_strings(_scossl_err_library_code, SCOSSL_ERR_reason_strings);
     }
 }
 
@@ -90,11 +153,13 @@ static void _close_trace_log_filename(FILE *fp)
 
 void _scossl_log(
     int trace_level,
-    const char *func,
+    SCOSSL_ERR_FUNC func_code,
+    SCOSSL_ERR_REASON reason_code,
     const char *file,
     int line,
     const char *format, ...)
 {
+    char errStringBuf[SCOSSL_ENGINE_TRACELOG_PARA_LENGTH];
     char paraBuf[SCOSSL_ENGINE_TRACELOG_PARA_LENGTH];
     FILE *fp = NULL;
     va_list args;
@@ -119,10 +184,6 @@ void _scossl_log(
         default:
             break;
     }
-    if( func == NULL )
-    {
-        func = "";
-    }
     if( format == NULL )
     {
         format = "";
@@ -131,25 +192,26 @@ void _scossl_log(
     {
         *paraBuf = '\0';
     }
+
+    // Log an OpenSSL error, so calling applications can handle the log appropriately
+    ERR_put_error(_scossl_err_library_code, func_code, reason_code, file, line);
+    // Add error string indicating the error details as error data
+    ERR_add_error_data(1, paraBuf);
+
+    // Log details to stderr or a log file
+    ERR_error_string_n(ERR_PACK(_scossl_err_library_code, func_code, reason_code), errStringBuf, sizeof(errStringBuf));
+
     fp = _open_trace_log_filename();
-    fprintf(fp, "[%s] %s: %s at %s, line %d\n", trace_level_prefix, func, paraBuf, file, line);
+    fprintf(fp, "[%s] %s:%s at %s, line %d\n", trace_level_prefix, errStringBuf, paraBuf, file, line);
     _close_trace_log_filename(fp);
 
-    // Also log an OpenSSL error for errors, so calling applications can handle them appropriately
-    if( trace_level == SCOSSL_LOG_LEVEL_ERROR )
-    {
-        ERR_PUT_error(_scossl_err_library_code, SCOSSL_ERR_UNKNOWN_FUNC_CODE, SCOSSL_ERR_UNKNOWN_REASON_CODE, file, line);
-
-        // Add error strings indicating the function and the error details as error data, rather
-        // than explicitly specifying all functions and error reasons ahead of time
-        ERR_add_error_data(3, func, ":", paraBuf);
-    }
     return;
 }
 
 void _scossl_log_bytes(
     int trace_level,
-    const char *func,
+    SCOSSL_ERR_FUNC func_code,
+    SCOSSL_ERR_REASON reason_code,
     const char *file,
     int line,
     char *description,
@@ -161,7 +223,7 @@ void _scossl_log_bytes(
         return;
     }
     FILE *fp = NULL;
-    _scossl_log(trace_level, func, file, line, description);
+    _scossl_log(trace_level, func_code, reason_code, file, line, description);
     fp = _open_trace_log_filename();
     BIO_dump_fp(fp, s, len);
     _close_trace_log_filename(fp);
@@ -170,7 +232,8 @@ void _scossl_log_bytes(
 
 void _scossl_log_bignum(
     int trace_level,
-    const char *func,
+    SCOSSL_ERR_FUNC func_code,
+    SCOSSL_ERR_REASON reason_code,
     const char *file,
     int line,
     char *description,
@@ -206,14 +269,15 @@ void _scossl_log_bignum(
         return;
     }
 
-    _scossl_log_bytes(trace_level, func, file, line, description, (const char*) string, length);
+    _scossl_log_bytes(trace_level, func_code, reason_code, file, line, description, (const char*) string, length);
     OPENSSL_free(string);
     return;
 }
 
 void _scossl_log_SYMCRYPT_ERROR(
     int trace_level,
-    const char *func,
+    SCOSSL_ERR_FUNC func_code,
+    SCOSSL_ERR_REASON reason_code,
     const char *file,
     int line,
     char *description,
@@ -222,67 +286,67 @@ void _scossl_log_SYMCRYPT_ERROR(
     switch( scError  )
     {
         case SYMCRYPT_NO_ERROR:
-            _scossl_log(trace_level, func, file, line, "%s - SYMCRYPT_NO_ERROR (0x%x)", description, scError);
+            _scossl_log(trace_level, func_code, reason_code, file, line, "%s - SYMCRYPT_NO_ERROR (0x%x)", description, scError);
             break;
         case SYMCRYPT_UNUSED:
-            _scossl_log(trace_level, func, file, line, "%s - SYMCRYPT_UNUSED (0x%x)", description, scError);
+            _scossl_log(trace_level, func_code, reason_code, file, line, "%s - SYMCRYPT_UNUSED (0x%x)", description, scError);
             break;
         case SYMCRYPT_WRONG_KEY_SIZE:
-            _scossl_log(trace_level, func, file, line, "%s - SYMCRYPT_WRONG_KEY_SIZE (0x%x)", description, scError);
+            _scossl_log(trace_level, func_code, reason_code, file, line, "%s - SYMCRYPT_WRONG_KEY_SIZE (0x%x)", description, scError);
             break;
         case SYMCRYPT_WRONG_BLOCK_SIZE:
-            _scossl_log(trace_level, func, file, line, "%s - SYMCRYPT_WRONG_BLOCK_SIZE (0x%x)", description, scError);
+            _scossl_log(trace_level, func_code, reason_code, file, line, "%s - SYMCRYPT_WRONG_BLOCK_SIZE (0x%x)", description, scError);
             break;
         case SYMCRYPT_WRONG_DATA_SIZE:
-            _scossl_log(trace_level, func, file, line, "%s - SYMCRYPT_WRONG_DATA_SIZE (0x%x)", description, scError);
+            _scossl_log(trace_level, func_code, reason_code, file, line, "%s - SYMCRYPT_WRONG_DATA_SIZE (0x%x)", description, scError);
             break;
         case SYMCRYPT_WRONG_NONCE_SIZE:
-            _scossl_log(trace_level, func, file, line, "%s - SYMCRYPT_WRONG_NONCE_SIZE (0x%x)", description, scError);
+            _scossl_log(trace_level, func_code, reason_code, file, line, "%s - SYMCRYPT_WRONG_NONCE_SIZE (0x%x)", description, scError);
             break;
         case SYMCRYPT_WRONG_TAG_SIZE:
-            _scossl_log(trace_level, func, file, line, "%s - SYMCRYPT_WRONG_TAG_SIZE (0x%x)", description, scError);
+            _scossl_log(trace_level, func_code, reason_code, file, line, "%s - SYMCRYPT_WRONG_TAG_SIZE (0x%x)", description, scError);
             break;
         case SYMCRYPT_WRONG_ITERATION_COUNT:
-            _scossl_log(trace_level, func, file, line, "%s - SYMCRYPT_WRONG_ITERATION_COUNT (0x%x)", description, scError);
+            _scossl_log(trace_level, func_code, reason_code, file, line, "%s - SYMCRYPT_WRONG_ITERATION_COUNT (0x%x)", description, scError);
             break;
         case SYMCRYPT_AUTHENTICATION_FAILURE:
-            _scossl_log(trace_level, func, file, line, "%s - SYMCRYPT_AUTHENTICATION_FAILURE (0x%x)", description, scError);
+            _scossl_log(trace_level, func_code, reason_code, file, line, "%s - SYMCRYPT_AUTHENTICATION_FAILURE (0x%x)", description, scError);
             break;
         case SYMCRYPT_EXTERNAL_FAILURE:
-            _scossl_log(trace_level, func, file, line, "%s - SYMCRYPT_EXTERNAL_FAILURE (0x%x)", description, scError);
+            _scossl_log(trace_level, func_code, reason_code, file, line, "%s - SYMCRYPT_EXTERNAL_FAILURE (0x%x)", description, scError);
             break;
         case SYMCRYPT_FIPS_FAILURE:
-            _scossl_log(trace_level, func, file, line, "%s - SYMCRYPT_FIPS_FAILURE (0x%x)", description, scError);
+            _scossl_log(trace_level, func_code, reason_code, file, line, "%s - SYMCRYPT_FIPS_FAILURE (0x%x)", description, scError);
             break;
         case SYMCRYPT_HARDWARE_FAILURE:
-            _scossl_log(trace_level, func, file, line, "%s - SYMCRYPT_HARDWARE_FAILURE (0x%x)", description, scError);
+            _scossl_log(trace_level, func_code, reason_code, file, line, "%s - SYMCRYPT_HARDWARE_FAILURE (0x%x)", description, scError);
             break;
         case SYMCRYPT_NOT_IMPLEMENTED:
-            _scossl_log(trace_level, func, file, line, "%s - SYMCRYPT_NOT_IMPLEMENTED (0x%x)", description, scError);
+            _scossl_log(trace_level, func_code, reason_code, file, line, "%s - SYMCRYPT_NOT_IMPLEMENTED (0x%x)", description, scError);
             break;
         case SYMCRYPT_INVALID_BLOB:
-            _scossl_log(trace_level, func, file, line, "%s - SYMCRYPT_INVALID_BLOB (0x%x)", description, scError);
+            _scossl_log(trace_level, func_code, reason_code, file, line, "%s - SYMCRYPT_INVALID_BLOB (0x%x)", description, scError);
             break;
         case SYMCRYPT_BUFFER_TOO_SMALL:
-            _scossl_log(trace_level, func, file, line, "%s - SYMCRYPT_BUFFER_TOO_SMALL (0x%x)", description, scError);
+            _scossl_log(trace_level, func_code, reason_code, file, line, "%s - SYMCRYPT_BUFFER_TOO_SMALL (0x%x)", description, scError);
             break;
         case SYMCRYPT_INVALID_ARGUMENT:
-            _scossl_log(trace_level, func, file, line, "%s - SYMCRYPT_INVALID_ARGUMENT (0x%x)", description, scError);
+            _scossl_log(trace_level, func_code, reason_code, file, line, "%s - SYMCRYPT_INVALID_ARGUMENT (0x%x)", description, scError);
             break;
         case SYMCRYPT_MEMORY_ALLOCATION_FAILURE:
-            _scossl_log(trace_level, func, file, line, "%s - SYMCRYPT_MEMORY_ALLOCATION_FAILURE (0x%x)", description, scError);
+            _scossl_log(trace_level, func_code, reason_code, file, line, "%s - SYMCRYPT_MEMORY_ALLOCATION_FAILURE (0x%x)", description, scError);
             break;
         case SYMCRYPT_SIGNATURE_VERIFICATION_FAILURE:
-            _scossl_log(trace_level, func, file, line, "%s - SYMCRYPT_SIGNATURE_VERIFICATION_FAILURE (0x%x)", description, scError);
+            _scossl_log(trace_level, func_code, reason_code, file, line, "%s - SYMCRYPT_SIGNATURE_VERIFICATION_FAILURE (0x%x)", description, scError);
             break;
         case SYMCRYPT_INCOMPATIBLE_FORMAT:
-            _scossl_log(trace_level, func, file, line, "%s - SYMCRYPT_INCOMPATIBLE_FORMAT (0x%x)", description, scError);
+            _scossl_log(trace_level, func_code, reason_code, file, line, "%s - SYMCRYPT_INCOMPATIBLE_FORMAT (0x%x)", description, scError);
             break;
         case SYMCRYPT_VALUE_TOO_LARGE:
-            _scossl_log(trace_level, func, file, line, "%s - SYMCRYPT_VALUE_TOO_LARGE (0x%x)", description, scError);
+            _scossl_log(trace_level, func_code, reason_code, file, line, "%s - SYMCRYPT_VALUE_TOO_LARGE (0x%x)", description, scError);
             break;
         default:
-            _scossl_log(trace_level, func, file, line, "%s - UNKNOWN SYMCRYPT_ERROR (0x%x)", description, scError);
+            _scossl_log(trace_level, func_code, reason_code, file, line, "%s - UNKNOWN SYMCRYPT_ERROR (0x%x)", description, scError);
             break;
     }
 }

--- a/SymCryptEngine/src/scossl_helpers.h
+++ b/SymCryptEngine/src/scossl_helpers.h
@@ -2,6 +2,8 @@
 // Copyright (c) Microsoft Corporation. Licensed under the MIT license.
 //
 
+#pragma once
+
 #include "scossl.h"
 #include <symcrypt.h>
 #include <string.h>
@@ -31,16 +33,83 @@ void SCOSSL_ENGINE_free(void *mem);
 
 void SCOSSL_ENGINE_setup_ERR();
 
+// SCOSSL function codes
+typedef enum {
+    SCOSSL_ERR_F_ENUM_START= 100,
+    SCOSSL_ERR_F_AES_CCM_CIPHER,
+    SCOSSL_ERR_F_AES_CCM_CTRL,
+    SCOSSL_ERR_F_AES_CCM_TLS,
+    SCOSSL_ERR_F_AES_GCM_CTRL,
+    SCOSSL_ERR_F_AES_GCM_TLS,
+    SCOSSL_ERR_F_AES_XTS_CIPHER,
+    SCOSSL_ERR_F_AES_XTS_CTRL,
+    SCOSSL_ERR_F_DH_COMPUTE_KEY,
+    SCOSSL_ERR_F_DH_GENERATE_KEY,
+    SCOSSL_ERR_F_DH_GENERATE_KEYPAIR,
+    SCOSSL_ERR_F_DH_IMPORT_KEYPAIR,
+    SCOSSL_ERR_F_DIGESTS,
+    SCOSSL_ERR_F_ECC_GENERATE_KEYPAIR,
+    SCOSSL_ERR_F_ECC_IMPORT_KEYPAIR,
+    SCOSSL_ERR_F_ECDSA_APPLY_DER,
+    SCOSSL_ERR_F_ECDSA_DER_CHECK_TAG_AND_GET_VALUE_AND_LENGTH,
+    SCOSSL_ERR_F_ECDSA_REMOVE_DER,
+    SCOSSL_ERR_F_ECKEY_COMPUTE_KEY,
+    SCOSSL_ERR_F_ECKEY_KEYGEN,
+    SCOSSL_ERR_F_ECKEY_SIGN,
+    SCOSSL_ERR_F_ECKEY_SIGN_SETUP,
+    SCOSSL_ERR_F_ECKEY_SIGN_SIG,
+    SCOSSL_ERR_F_ECKEY_VERIFY,
+    SCOSSL_ERR_F_ECKEY_VERIFY_SIG,
+    SCOSSL_ERR_F_GET_DH_CONTEXT_EX,
+    SCOSSL_ERR_F_GET_ECC_CONTEXT_EX,
+    SCOSSL_ERR_F_GET_SYMCRYPT_HASH_ALGORITHM,
+    SCOSSL_ERR_F_GET_SYMCRYPT_MAC_ALGORITHM,
+    SCOSSL_ERR_F_HKDF_CTRL,
+    SCOSSL_ERR_F_HKDF_DERIVE,
+    SCOSSL_ERR_F_HKDF_INIT,
+    SCOSSL_ERR_F_INITIALIZE_RSA_KEY,
+    SCOSSL_ERR_F_PKEY_METHODS,
+    SCOSSL_ERR_F_PKEY_RSA_SIGN,
+    SCOSSL_ERR_F_PKEY_RSA_VERIFY,
+    SCOSSL_ERR_F_RSA_INIT,
+    SCOSSL_ERR_F_RSA_KEYGEN,
+    SCOSSL_ERR_F_RSA_PRIV_DEC,
+    SCOSSL_ERR_F_RSA_PRIV_ENC,
+    SCOSSL_ERR_F_RSA_PUB_DEC,
+    SCOSSL_ERR_F_RSA_PUB_ENC,
+    SCOSSL_ERR_F_RSA_SIGN,
+    SCOSSL_ERR_F_RSA_VERIFY,
+    SCOSSL_ERR_F_RSAPSS_SIGN,
+    SCOSSL_ERR_F_RSAPSS_VERIFY,
+    SCOSSL_ERR_F_TLS1PRF_CTRL,
+    SCOSSL_ERR_F_TLS1PRF_DERIVE,
+    SCOSSL_ERR_F_TLS1PRF_INIT,
+    SCOSSL_ERR_F_ENUM_END
+} SCOSSL_ERR_FUNC;
+
+// SCOSSL reason codes
+typedef enum {
+    SCOSSL_ERR_R_ENUM_START = 100,
+    SCOSSL_ERR_R_MISSING_CTX_DATA,
+    SCOSSL_ERR_R_NOT_IMPLEMENTED,
+    SCOSSL_ERR_R_NOT_FIPS_ALGORITHM,
+    SCOSSL_ERR_R_OPENSSL_FALLBACK,
+    SCOSSL_ERR_R_SYMCRYPT_FAILURE,
+    SCOSSL_ERR_R_ENUM_END
+} SCOSSL_ERR_REASON;
+
 void _scossl_log(
     int trace_level,
-    const char *func,
+    SCOSSL_ERR_FUNC func_code,
+    SCOSSL_ERR_REASON reason_code, // can also accept generic ERR_R_* values specified by OpenSSL
     const char *file,
     int line,
     const char *format, ...);
 
 void _scossl_log_bytes(
     int trace_level,
-    const char *func,
+    SCOSSL_ERR_FUNC func_code,
+    SCOSSL_ERR_REASON reason_code,
     const char *file,
     int line,
     char *description,
@@ -49,7 +118,8 @@ void _scossl_log_bytes(
 
 void _scossl_log_bignum(
     int trace_level,
-    const char *func,
+    SCOSSL_ERR_FUNC func_code,
+    SCOSSL_ERR_REASON reason_code,
     const char *file,
     int line,
     char *description,
@@ -57,7 +127,8 @@ void _scossl_log_bignum(
 
 void _scossl_log_SYMCRYPT_ERROR(
     int trace_level,
-    const char *func,
+    SCOSSL_ERR_FUNC func_code,
+    SCOSSL_ERR_REASON reason_code,
     const char *file,
     int line,
     char *description,
@@ -65,51 +136,51 @@ void _scossl_log_SYMCRYPT_ERROR(
 
 // Enable debug and info messages in debug builds, but compile them out in release builds
 #if DBG
-    #define SCOSSL_LOG_DEBUG(...) \
-        _scossl_log(SCOSSL_LOG_LEVEL_DEBUG, __func__, __FILE__, __LINE__, __VA_ARGS__)
+    #define SCOSSL_LOG_DEBUG(func_code, reason_code, ...) \
+        _scossl_log(SCOSSL_LOG_LEVEL_DEBUG, func_code, reason_code, __FILE__, __LINE__, __VA_ARGS__)
 
-    #define SCOSSL_LOG_INFO(...) \
-        _scossl_log(SCOSSL_LOG_LEVEL_INFO, __func__, __FILE__, __LINE__, __VA_ARGS__)
+    #define SCOSSL_LOG_INFO(func_code, reason_code, ...) \
+        _scossl_log(SCOSSL_LOG_LEVEL_INFO, func_code, reason_code, __FILE__, __LINE__, __VA_ARGS__)
 
-    #define SCOSSL_LOG_BYTES_DEBUG(description, s, len) \
-        _scossl_log_bytes(SCOSSL_LOG_LEVEL_DEBUG, __func__, __FILE__, __LINE__, description, (const char*) s, len)
+    #define SCOSSL_LOG_BYTES_DEBUG(func_code, reason_code, description, s, len) \
+        _scossl_log_bytes(SCOSSL_LOG_LEVEL_DEBUG, func_code, reason_code, __FILE__, __LINE__, description, (const char*) s, len)
 
-    #define SCOSSL_LOG_BYTES_INFO(description, s, len) \
-        _scossl_log_bytes(SCOSSL_LOG_LEVEL_INFO, __func__, __FILE__, __LINE__, description, (const char*) s, len)
+    #define SCOSSL_LOG_BYTES_INFO(func_code, reason_code, description, s, len) \
+        _scossl_log_bytes(SCOSSL_LOG_LEVEL_INFO, func_code, reason_code, __FILE__, __LINE__, description, (const char*) s, len)
 
-    #define SCOSSL_LOG_BIGNUM_DEBUG(description, bn) \
-        _scossl_log_bignum(SCOSSL_LOG_LEVEL_DEBUG, __func__, __FILE__, __LINE__, description, bn)
+    #define SCOSSL_LOG_BIGNUM_DEBUG(func_code, reason_code, description, bn) \
+        _scossl_log_bignum(SCOSSL_LOG_LEVEL_DEBUG, func_code, reason_code, __FILE__, __LINE__, description, bn)
 
-    #define SCOSSL_LOG_BIGNUM_INFO(description, s, len) \
-        _scossl_log_bignum(SCOSSL_LOG_LEVEL_INFO, __func__, __FILE__, __LINE__, description, bn)
+    #define SCOSSL_LOG_BIGNUM_INFO(func_code, reason_code, description, s, len) \
+        _scossl_log_bignum(SCOSSL_LOG_LEVEL_INFO, func_code, reason_code, __FILE__, __LINE__, description, bn)
 
-    #define SCOSSL_LOG_SYMCRYPT_DEBUG(description, scError) \
-        _scossl_log_SYMCRYPT_ERROR(SCOSSL_LOG_LEVEL_DEBUG, __func__, __FILE__, __LINE__, description, scError)
+    #define SCOSSL_LOG_SYMCRYPT_DEBUG(func_code, reason_code, description, scError) \
+        _scossl_log_SYMCRYPT_ERROR(SCOSSL_LOG_LEVEL_DEBUG, func_code, reason_code, __FILE__, __LINE__, description, scError)
 
-    #define SCOSSL_LOG_SYMCRYPT_INFO(description, scError) \
-        _scossl_log_SYMCRYPT_ERROR(SCOSSL_LOG_LEVEL_INFO, __func__, __FILE__, __LINE__, description, scError)
+    #define SCOSSL_LOG_SYMCRYPT_INFO(func_code, reason_code, description, scError) \
+        _scossl_log_SYMCRYPT_ERROR(SCOSSL_LOG_LEVEL_INFO, func_code, reason_code, __FILE__, __LINE__, description, scError)
 #else
-    #define SCOSSL_LOG_DEBUG(...)
-    #define SCOSSL_LOG_INFO(...)
-    #define SCOSSL_LOG_BYTES_DEBUG(description, s, len)
-    #define SCOSSL_LOG_BYTES_INFO(description, s, len)
-    #define SCOSSL_LOG_BIGNUM_DEBUG(description, bn)
-    #define SCOSSL_LOG_BIGNUM_INFO(description, s, len)
-    #define SCOSSL_LOG_SYMCRYPT_DEBUG(description, scError)
-    #define SCOSSL_LOG_SYMCRYPT_INFO(description, scError)
+    #define SCOSSL_LOG_DEBUG(func_code, reason_code, ...)
+    #define SCOSSL_LOG_INFO(func_code, reason_code, ...)
+    #define SCOSSL_LOG_BYTES_DEBUG(func_code, reason_code, description, s, len)
+    #define SCOSSL_LOG_BYTES_INFO(func_code, reason_code, description, s, len)
+    #define SCOSSL_LOG_BIGNUM_DEBUG(func_code, reason_code, description, bn)
+    #define SCOSSL_LOG_BIGNUM_INFO(func_code, reason_code, description, s, len)
+    #define SCOSSL_LOG_SYMCRYPT_DEBUG(func_code, reason_code, description, scError)
+    #define SCOSSL_LOG_SYMCRYPT_INFO(func_code, reason_code, description, scError)
 #endif
 
-#define SCOSSL_LOG_ERROR(...) \
-    _scossl_log(SCOSSL_LOG_LEVEL_ERROR, __func__, __FILE__, __LINE__, __VA_ARGS__)
+#define SCOSSL_LOG_ERROR(func_code, reason_code, ...) \
+    _scossl_log(SCOSSL_LOG_LEVEL_ERROR, func_code, reason_code, __FILE__, __LINE__, __VA_ARGS__)
 
-#define SCOSSL_LOG_BYTES_ERROR(description, s, len) \
-    _scossl_log_bytes(SCOSSL_LOG_LEVEL_ERROR, __func__, __FILE__, __LINE__, description, (const char*) s, len)
+#define SCOSSL_LOG_BYTES_ERROR(func_code, reason_code, description, s, len) \
+    _scossl_log_bytes(SCOSSL_LOG_LEVEL_ERROR, func_code, reason_code, __FILE__, __LINE__, description, (const char*) s, len)
 
-#define SCOSSL_LOG_BIGNUM_ERROR(description, s, len) \
-    _scossl_log_bignum(SCOSSL_LOG_LEVEL_ERROR, __func__, __FILE__, __LINE__, description, bn)
+#define SCOSSL_LOG_BIGNUM_ERROR(func_code, reason_code, description, s, len) \
+    _scossl_log_bignum(SCOSSL_LOG_LEVEL_ERROR, func_code, reason_code, __FILE__, __LINE__, description, bn)
 
-#define SCOSSL_LOG_SYMCRYPT_ERROR(description, scError) \
-    _scossl_log_SYMCRYPT_ERROR(SCOSSL_LOG_LEVEL_ERROR, __func__, __FILE__, __LINE__, description, scError)
+#define SCOSSL_LOG_SYMCRYPT_ERROR(func_code, reason_code, description, scError) \
+    _scossl_log_SYMCRYPT_ERROR(SCOSSL_LOG_LEVEL_ERROR, func_code, reason_code, __FILE__, __LINE__, description, scError)
 
 #ifdef __cplusplus
 }

--- a/SymCryptEngine/src/scossl_helpers.h
+++ b/SymCryptEngine/src/scossl_helpers.h
@@ -112,9 +112,9 @@ void _scossl_log_bytes(
     SCOSSL_ERR_REASON reason_code,
     const char *file,
     int line,
-    char *description,
     const char *s,
-    int len);
+    int len,
+    const char *format, ...);
 
 void _scossl_log_bignum(
     int trace_level,
@@ -143,10 +143,10 @@ void _scossl_log_SYMCRYPT_ERROR(
         _scossl_log(SCOSSL_LOG_LEVEL_INFO, func_code, reason_code, __FILE__, __LINE__, __VA_ARGS__)
 
     #define SCOSSL_LOG_BYTES_DEBUG(func_code, reason_code, description, s, len) \
-        _scossl_log_bytes(SCOSSL_LOG_LEVEL_DEBUG, func_code, reason_code, __FILE__, __LINE__, description, (const char*) s, len)
+        _scossl_log_bytes(SCOSSL_LOG_LEVEL_DEBUG, func_code, reason_code, __FILE__, __LINE__, (const char*) s, len, description)
 
     #define SCOSSL_LOG_BYTES_INFO(func_code, reason_code, description, s, len) \
-        _scossl_log_bytes(SCOSSL_LOG_LEVEL_INFO, func_code, reason_code, __FILE__, __LINE__, description, (const char*) s, len)
+        _scossl_log_bytes(SCOSSL_LOG_LEVEL_INFO, func_code, reason_code, __FILE__, __LINE__, (const char*) s, len, description)
 
     #define SCOSSL_LOG_BIGNUM_DEBUG(func_code, reason_code, description, bn) \
         _scossl_log_bignum(SCOSSL_LOG_LEVEL_DEBUG, func_code, reason_code, __FILE__, __LINE__, description, bn)
@@ -174,7 +174,7 @@ void _scossl_log_SYMCRYPT_ERROR(
     _scossl_log(SCOSSL_LOG_LEVEL_ERROR, func_code, reason_code, __FILE__, __LINE__, __VA_ARGS__)
 
 #define SCOSSL_LOG_BYTES_ERROR(func_code, reason_code, description, s, len) \
-    _scossl_log_bytes(SCOSSL_LOG_LEVEL_ERROR, func_code, reason_code, __FILE__, __LINE__, description, (const char*) s, len)
+    _scossl_log_bytes(SCOSSL_LOG_LEVEL_ERROR, func_code, reason_code, __FILE__, __LINE__, (const char*) s, len, description)
 
 #define SCOSSL_LOG_BIGNUM_ERROR(func_code, reason_code, description, s, len) \
     _scossl_log_bignum(SCOSSL_LOG_LEVEL_ERROR, func_code, reason_code, __FILE__, __LINE__, description, bn)

--- a/SymCryptEngine/src/scossl_helpers.h
+++ b/SymCryptEngine/src/scossl_helpers.h
@@ -29,14 +29,20 @@ void* SCOSSL_ENGINE_zalloc(size_t num);
 void* SCOSSL_ENGINE_realloc(void *mem, size_t num);
 void SCOSSL_ENGINE_free(void *mem);
 
+void SCOSSL_ENGINE_setup_ERR();
+
 void _scossl_log(
     int trace_level,
     const char *func,
+    const char *file,
+    int line,
     const char *format, ...);
 
 void _scossl_log_bytes(
     int trace_level,
     const char *func,
+    const char *file,
+    int line,
     char *description,
     const char *s,
     int len);
@@ -44,40 +50,44 @@ void _scossl_log_bytes(
 void _scossl_log_bignum(
     int trace_level,
     const char *func,
+    const char *file,
+    int line,
     char *description,
     BIGNUM *bn);
 
 void _scossl_log_SYMCRYPT_ERROR(
     int trace_level,
     const char *func,
+    const char *file,
+    int line,
     char *description,
     SYMCRYPT_ERROR scError);
 
 // Enable debug and info messages in debug builds, but compile them out in release builds
 #if DBG
     #define SCOSSL_LOG_DEBUG(...) \
-        _scossl_log(SCOSSL_LOG_LEVEL_DEBUG, __func__, __VA_ARGS__)
+        _scossl_log(SCOSSL_LOG_LEVEL_DEBUG, __func__, __FILE__, __LINE__, __VA_ARGS__)
 
     #define SCOSSL_LOG_INFO(...) \
-        _scossl_log(SCOSSL_LOG_LEVEL_INFO, __func__, __VA_ARGS__)
+        _scossl_log(SCOSSL_LOG_LEVEL_INFO, __func__, __FILE__, __LINE__, __VA_ARGS__)
 
     #define SCOSSL_LOG_BYTES_DEBUG(description, s, len) \
-        _scossl_log_bytes(SCOSSL_LOG_LEVEL_DEBUG, __func__, description, (const char*) s, len)
+        _scossl_log_bytes(SCOSSL_LOG_LEVEL_DEBUG, __func__, __FILE__, __LINE__, description, (const char*) s, len)
 
     #define SCOSSL_LOG_BYTES_INFO(description, s, len) \
-        _scossl_log_bytes(SCOSSL_LOG_LEVEL_INFO, __func__, description, (const char*) s, len)
+        _scossl_log_bytes(SCOSSL_LOG_LEVEL_INFO, __func__, __FILE__, __LINE__, description, (const char*) s, len)
 
     #define SCOSSL_LOG_BIGNUM_DEBUG(description, bn) \
-        _scossl_log_bignum(SCOSSL_LOG_LEVEL_DEBUG, __func__, description, bn)
+        _scossl_log_bignum(SCOSSL_LOG_LEVEL_DEBUG, __func__, __FILE__, __LINE__, description, bn)
 
     #define SCOSSL_LOG_BIGNUM_INFO(description, s, len) \
-        _scossl_log_bignum(SCOSSL_LOG_LEVEL_INFO, __func__, description, bn)
+        _scossl_log_bignum(SCOSSL_LOG_LEVEL_INFO, __func__, __FILE__, __LINE__, description, bn)
 
     #define SCOSSL_LOG_SYMCRYPT_DEBUG(description, scError) \
-        _scossl_log_SYMCRYPT_ERROR(SCOSSL_LOG_LEVEL_DEBUG, __func__, description, scError)
+        _scossl_log_SYMCRYPT_ERROR(SCOSSL_LOG_LEVEL_DEBUG, __func__, __FILE__, __LINE__, description, scError)
 
     #define SCOSSL_LOG_SYMCRYPT_INFO(description, scError) \
-        _scossl_log_SYMCRYPT_ERROR(SCOSSL_LOG_LEVEL_INFO, __func__, description, scError)
+        _scossl_log_SYMCRYPT_ERROR(SCOSSL_LOG_LEVEL_INFO, __func__, __FILE__, __LINE__, description, scError)
 #else
     #define SCOSSL_LOG_DEBUG(...)
     #define SCOSSL_LOG_INFO(...)
@@ -90,16 +100,16 @@ void _scossl_log_SYMCRYPT_ERROR(
 #endif
 
 #define SCOSSL_LOG_ERROR(...) \
-    _scossl_log(SCOSSL_LOG_LEVEL_ERROR, __FUNCTION__, __VA_ARGS__)
+    _scossl_log(SCOSSL_LOG_LEVEL_ERROR, __func__, __FILE__, __LINE__, __VA_ARGS__)
 
 #define SCOSSL_LOG_BYTES_ERROR(description, s, len) \
-    _scossl_log_bytes(SCOSSL_LOG_LEVEL_ERROR, __FUNCTION__, description, (const char*) s, len)
+    _scossl_log_bytes(SCOSSL_LOG_LEVEL_ERROR, __func__, __FILE__, __LINE__, description, (const char*) s, len)
 
 #define SCOSSL_LOG_BIGNUM_ERROR(description, s, len) \
-    _scossl_log_bignum(SCOSSL_LOG_LEVEL_ERROR, __FUNCTION__, description, bn)
+    _scossl_log_bignum(SCOSSL_LOG_LEVEL_ERROR, __func__, __FILE__, __LINE__, description, bn)
 
 #define SCOSSL_LOG_SYMCRYPT_ERROR(description, scError) \
-    _scossl_log_SYMCRYPT_ERROR(SCOSSL_LOG_LEVEL_ERROR, __FUNCTION__, description, scError)
+    _scossl_log_SYMCRYPT_ERROR(SCOSSL_LOG_LEVEL_ERROR, __func__, __FILE__, __LINE__, description, scError)
 
 #ifdef __cplusplus
 }

--- a/SymCryptEngine/src/scossl_hkdf.c
+++ b/SymCryptEngine/src/scossl_hkdf.c
@@ -27,7 +27,8 @@ SCOSSL_STATUS scossl_hkdf_init(_Inout_ EVP_PKEY_CTX *ctx)
 {
     SCOSSL_HKDF_PKEY_CTX *scossl_hkdf_context;
     if ((scossl_hkdf_context = OPENSSL_zalloc(sizeof(*scossl_hkdf_context))) == NULL) {
-        SCOSSL_LOG_ERROR("Memory Allocation Error");
+        SCOSSL_LOG_ERROR(SCOSSL_ERR_F_HKDF_INIT, ERR_R_MALLOC_FAILURE,
+            "OPENSSL_zalloc returned NULL");
         return SCOSSL_FAILURE;
     }
     EVP_PKEY_CTX_set_data(ctx, scossl_hkdf_context);
@@ -92,7 +93,8 @@ SCOSSL_STATUS scossl_hkdf_ctrl(EVP_PKEY_CTX *ctx, int type, int p1, void *p2)
         scossl_hkdf_context->info_len += p1;
         return SCOSSL_SUCCESS;
     default:
-        SCOSSL_LOG_ERROR("SymCrypt Engine does not support ctrl type (%d)", type);
+        SCOSSL_LOG_ERROR(SCOSSL_ERR_F_HKDF_CTRL, SCOSSL_ERR_R_NOT_IMPLEMENTED,
+            "SymCrypt Engine does not support ctrl type (%d)", type);
         return SCOSSL_UNSUPPORTED;
     }
 }
@@ -218,7 +220,8 @@ static PCSYMCRYPT_MAC scossl_get_symcrypt_mac_algorithm( _In_ const EVP_MD *evp_
         return SymCryptHmacSha512Algorithm;
     // if (type == NID_AES_CMC)
     //     return SymCryptAesCmacAlgorithm;
-    SCOSSL_LOG_ERROR("SymCrypt engine does not support Mac algorithm %d", type);
+    SCOSSL_LOG_ERROR(SCOSSL_ERR_F_GET_SYMCRYPT_MAC_ALGORITHM, SCOSSL_ERR_R_NOT_IMPLEMENTED,
+        "SymCrypt engine does not support Mac algorithm %d", type);
     return NULL;
 }
 
@@ -231,12 +234,14 @@ SCOSSL_STATUS scossl_hkdf_derive(_Inout_ EVP_PKEY_CTX *ctx, _Out_writes_opt_(*ke
     // SYMCRYPT_HKDF_EXPANDED_KEY  scExpandedKey;
 
     if (scossl_hkdf_context->md == NULL) {
-        SCOSSL_LOG_ERROR("Missing Digest");
+        SCOSSL_LOG_ERROR(SCOSSL_ERR_F_HKDF_DERIVE, ERR_R_INTERNAL_ERROR,
+            "Missing Digest");
         return SCOSSL_FAILURE;
     }
     scossl_mac_algo = scossl_get_symcrypt_mac_algorithm(scossl_hkdf_context->md);
     if (scossl_hkdf_context->key == NULL) {
-        SCOSSL_LOG_ERROR("Missing Key");
+        SCOSSL_LOG_ERROR(SCOSSL_ERR_F_HKDF_DERIVE, ERR_R_INTERNAL_ERROR,
+            "Missing Key");
         return SCOSSL_FAILURE;
     }
 
@@ -261,7 +266,8 @@ SCOSSL_STATUS scossl_hkdf_derive(_Inout_ EVP_PKEY_CTX *ctx, _Out_writes_opt_(*ke
         }
         else
         {
-            SCOSSL_LOG_INFO("SymCrypt engine does not support Mac algorithm %d - falling back to OpenSSL", EVP_MD_type(scossl_hkdf_context->md));
+            SCOSSL_LOG_INFO(SCOSSL_ERR_F_HKDF_DERIVE, SCOSSL_ERR_R_OPENSSL_FALLBACK,
+                "SymCrypt engine does not support Mac algorithm %d - falling back to OpenSSL", EVP_MD_type(scossl_hkdf_context->md));
 
             return HKDF(
                 scossl_hkdf_context->md,
@@ -288,7 +294,8 @@ SCOSSL_STATUS scossl_hkdf_derive(_Inout_ EVP_PKEY_CTX *ctx, _Out_writes_opt_(*ke
         //     scossl_hkdf_context->salt_len);
         // if (SymCryptError != SYMCRYPT_NO_ERROR)
         // {
-        //     SCOSSL_LOG_SYMCRYPT_DEBUG("SymCryptHkdfExpandKey failed", scError);
+        //     SCOSSL_LOG_SYMCRYPT_DEBUG(SCOSSL_ERR_F_HKDF_DERIVE, SCOSSL_ERR_R_SYMCRYPT_FAILURE,
+        //         "SymCryptHkdfExpandKey failed", scError);
         //     return SCOSSL_FAILURE;
         // }
 
@@ -316,7 +323,8 @@ SCOSSL_STATUS scossl_hkdf_derive(_Inout_ EVP_PKEY_CTX *ctx, _Out_writes_opt_(*ke
         //                     *keylen);
         // if (SymCryptError != SYMCRYPT_NO_ERROR)
         // {
-        //     SCOSSL_LOG_SYMCRYPT_DEBUG("SymCryptHkdfExpandKey failed", scError);
+        //     SCOSSL_LOG_SYMCRYPT_DEBUG(SCOSSL_ERR_F_HKDF_DERIVE, SCOSSL_ERR_R_SYMCRYPT_FAILURE,
+        //         "SymCryptHkdfExpandKey failed", scError);
         //     return SCOSSL_FAILURE;
         // }
         // return SCOSSL_SUCCESS;

--- a/SymCryptEngine/src/scossl_pkey_meths.c
+++ b/SymCryptEngine/src/scossl_pkey_meths.c
@@ -38,7 +38,8 @@ static int scossl_pkey_rsa_sign(_Inout_ EVP_PKEY_CTX *ctx, _Out_writes_bytes_(*s
 
     if( EVP_PKEY_CTX_get_rsa_padding(ctx, &padding) <= 0 )
     {
-        SCOSSL_LOG_ERROR("Failed to get padding");
+        SCOSSL_LOG_ERROR(SCOSSL_ERR_F_PKEY_RSA_SIGN, ERR_R_OPERATION_FAIL,
+            "Failed to get padding");
         return SCOSSL_UNSUPPORTED;
     }
 
@@ -59,7 +60,8 @@ static int scossl_pkey_rsa_verify(_Inout_ EVP_PKEY_CTX *ctx, _In_reads_bytes_(si
 
     if( EVP_PKEY_CTX_get_rsa_padding(ctx, &padding) <= 0 )
     {
-        SCOSSL_LOG_ERROR("Failed to get padding");
+        SCOSSL_LOG_ERROR(SCOSSL_ERR_F_PKEY_RSA_VERIFY, ERR_R_OPERATION_FAIL,
+            "Failed to get padding");
         return SCOSSL_UNSUPPORTED;
     }
 
@@ -67,7 +69,8 @@ static int scossl_pkey_rsa_verify(_Inout_ EVP_PKEY_CTX *ctx, _In_reads_bytes_(si
     {
         if( EVP_PKEY_CTX_get_rsa_pss_saltlen(ctx, &cbSalt) <= 0 )
         {
-            SCOSSL_LOG_ERROR("Failed to get cbSalt");
+            SCOSSL_LOG_ERROR(SCOSSL_ERR_F_PKEY_RSA_VERIFY, ERR_R_OPERATION_FAIL,
+                "Failed to get cbSalt");
             return SCOSSL_UNSUPPORTED;
         }
         if( cbSalt != RSA_PSS_SALTLEN_AUTO )
@@ -75,7 +78,8 @@ static int scossl_pkey_rsa_verify(_Inout_ EVP_PKEY_CTX *ctx, _In_reads_bytes_(si
 
             return scossl_rsapss_verify(ctx, sig, siglen, tbs, tbslen);
         }
-        SCOSSL_LOG_INFO("SymCrypt Engine does not support RSA_PSS_SALTLEN_AUTO saltlen - falling back to OpenSSL");
+        SCOSSL_LOG_INFO(SCOSSL_ERR_F_PKEY_RSA_VERIFY, SCOSSL_ERR_R_OPENSSL_FALLBACK,
+            "SymCrypt Engine does not support RSA_PSS_SALTLEN_AUTO saltlen - falling back to OpenSSL");
     }
 
     return _openssl_pkey_rsa_verify(ctx, sig, siglen, tbs, tbslen);
@@ -230,7 +234,8 @@ int scossl_pkey_methods(_Inout_ ENGINE *e, _Out_opt_ EVP_PKEY_METHOD **pmeth,
         *pmeth = _scossl_pkey_hkdf;
         break;
     default:
-        SCOSSL_LOG_ERROR("NID %d not supported");
+        SCOSSL_LOG_ERROR(SCOSSL_ERR_F_PKEY_METHODS, SCOSSL_ERR_R_NOT_IMPLEMENTED,
+            "NID %d not supported");
         ok = 0;
         *pmeth = NULL;
         break;

--- a/SymCryptEngine/src/scossl_rsa.c
+++ b/SymCryptEngine/src/scossl_rsa.c
@@ -51,7 +51,8 @@ SCOSSL_RETURNLENGTH scossl_rsa_pub_enc(int flen, _In_reads_bytes_(flen) const un
 
     if( keyCtx == NULL )
     {
-        SCOSSL_LOG_ERROR("SymCrypt Context Not Found.");
+        SCOSSL_LOG_ERROR(SCOSSL_ERR_F_RSA_PUB_ENC, SCOSSL_ERR_R_MISSING_CTX_DATA,
+            "SymCrypt Context Not Found.");
         goto cleanup;
     }
     if( keyCtx->initialized == 0 )
@@ -87,7 +88,8 @@ SCOSSL_RETURNLENGTH scossl_rsa_pub_enc(int flen, _In_reads_bytes_(flen) const un
                        &cbResult);
         if( scError != SYMCRYPT_NO_ERROR )
         {
-            SCOSSL_LOG_SYMCRYPT_ERROR("SymCryptRsaPkcs1Encrypt failed", scError);
+            SCOSSL_LOG_SYMCRYPT_ERROR(SCOSSL_ERR_F_RSA_PUB_ENC, SCOSSL_ERR_R_SYMCRYPT_FAILURE,
+                "SymCryptRsaPkcs1Encrypt failed", scError);
             goto cleanup;
         }
         break;
@@ -110,7 +112,8 @@ SCOSSL_RETURNLENGTH scossl_rsa_pub_enc(int flen, _In_reads_bytes_(flen) const un
                        &cbResult);
         if( scError != SYMCRYPT_NO_ERROR )
         {
-            SCOSSL_LOG_SYMCRYPT_ERROR("SymCryptRsaOaepEncrypt failed", scError);
+            SCOSSL_LOG_SYMCRYPT_ERROR(SCOSSL_ERR_F_RSA_PUB_ENC, SCOSSL_ERR_R_SYMCRYPT_FAILURE,
+                "SymCryptRsaOaepEncrypt failed", scError);
             goto cleanup;
         }
         break;
@@ -130,17 +133,18 @@ SCOSSL_RETURNLENGTH scossl_rsa_pub_enc(int flen, _In_reads_bytes_(flen) const un
         cbResult = cbModulus;
         if( scError != SYMCRYPT_NO_ERROR )
         {
-            SCOSSL_LOG_SYMCRYPT_ERROR("SymCryptRsaRawEncrypt failed", scError);
+            SCOSSL_LOG_SYMCRYPT_ERROR(SCOSSL_ERR_F_RSA_PUB_ENC, SCOSSL_ERR_R_SYMCRYPT_FAILURE,
+                "SymCryptRsaRawEncrypt failed", scError);
             goto cleanup;
         }
         break;
     default:
-        SCOSSL_LOG_INFO("Unsupported Padding: %d. Forwarding to OpenSSL. Size: %d.", padding, flen);
+        SCOSSL_LOG_INFO(SCOSSL_ERR_F_RSA_PUB_ENC, SCOSSL_ERR_R_OPENSSL_FALLBACK,
+            "Unsupported Padding: %d. Forwarding to OpenSSL. Size: %d.", padding, flen);
         ossl_rsa_meth = RSA_PKCS1_OpenSSL();
         pfn_rsa_meth_pub_enc = RSA_meth_get_pub_enc(ossl_rsa_meth);
         if( !pfn_rsa_meth_pub_enc )
         {
-            SCOSSL_LOG_ERROR("RSA_meth_set_pub_enc failed");
             goto cleanup;
         }
         cbResult = pfn_rsa_meth_pub_enc(flen, from, to, rsa, padding);
@@ -167,7 +171,8 @@ SCOSSL_RETURNLENGTH scossl_rsa_priv_dec(int flen, _In_reads_bytes_(flen) const u
 
     if( keyCtx == NULL )
     {
-        SCOSSL_LOG_ERROR("SymCrypt Context Not Found.");
+        SCOSSL_LOG_ERROR(SCOSSL_ERR_F_RSA_PRIV_DEC, SCOSSL_ERR_R_MISSING_CTX_DATA,
+            "SymCrypt Context Not Found.");
         goto cleanup;
     }
     if( keyCtx->initialized == 0 )
@@ -231,7 +236,8 @@ SCOSSL_RETURNLENGTH scossl_rsa_priv_dec(int flen, _In_reads_bytes_(flen) const u
                        &cbResult);
         if( scError != SYMCRYPT_NO_ERROR )
         {
-            SCOSSL_LOG_SYMCRYPT_ERROR("SymCryptRsaOaepDecrypt failed", scError);
+            SCOSSL_LOG_SYMCRYPT_ERROR(SCOSSL_ERR_F_RSA_PRIV_DEC, SCOSSL_ERR_R_SYMCRYPT_FAILURE,
+                "SymCryptRsaOaepDecrypt failed", scError);
             goto cleanup;
         }
         break;
@@ -247,17 +253,18 @@ SCOSSL_RETURNLENGTH scossl_rsa_priv_dec(int flen, _In_reads_bytes_(flen) const u
         cbResult = cbModulus;
         if( scError != SYMCRYPT_NO_ERROR )
         {
-            SCOSSL_LOG_SYMCRYPT_ERROR("SymCryptRsaRawDecrypt failed", scError);
+            SCOSSL_LOG_SYMCRYPT_ERROR(SCOSSL_ERR_F_RSA_PRIV_DEC, SCOSSL_ERR_R_SYMCRYPT_FAILURE,
+                "SymCryptRsaRawDecrypt failed", scError);
             goto cleanup;
         }
         break;
     default:
-        SCOSSL_LOG_INFO("Unsupported Padding: %d. Forwarding to OpenSSL. Size: %d.", padding, flen);
+        SCOSSL_LOG_INFO(SCOSSL_ERR_F_RSA_PRIV_DEC, SCOSSL_ERR_R_OPENSSL_FALLBACK,
+            "Unsupported Padding: %d. Forwarding to OpenSSL. Size: %d.", padding, flen);
         ossl_rsa_meth = RSA_PKCS1_OpenSSL();
         pfn_rsa_meth_priv_dec = RSA_meth_get_priv_dec(ossl_rsa_meth);
         if( !pfn_rsa_meth_priv_dec )
         {
-            SCOSSL_LOG_ERROR("RSA_meth_get_priv_dec failed");
             goto cleanup;
         }
         cbResult = pfn_rsa_meth_priv_dec(flen, from, to, rsa, padding);
@@ -273,14 +280,14 @@ cleanup:
 SCOSSL_RETURNLENGTH scossl_rsa_priv_enc(int flen, _In_reads_bytes_(flen) const unsigned char* from,
     _Out_writes_bytes_(RSA_size(rsa)) unsigned char* to, _In_ RSA* rsa, int padding)
 {
-    SCOSSL_LOG_INFO("RSA private encrypt equivalent not found in SymCrypt. Forwarding to OpenSSL. Size: %d.", flen);
+    SCOSSL_LOG_INFO(SCOSSL_ERR_F_RSA_PRIV_ENC, SCOSSL_ERR_R_OPENSSL_FALLBACK,
+        "RSA private encrypt equivalent not FIPS certifiable. Forwarding to OpenSSL. Size: %d.", flen);
     const RSA_METHOD *ossl_rsa_meth = RSA_PKCS1_OpenSSL(); // Use default implementation
     PFN_RSA_meth_priv_enc pfn_rsa_meth_priv_enc = NULL;
 
     pfn_rsa_meth_priv_enc = RSA_meth_get_priv_enc(ossl_rsa_meth);
     if( !pfn_rsa_meth_priv_enc )
     {
-        SCOSSL_LOG_ERROR("RSA_meth_get_priv_enc failed");
         return -1;
     }
     return pfn_rsa_meth_priv_enc(flen, from, to, rsa, padding);
@@ -290,14 +297,14 @@ SCOSSL_RETURNLENGTH scossl_rsa_pub_dec(int flen, _In_reads_bytes_(flen) const un
     _Out_writes_bytes_(RSA_size(rsa)) unsigned char* to, _In_ RSA* rsa,
     int padding)
 {
-    SCOSSL_LOG_INFO("RSA public decrypt equivalent not found in SymCrypt. Forwarding to OpenSSL. Size: %d.", flen);
+    SCOSSL_LOG_INFO(SCOSSL_ERR_F_RSA_PUB_DEC, SCOSSL_ERR_R_OPENSSL_FALLBACK,
+        "RSA public decrypt equivalent not found in SymCrypt. Forwarding to OpenSSL. Size: %d.", flen);
     const RSA_METHOD *ossl_rsa_meth = RSA_PKCS1_OpenSSL(); // Use default implementation
     PFN_RSA_meth_pub_dec pfn_rsa_meth_pub_dec = NULL;
 
     pfn_rsa_meth_pub_dec = RSA_meth_get_pub_dec(ossl_rsa_meth);
     if( !pfn_rsa_meth_pub_dec )
     {
-        SCOSSL_LOG_ERROR("RSA_meth_get_pub_dec failed");
         return -1;
     }
     return pfn_rsa_meth_pub_dec(flen, from, to, rsa, padding);
@@ -315,7 +322,8 @@ SCOSSL_STATUS scossl_rsa_sign(int type, _In_reads_bytes_(m_length) const unsigne
 
     if( keyCtx == NULL )
     {
-        SCOSSL_LOG_ERROR("SymCrypt Context Not Found.");
+        SCOSSL_LOG_ERROR(SCOSSL_ERR_F_RSA_SIGN, SCOSSL_ERR_R_MISSING_CTX_DATA,
+            "SymCrypt Context Not Found.");
         goto cleanup;
     }
     if( keyCtx->initialized == 0 )
@@ -335,10 +343,10 @@ SCOSSL_STATUS scossl_rsa_sign(int type, _In_reads_bytes_(m_length) const unsigne
     switch( type )
     {
     case NID_md5_sha1:
-        SCOSSL_LOG_INFO("Using Mac algorithm MD5+SHA1 which is not FIPS compliant");
+        SCOSSL_LOG_INFO(SCOSSL_ERR_F_RSA_SIGN, SCOSSL_ERR_R_NOT_FIPS_ALGORITHM,
+            "Using Mac algorithm MD5+SHA1 which is not FIPS compliant");
         if( m_length != SCOSSL_MD5_SHA1_DIGEST_LENGTH )
         {
-            SCOSSL_LOG_ERROR("m_length == %d", m_length);
             goto cleanup;
         }
 
@@ -353,15 +361,10 @@ SCOSSL_STATUS scossl_rsa_sign(int type, _In_reads_bytes_(m_length) const unsigne
                        sigret,
                        cbModulus,
                        &cbResult);
-
-        if( scError != SYMCRYPT_NO_ERROR )
-        {
-            SCOSSL_LOG_SYMCRYPT_ERROR("SymCryptRsaPkcs1Sign failed", scError);
-            goto cleanup;
-        }
         break;
     case NID_md5:
-        SCOSSL_LOG_INFO("Using Mac algorithm MD5 which is not FIPS compliant");
+        SCOSSL_LOG_INFO(SCOSSL_ERR_F_RSA_SIGN, SCOSSL_ERR_R_NOT_FIPS_ALGORITHM,
+            "Using Mac algorithm MD5 which is not FIPS compliant");
         if( m_length != SCOSSL_MD5_DIGEST_LENGTH )
         {
             goto cleanup;
@@ -378,15 +381,10 @@ SCOSSL_STATUS scossl_rsa_sign(int type, _In_reads_bytes_(m_length) const unsigne
                        sigret,
                        cbModulus,
                        &cbResult);
-
-        if( scError != SYMCRYPT_NO_ERROR )
-        {
-            SCOSSL_LOG_SYMCRYPT_ERROR("SymCryptRsaPkcs1Sign failed", scError);
-            goto cleanup;
-        }
         break;
     case NID_sha1:
-        SCOSSL_LOG_INFO("Using Mac algorithm SHA1 which is not FIPS compliant");
+        SCOSSL_LOG_INFO(SCOSSL_ERR_F_RSA_SIGN, SCOSSL_ERR_R_NOT_FIPS_ALGORITHM,
+            "Using Mac algorithm SHA1 which is not FIPS compliant");
         if( m_length != SCOSSL_SHA1_DIGEST_LENGTH )
         {
             goto cleanup;
@@ -403,12 +401,6 @@ SCOSSL_STATUS scossl_rsa_sign(int type, _In_reads_bytes_(m_length) const unsigne
                        sigret,
                        cbModulus,
                        &cbResult);
-
-        if( scError != SYMCRYPT_NO_ERROR )
-        {
-            SCOSSL_LOG_SYMCRYPT_ERROR("SymCryptRsaPkcs1Sign failed", scError);
-            goto cleanup;
-        }
         break;
     case NID_sha256:
         if( m_length != SCOSSL_SHA256_DIGEST_LENGTH )
@@ -427,13 +419,6 @@ SCOSSL_STATUS scossl_rsa_sign(int type, _In_reads_bytes_(m_length) const unsigne
                        sigret,
                        cbModulus,
                        &cbResult);
-
-        if( scError != SYMCRYPT_NO_ERROR )
-        {
-            SCOSSL_LOG_SYMCRYPT_ERROR("SymCryptRsaPkcs1Sign failed", scError);
-            goto cleanup;
-        }
-
         break;
     case NID_sha384:
         if( m_length != SCOSSL_SHA384_DIGEST_LENGTH )
@@ -452,12 +437,6 @@ SCOSSL_STATUS scossl_rsa_sign(int type, _In_reads_bytes_(m_length) const unsigne
                        sigret,
                        cbModulus,
                        &cbResult);
-
-        if( scError != SYMCRYPT_NO_ERROR )
-        {
-            SCOSSL_LOG_SYMCRYPT_ERROR("SymCryptRsaPkcs1Sign failed", scError);
-            goto cleanup;
-        }
         break;
     case NID_sha512:
         if( m_length != SCOSSL_SHA512_DIGEST_LENGTH )
@@ -476,15 +455,17 @@ SCOSSL_STATUS scossl_rsa_sign(int type, _In_reads_bytes_(m_length) const unsigne
                        sigret,
                        cbModulus,
                        &cbResult);
-
-        if( scError != SYMCRYPT_NO_ERROR )
-        {
-            SCOSSL_LOG_SYMCRYPT_ERROR("SymCryptRsaPkcs1Sign failed", scError);
-            goto cleanup;
-        }
         break;
     default:
-        SCOSSL_LOG_ERROR("Unknown type: %d. Size: %d.", type, m_length);
+        SCOSSL_LOG_ERROR(SCOSSL_ERR_F_RSA_SIGN, SCOSSL_ERR_R_NOT_IMPLEMENTED,
+            "Unknown type: %d. Size: %d.", type, m_length);
+        goto cleanup;
+    }
+
+    if( scError != SYMCRYPT_NO_ERROR )
+    {
+        SCOSSL_LOG_SYMCRYPT_ERROR(SCOSSL_ERR_F_RSA_SIGN, SCOSSL_ERR_R_SYMCRYPT_FAILURE,
+            "SymCryptRsaPkcs1Sign failed", scError);
         goto cleanup;
     }
 
@@ -507,7 +488,8 @@ SCOSSL_STATUS scossl_rsa_verify(int dtype, _In_reads_bytes_(m_length) const unsi
 
     if( keyCtx == NULL )
     {
-        SCOSSL_LOG_ERROR("SymCrypt Context Not Found.");
+        SCOSSL_LOG_ERROR(SCOSSL_ERR_F_RSA_VERIFY, SCOSSL_ERR_R_MISSING_CTX_DATA,
+            "SymCrypt Context Not Found.");
         goto cleanup;
     }
     if( keyCtx->initialized == 0 )
@@ -522,10 +504,10 @@ SCOSSL_STATUS scossl_rsa_verify(int dtype, _In_reads_bytes_(m_length) const unsi
     switch( dtype )
     {
     case NID_md5_sha1:
-        SCOSSL_LOG_INFO("Using Mac algorithm MD5+SHA1 which is not FIPS compliant");
+        SCOSSL_LOG_INFO(SCOSSL_ERR_F_RSA_VERIFY, SCOSSL_ERR_R_NOT_FIPS_ALGORITHM,
+            "Using Mac algorithm MD5+SHA1 which is not FIPS compliant");
         if( m_length != SCOSSL_MD5_SHA1_DIGEST_LENGTH )
         {
-            SCOSSL_LOG_ERROR("m_length == %d", m_length);
             goto cleanup;
         }
 
@@ -539,18 +521,10 @@ SCOSSL_STATUS scossl_rsa_verify(int dtype, _In_reads_bytes_(m_length) const unsi
                        NULL,
                        0,
                        0);
-
-        if( scError != SYMCRYPT_NO_ERROR )
-        {
-            if( scError != SYMCRYPT_SIGNATURE_VERIFICATION_FAILURE )
-            {
-                SCOSSL_LOG_SYMCRYPT_ERROR("SymCryptRsaPkcs1verify returned unexpected error", scError);
-            }
-            goto cleanup;
-        }
         break;
     case NID_md5:
-        SCOSSL_LOG_INFO("Using Mac algorithm MD5 which is not FIPS compliant");
+        SCOSSL_LOG_INFO(SCOSSL_ERR_F_RSA_VERIFY, SCOSSL_ERR_R_NOT_FIPS_ALGORITHM,
+            "Using Mac algorithm MD5 which is not FIPS compliant");
         if( m_length != SCOSSL_MD5_DIGEST_LENGTH )
         {
             goto cleanup;
@@ -566,18 +540,10 @@ SCOSSL_STATUS scossl_rsa_verify(int dtype, _In_reads_bytes_(m_length) const unsi
                        SymCryptMd5OidList,
                        SYMCRYPT_MD5_OID_COUNT,
                        0);
-
-        if( scError != SYMCRYPT_NO_ERROR )
-        {
-            if( scError != SYMCRYPT_SIGNATURE_VERIFICATION_FAILURE )
-            {
-                SCOSSL_LOG_SYMCRYPT_ERROR("SymCryptRsaPkcs1verify returned unexpected error", scError);
-            }
-            goto cleanup;
-        }
         break;
     case NID_sha1:
-        SCOSSL_LOG_INFO("Using Mac algorithm SHA1 which is not FIPS compliant");
+        SCOSSL_LOG_INFO(SCOSSL_ERR_F_RSA_VERIFY, SCOSSL_ERR_R_NOT_FIPS_ALGORITHM,
+            "Using Mac algorithm SHA1 which is not FIPS compliant");
         if( m_length != SCOSSL_SHA1_DIGEST_LENGTH )
         {
             goto cleanup;
@@ -593,15 +559,6 @@ SCOSSL_STATUS scossl_rsa_verify(int dtype, _In_reads_bytes_(m_length) const unsi
                        SymCryptSha1OidList,
                        SYMCRYPT_SHA1_OID_COUNT,
                        0);
-
-        if( scError != SYMCRYPT_NO_ERROR )
-        {
-            if( scError != SYMCRYPT_SIGNATURE_VERIFICATION_FAILURE )
-            {
-                SCOSSL_LOG_SYMCRYPT_ERROR("SymCryptRsaPkcs1verify returned unexpected error", scError);
-            }
-            goto cleanup;
-        }
         break;
     case NID_sha256:
         if( m_length != SCOSSL_SHA256_DIGEST_LENGTH )
@@ -619,14 +576,6 @@ SCOSSL_STATUS scossl_rsa_verify(int dtype, _In_reads_bytes_(m_length) const unsi
                        SymCryptSha256OidList,
                        SYMCRYPT_SHA256_OID_COUNT,
                        0);
-        if( scError != SYMCRYPT_NO_ERROR )
-        {
-            if( scError != SYMCRYPT_SIGNATURE_VERIFICATION_FAILURE )
-            {
-                SCOSSL_LOG_SYMCRYPT_ERROR("SymCryptRsaPkcs1verify returned unexpected error", scError);
-            }
-            goto cleanup;
-        }
         break;
     case NID_sha384:
         if( m_length != SCOSSL_SHA384_DIGEST_LENGTH )
@@ -644,15 +593,6 @@ SCOSSL_STATUS scossl_rsa_verify(int dtype, _In_reads_bytes_(m_length) const unsi
                        SymCryptSha384OidList,
                        SYMCRYPT_SHA384_OID_COUNT,
                        0);
-
-        if( scError != SYMCRYPT_NO_ERROR )
-        {
-            if( scError != SYMCRYPT_SIGNATURE_VERIFICATION_FAILURE )
-            {
-                SCOSSL_LOG_SYMCRYPT_ERROR("SymCryptRsaPkcs1verify returned unexpected error", scError);
-            }
-            goto cleanup;
-        }
         break;
     case NID_sha512:
         if( m_length != SCOSSL_SHA512_DIGEST_LENGTH )
@@ -670,22 +610,22 @@ SCOSSL_STATUS scossl_rsa_verify(int dtype, _In_reads_bytes_(m_length) const unsi
                        SymCryptSha512OidList,
                        SYMCRYPT_SHA512_OID_COUNT,
                        0);
-
-        if( scError != SYMCRYPT_NO_ERROR )
-        {
-            if( scError != SYMCRYPT_SIGNATURE_VERIFICATION_FAILURE )
-            {
-                SCOSSL_LOG_SYMCRYPT_ERROR("SymCryptRsaPkcs1verify returned unexpected error", scError);
-            }
-            goto cleanup;
-        }
         break;
     default:
-        SCOSSL_LOG_ERROR("Unknown dtype: %d. Size: %d.", dtype, m_length);
+        SCOSSL_LOG_ERROR(SCOSSL_ERR_F_RSA_VERIFY, SCOSSL_ERR_R_NOT_IMPLEMENTED,
+            "Unknown dtype: %d. Size: %d.", dtype, m_length);
         goto cleanup;
     }
 
-    ret = SCOSSL_SUCCESS;
+    if( scError == SYMCRYPT_NO_ERROR )
+    {
+        ret = SCOSSL_SUCCESS;
+    }
+    else if (scError != SYMCRYPT_SIGNATURE_VERIFICATION_FAILURE )
+    {
+        SCOSSL_LOG_SYMCRYPT_ERROR(SCOSSL_ERR_F_RSA_VERIFY, SCOSSL_ERR_R_SYMCRYPT_FAILURE,
+            "SymCryptRsaPkcs1verify returned unexpected error", scError);
+    }
 
 cleanup:
     return ret;
@@ -726,7 +666,8 @@ SCOSSL_STATUS scossl_rsa_keygen(_Out_ RSA* rsa, int bits, _In_ BIGNUM* e,
 
     if( keyCtx == NULL )
     {
-        SCOSSL_LOG_ERROR("SymCrypt Context Not Found.");
+        SCOSSL_LOG_ERROR(SCOSSL_ERR_F_RSA_KEYGEN, SCOSSL_ERR_R_MISSING_CTX_DATA,
+            "SymCrypt Context Not Found.");
         goto cleanup;
     }
     if( keyCtx->initialized != 0 )
@@ -741,23 +682,27 @@ SCOSSL_STATUS scossl_rsa_keygen(_Out_ RSA* rsa, int bits, _In_ BIGNUM* e,
     keyCtx->key = SymCryptRsakeyAllocate(&SymcryptRsaParam, 0);
     if( keyCtx->key == NULL )
     {
-        SCOSSL_LOG_ERROR("SymCryptRsakeyAllocate failed");
+        SCOSSL_LOG_ERROR(SCOSSL_ERR_F_RSA_KEYGEN, SCOSSL_ERR_R_SYMCRYPT_FAILURE,
+            "SymCryptRsakeyAllocate failed");
         goto cleanup;
     }
     if( BN_bn2binpad(e, (PBYTE) &pubExp64, sizeof(pubExp64)) != sizeof(pubExp64) )
     {
-        SCOSSL_LOG_ERROR("BN_bn2binpad failed - Probably Public Exponent larger than maximum supported size (8 bytes)");
+        SCOSSL_LOG_ERROR(SCOSSL_ERR_F_RSA_KEYGEN, ERR_R_OPERATION_FAIL,
+            "BN_bn2binpad failed - Probably Public Exponent larger than maximum supported size (8 bytes)");
         goto cleanup;
     }
     if( SymCryptLoadMsbFirstUint64((PBYTE) &pubExp64, sizeof(pubExp64), &pubExp64) != SYMCRYPT_NO_ERROR )
     {
-        SCOSSL_LOG_ERROR("SymCryptLoadMsbFirstUint64 failed");
+        SCOSSL_LOG_ERROR(SCOSSL_ERR_F_RSA_KEYGEN, SCOSSL_ERR_R_SYMCRYPT_FAILURE,
+            "SymCryptLoadMsbFirstUint64 failed");
         goto cleanup;
     }
     scError = SymCryptRsakeyGenerate(keyCtx->key, &pubExp64, 1, 0);
     if( scError != SYMCRYPT_NO_ERROR )
     {
-        SCOSSL_LOG_SYMCRYPT_ERROR("SymCryptRsakeyGenerate failed", scError);
+        SCOSSL_LOG_SYMCRYPT_ERROR(SCOSSL_ERR_F_RSA_KEYGEN, SCOSSL_ERR_R_SYMCRYPT_FAILURE,
+            "SymCryptRsakeyGenerate failed", scError);
         goto cleanup;
     }
 
@@ -783,7 +728,8 @@ SCOSSL_STATUS scossl_rsa_keygen(_Out_ RSA* rsa, int bits, _In_ BIGNUM* e,
     pbData = OPENSSL_zalloc(cbData);
     if( pbData == NULL )
     {
-        SCOSSL_LOG_ERROR("OPENSSL_zalloc failed");
+        SCOSSL_LOG_ERROR(SCOSSL_ERR_F_RSA_KEYGEN, ERR_R_MALLOC_FAILURE,
+            "OPENSSL_zalloc failed");
         goto cleanup;
     }
     pbCurrent = pbData;
@@ -827,7 +773,8 @@ SCOSSL_STATUS scossl_rsa_keygen(_Out_ RSA* rsa, int bits, _In_ BIGNUM* e,
                    0);
     if( scError != SYMCRYPT_NO_ERROR )
     {
-        SCOSSL_LOG_SYMCRYPT_ERROR("SymCryptRsakeyGetValue failed", scError);
+        SCOSSL_LOG_SYMCRYPT_ERROR(SCOSSL_ERR_F_RSA_KEYGEN, SCOSSL_ERR_R_SYMCRYPT_FAILURE,
+            "SymCryptRsakeyGetValue failed", scError);
         goto cleanup;
     }
 
@@ -844,7 +791,8 @@ SCOSSL_STATUS scossl_rsa_keygen(_Out_ RSA* rsa, int bits, _In_ BIGNUM* e,
                     0);
     if( scError != SYMCRYPT_NO_ERROR )
     {
-        SCOSSL_LOG_SYMCRYPT_ERROR("SymCryptRsakeyGetCrtValue failed", scError);
+        SCOSSL_LOG_SYMCRYPT_ERROR(SCOSSL_ERR_F_RSA_KEYGEN, SCOSSL_ERR_R_SYMCRYPT_FAILURE,
+            "SymCryptRsakeyGetCrtValue failed", scError);
         goto cleanup;
     }
 
@@ -858,7 +806,8 @@ SCOSSL_STATUS scossl_rsa_keygen(_Out_ RSA* rsa, int bits, _In_ BIGNUM* e,
         ((rsa_iqmp = BN_secure_new()) == NULL) ||
         ((rsa_d = BN_secure_new()) == NULL))
     {
-        SCOSSL_LOG_ERROR("BN_new returned NULL.");
+        SCOSSL_LOG_ERROR(SCOSSL_ERR_F_RSA_KEYGEN, ERR_R_MALLOC_FAILURE,
+            "BN_new returned NULL.");
         goto cleanup;
     }
 
@@ -870,7 +819,8 @@ SCOSSL_STATUS scossl_rsa_keygen(_Out_ RSA* rsa, int bits, _In_ BIGNUM* e,
         (BN_bin2bn(pbCrtCoefficient, cbPrime1, rsa_iqmp) == NULL) ||
         (BN_bin2bn(pbPrivateExponent, cbPrivateExponent, rsa_d) == NULL) )
     {
-        SCOSSL_LOG_ERROR("BN_bin2bn failed.");
+        SCOSSL_LOG_ERROR(SCOSSL_ERR_F_RSA_KEYGEN, ERR_R_OPERATION_FAIL,
+            "BN_bin2bn failed.");
         goto cleanup;
     }
 
@@ -935,7 +885,8 @@ SCOSSL_STATUS scossl_initialize_rsa_key(_In_ RSA* rsa, _Out_ SCOSSL_RSA_KEY_CONT
     if( RSA_get_version(rsa) != RSA_ASN1_VERSION_DEFAULT )
     {
         // Currently only support normal two-prime RSA with SymCrypt Engine
-        SCOSSL_LOG_ERROR("Unsupported RSA version");
+        SCOSSL_LOG_ERROR(SCOSSL_ERR_F_INITIALIZE_RSA_KEY, SCOSSL_ERR_R_NOT_IMPLEMENTED,
+            "Unsupported RSA version");
         goto cleanup;
     }
 
@@ -944,7 +895,8 @@ SCOSSL_STATUS scossl_initialize_rsa_key(_In_ RSA* rsa, _Out_ SCOSSL_RSA_KEY_CONT
 
     if( rsa_n == NULL || rsa_e == NULL )
     {
-        SCOSSL_LOG_ERROR("Not enough Parameters");
+        SCOSSL_LOG_ERROR(SCOSSL_ERR_F_INITIALIZE_RSA_KEY, ERR_R_PASSED_NULL_PARAMETER,
+            "Not enough Parameters");
         goto cleanup;
     }
     // Modulus
@@ -968,7 +920,8 @@ SCOSSL_STATUS scossl_initialize_rsa_key(_In_ RSA* rsa, _Out_ SCOSSL_RSA_KEY_CONT
     pbData = OPENSSL_zalloc(cbData);
     if( pbData == NULL )
     {
-        SCOSSL_LOG_ERROR("OPENSSL_zalloc failed");
+        SCOSSL_LOG_ERROR(SCOSSL_ERR_F_INITIALIZE_RSA_KEY, ERR_R_MALLOC_FAILURE,
+            "OPENSSL_zalloc failed");
         goto cleanup;
     }
 
@@ -976,12 +929,14 @@ SCOSSL_STATUS scossl_initialize_rsa_key(_In_ RSA* rsa, _Out_ SCOSSL_RSA_KEY_CONT
 
     if( BN_bn2binpad(rsa_e, (PBYTE) &pubExp64, sizeof(pubExp64)) != sizeof(pubExp64) )
     {
-        SCOSSL_LOG_ERROR("BN_bn2binpad failed - Probably Public Exponent larger than maximum supported size (8 bytes)");
+        SCOSSL_LOG_ERROR(SCOSSL_ERR_F_INITIALIZE_RSA_KEY, ERR_R_OPERATION_FAIL,
+            "BN_bn2binpad failed - Probably Public Exponent larger than maximum supported size (8 bytes)");
         goto cleanup;
     }
     if( SymCryptLoadMsbFirstUint64((PBYTE) &pubExp64, sizeof(pubExp64), &pubExp64) != SYMCRYPT_NO_ERROR )
     {
-        SCOSSL_LOG_ERROR("SymCryptLoadMsbFirstUint64 failed");
+        SCOSSL_LOG_ERROR(SCOSSL_ERR_F_INITIALIZE_RSA_KEY, SCOSSL_ERR_R_SYMCRYPT_FAILURE,
+            "SymCryptLoadMsbFirstUint64 failed");
         goto cleanup;
     }
 
@@ -1005,7 +960,8 @@ SCOSSL_STATUS scossl_initialize_rsa_key(_In_ RSA* rsa, _Out_ SCOSSL_RSA_KEY_CONT
     if( nPrimes != 0 && nPrimes != 2 )
     {
         // Currently only support normal two-prime RSA with SymCrypt Engine
-        SCOSSL_LOG_ERROR("Unsupported RSA version");
+        SCOSSL_LOG_ERROR(SCOSSL_ERR_F_INITIALIZE_RSA_KEY, SCOSSL_ERR_R_NOT_IMPLEMENTED,
+            "Unsupported RSA version");
         goto cleanup;
     }
 
@@ -1016,7 +972,8 @@ SCOSSL_STATUS scossl_initialize_rsa_key(_In_ RSA* rsa, _Out_ SCOSSL_RSA_KEY_CONT
     keyCtx->key = SymCryptRsakeyAllocate(&SymcryptRsaParam, 0);
     if( keyCtx->key == NULL )
     {
-        SCOSSL_LOG_ERROR("SymCryptRsakeyAllocate failed");
+        SCOSSL_LOG_ERROR(SCOSSL_ERR_F_INITIALIZE_RSA_KEY, SCOSSL_ERR_R_SYMCRYPT_FAILURE,
+            "SymCryptRsakeyAllocate failed");
         goto cleanup;
     }
 
@@ -1033,7 +990,8 @@ SCOSSL_STATUS scossl_initialize_rsa_key(_In_ RSA* rsa, _Out_ SCOSSL_RSA_KEY_CONT
                    keyCtx->key);
     if( scError != SYMCRYPT_NO_ERROR )
     {
-        SCOSSL_LOG_SYMCRYPT_ERROR("SymCryptRsakeySetValue failed", scError);
+        SCOSSL_LOG_SYMCRYPT_ERROR(SCOSSL_ERR_F_INITIALIZE_RSA_KEY, SCOSSL_ERR_R_SYMCRYPT_FAILURE,
+            "SymCryptRsakeySetValue failed", scError);
         goto cleanup;
     }
 
@@ -1044,7 +1002,8 @@ SCOSSL_STATUS scossl_initialize_rsa_key(_In_ RSA* rsa, _Out_ SCOSSL_RSA_KEY_CONT
 cleanup:
     if( ret != SCOSSL_SUCCESS )
     {
-        SCOSSL_LOG_ERROR("scossl_initialize_rsa_key failed.");
+        SCOSSL_LOG_ERROR(SCOSSL_ERR_F_INITIALIZE_RSA_KEY, ERR_R_OPERATION_FAIL,
+            "scossl_initialize_rsa_key failed.");
         scossl_rsa_free_key_context(keyCtx);
     }
 
@@ -1080,7 +1039,6 @@ SCOSSL_STATUS scossl_rsa_bn_mod_exp(_Out_ BIGNUM* r, _In_ const BIGNUM* a, _In_ 
     PFN_RSA_meth_bn_mod_exp pfn_rsa_meth_bn_mod_exp = RSA_meth_get_bn_mod_exp(ossl_rsa_meth);
     if( !pfn_rsa_meth_bn_mod_exp )
     {
-        SCOSSL_LOG_ERROR("RSA_meth_get_bn_mod_exp failed");
         return SCOSSL_FAILURE;
     }
     return pfn_rsa_meth_bn_mod_exp(r, a, p, m, ctx, m_ctx);
@@ -1091,13 +1049,15 @@ SCOSSL_STATUS scossl_rsa_init(_Inout_ RSA *rsa)
     SCOSSL_RSA_KEY_CONTEXT *keyCtx = OPENSSL_zalloc(sizeof(*keyCtx));
     if( !keyCtx )
     {
-        SCOSSL_LOG_ERROR("OPENSSL_zalloc failed");
+        SCOSSL_LOG_ERROR(SCOSSL_ERR_F_RSA_INIT, ERR_R_MALLOC_FAILURE,
+            "OPENSSL_zalloc failed");
         return SCOSSL_FAILURE;
     }
 
     if( RSA_set_ex_data(rsa, scossl_rsa_idx, keyCtx) == 0 )
     {
-        SCOSSL_LOG_ERROR("RSA_set_ex_data failed");
+        SCOSSL_LOG_ERROR(SCOSSL_ERR_F_RSA_INIT, ERR_R_OPERATION_FAIL,
+            "RSA_set_ex_data failed");
         OPENSSL_free(keyCtx);
         return SCOSSL_FAILURE;
     }


### PR DESCRIPTION
+ This is in addition to logging to stderr or a log file specified by
  the caller
+ For now do not specify all the functions which can generate errors and
  error reasons up front, but instead log all SCOSSL errors as being for
  an unknown function and with a generic reason of "Error".
  + Log additional information with the errors indicating the function
    and error reason using the existing data that SCOSSL provides to
    error logging functions