### PR TITLE
Various logging tweaks

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 3.13.0)
 
 project(scossl)
 
-include_directories(~/SymCrypt/inc)
+include_directories(${SYMCRYPT_ROOT_DIR}/inc)
 
 # In Sanitize version, enable sanitizers
 if (CMAKE_BUILD_TYPE MATCHES Sanitize)

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ Follow Linux build instructions from SymCrypt repository [SymCrypt](https://gith
 ```
 cp <SymCryptRepo>/bin/module/<arch>/LinuxUserMode/<module_name>/libsymcrypt.so ./
 mkdir bin; cd bin
-cmake .. -DOPENSSL_ROOT_DIR=<OpensslInstallDirectory> -DCMAKE_TOOLCHAIN_FILE=../cmake-toolchain/LinuxUserMode-<arch>.cmake
+cmake .. -DSYMCRYPT_ROOT_DIR=<SymCryptRepo> -DOPENSSL_ROOT_DIR=<OpensslInstallDirectory> -DCMAKE_TOOLCHAIN_FILE=../cmake-toolchain/LinuxUserMode-<arch>.cmake -DCMAKE_BUILD_TYPE=Release
 cmake --build .
 ```
 

--- a/SslPlay/CMakeLists.txt
+++ b/SslPlay/CMakeLists.txt
@@ -13,5 +13,4 @@ add_executable (SslPlay
 target_link_directories(SslPlay PUBLIC ${CMAKE_BINARY_DIR} ${CMAKE_INSTALL_LIBDIR})
 target_include_directories(SslPlay PUBLIC ${CMAKE_SOURCE_DIR}/SymCryptEngine/inc)
 
-target_link_libraries(SslPlay LINK_PUBLIC $<TARGET_FILE:scossl_dynamic> ${OPENSSL_CRYPTO_LIBRARY})
-#target_link_libraries(SslPlay ${OPENSSL_CRYPTO_LIBRARY})
+target_link_libraries(SslPlay PUBLIC scossl_dynamic ${OPENSSL_CRYPTO_LIBRARY})

--- a/SslPlay/SslPlay.cpp
+++ b/SslPlay/SslPlay.cpp
@@ -1729,11 +1729,15 @@ end:
 
 int main(int argc, char** argv)
 {
-    int scossl_log_level_debug = SCOSSL_LOG_LEVEL_ERROR;
+    int scossl_log_level = SCOSSL_LOG_LEVEL_NO_CHANGE;
+    int scossl_ossl_ERR_level = SCOSSL_LOG_LEVEL_NO_CHANGE;
     if (argc >= 2) {
-         scossl_log_level_debug = atoi(argv[1]);
-        SCOSSL_ENGINE_set_trace_level(scossl_log_level_debug);
+        scossl_log_level = atoi(argv[1]);
     }
+    if (argc >= 3) {
+        scossl_ossl_ERR_level = atoi(argv[2]);
+    }
+    SCOSSL_ENGINE_set_trace_level(scossl_log_level, scossl_ossl_ERR_level);
     SCOSSL_ENGINE_Initialize();
     bio_err = BIO_new_fp(stdout, BIO_NOCLOSE);
 

--- a/SymCryptEngine/dynamic/CMakeLists.txt
+++ b/SymCryptEngine/dynamic/CMakeLists.txt
@@ -34,7 +34,8 @@ target_include_directories(scossl_dynamic PUBLIC ../inc)
 target_include_directories(scossl_dynamic PRIVATE ../src)
 target_include_directories (scossl_dynamic PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
 
-# set_target_properties(scossl_dynamic PROPERTIES PREFIX "")
+# Remove default "lib" prefix from symcryptengine.so as OpenSSL engine is not a generic Linux .so
+set_target_properties(scossl_dynamic PROPERTIES PREFIX "")
 set_target_properties(scossl_dynamic PROPERTIES OUTPUT_NAME "symcryptengine")
 
 target_link_directories(scossl_dynamic PUBLIC ${CMAKE_SOURCE_DIR})

--- a/SymCryptEngine/dynamic/OpenSSLConfig.conf
+++ b/SymCryptEngine/dynamic/OpenSSLConfig.conf
@@ -8,5 +8,5 @@ symcrypt = symcrypt_section
 
 [ symcrypt_section ]
 engine_id = symcrypt
-dynamic_path = /usr/local/ssl/lib/engines-1.1/libsymcryptengine.so
+dynamic_path = /usr/local/ssl/lib/engines-1.1/symcryptengine.so
 default_algorithms = ALL

--- a/SymCryptEngine/inc/scossl.h
+++ b/SymCryptEngine/inc/scossl.h
@@ -10,12 +10,13 @@
 extern "C" {
 #endif
 
-#define SCOSSL_LOG_LEVEL_OFF        0
-#define SCOSSL_LOG_LEVEL_ERROR      1   // DEFAULT
-#define SCOSSL_LOG_LEVEL_INFO       2
-#define SCOSSL_LOG_LEVEL_DEBUG      3
+#define SCOSSL_LOG_LEVEL_NO_CHANGE  (-1)
+#define SCOSSL_LOG_LEVEL_OFF        (0)
+#define SCOSSL_LOG_LEVEL_ERROR      (1) // DEFAULT for OpenSSL ERR
+#define SCOSSL_LOG_LEVEL_INFO       (2) // DEFAULT for stderr / logging to logfile
+#define SCOSSL_LOG_LEVEL_DEBUG      (3)
 
-void SCOSSL_ENGINE_set_trace_level(int trace_level);
+void SCOSSL_ENGINE_set_trace_level(int trace_level, int ossl_ERR_level);
 void SCOSSL_ENGINE_set_trace_log_filename(const char *filename);
 
 // SymCrypt-OpenSSL Engine Initialization.

--- a/SymCryptEngine/src/scossl.c
+++ b/SymCryptEngine/src/scossl.c
@@ -20,8 +20,8 @@ extern "C" {
 int scossl_module_initialized = 0;
 
 /* The constants used when creating the ENGINE */
-static const char* engine_scossl_id = "symcrypt";
-static const char* engine_scossl_name = "Symcrypt Engine";
+static const char* engine_scossl_id = "SCOSSL";
+static const char* engine_scossl_name = "SymCrypt engine for OpenSSL";
 static EC_KEY_METHOD* scossl_eckey_method = NULL;
 static RSA_METHOD* scossl_rsa_method = NULL;
 // static DSA_METHOD* scossl_dsa_method = NULL;
@@ -45,6 +45,7 @@ SCOSSL_STATUS scossl_destroy(ENGINE* e)
     DH_meth_free(scossl_dh_method);
     scossl_dh_method = NULL;
     CRYPTO_free_ex_index(CRYPTO_EX_INDEX_DH, scossl_dh_idx);
+    scossl_destroy_logging();
 
     return SCOSSL_SUCCESS;
 }
@@ -60,7 +61,7 @@ static SCOSSL_STATUS scossl_bind_engine(ENGINE* e)
     }
 
     scossl_eckey_method = EC_KEY_METHOD_new(EC_KEY_OpenSSL());
-    scossl_rsa_method = RSA_meth_new("SymCrypt RSA Method", 0);
+    scossl_rsa_method = RSA_meth_new("SCOSSL RSA Method", 0);
     // scossl_dsa_method = DSA_meth_dup(DSA_OpenSSL());
     scossl_dh_method = DH_meth_dup(DH_OpenSSL());
 
@@ -177,8 +178,8 @@ static SCOSSL_STATUS scossl_bind_engine(ENGINE* e)
     RSA_set_default_method(ENGINE_get_RSA(e));
     EC_KEY_set_default_method(ENGINE_get_EC(e));
 
-    // Register the Engine as a source of OpenSSL errors
-    SCOSSL_ENGINE_setup_ERR();
+    // Register the Engine as a source of OpenSSL errors and create logging lock
+    scossl_setup_logging();
 
     // Initialize hidden static variables once at Engine load time
     if(    !scossl_ecc_init_static()

--- a/SymCryptEngine/src/scossl.c
+++ b/SymCryptEngine/src/scossl.c
@@ -20,8 +20,8 @@ extern "C" {
 int scossl_module_initialized = 0;
 
 /* The constants used when creating the ENGINE */
-static const char* engine_scossl_id = "SCOSSL";
-static const char* engine_scossl_name = "SymCrypt engine for OpenSSL";
+static const char* engine_scossl_id = "symcrypt";
+static const char* engine_scossl_name = "SCOSSL (SymCrypt engine for OpenSSL)";
 static EC_KEY_METHOD* scossl_eckey_method = NULL;
 static RSA_METHOD* scossl_rsa_method = NULL;
 // static DSA_METHOD* scossl_dsa_method = NULL;
@@ -61,7 +61,7 @@ static SCOSSL_STATUS scossl_bind_engine(ENGINE* e)
     }
 
     scossl_eckey_method = EC_KEY_METHOD_new(EC_KEY_OpenSSL());
-    scossl_rsa_method = RSA_meth_new("SCOSSL RSA Method", 0);
+    scossl_rsa_method = RSA_meth_new("SCOSSL (SymCrypt engine for OpenSSL) RSA Method", 0);
     // scossl_dsa_method = DSA_meth_dup(DSA_OpenSSL());
     scossl_dh_method = DH_meth_dup(DH_OpenSSL());
 

--- a/SymCryptEngine/src/scossl_helpers.c
+++ b/SymCryptEngine/src/scossl_helpers.c
@@ -149,15 +149,18 @@ void SCOSSL_ENGINE_set_trace_log_filename(const char *filename)
     }
     _traceLogFilename = OPENSSL_strdup(filename);
 
-
     if( CRYPTO_THREAD_write_lock(_loggingLock) )
     {
         if( _traceLogFile != NULL && _traceLogFile != stderr )
         {
             fflush(_traceLogFile);
             fclose(_traceLogFile);
+            _traceLogFile = NULL;
         }
-        _traceLogFile = fopen(_traceLogFilename, "a");
+        if( _traceLogFilename != NULL )
+        {
+            _traceLogFile = fopen(_traceLogFilename, "a");
+        }
         if( _traceLogFile == NULL )
         {
             _traceLogFile = stderr;

--- a/SymCryptEngine/src/scossl_helpers.c
+++ b/SymCryptEngine/src/scossl_helpers.c
@@ -17,9 +17,16 @@ extern "C" {
 #define SCOSSL_LOG_LEVEL_PREFIX_INFO        "INFO"
 #define SCOSSL_LOG_LEVEL_PREFIX_DEBUG       "DEBUG"
 
+// Level of tracing that is output to stderr / log file
 static int _traceLogLevel = SCOSSL_LOG_LEVEL_INFO;
 static char *_traceLogFilename = NULL;
 static FILE *_traceLogFile = NULL;
+
+// Level of tracing that is output to OpenSSL ERR infrastructure
+// By default only log actual errors, as some OpenSSL unit tests check that successful calls do not
+// generate any ERR entries. Callers may wish to set this to SCOSSL_LOG_LEVEL_INFO to expose data
+// about where they may not be calling FIPS certified code.
+static int _osslERRLogLevel = SCOSSL_LOG_LEVEL_ERROR;
 
 // Lock around writing information to stderr/log file/OpenSSL ERR handling framework to avoid
 // muddled error messages in multi-threaded environment
@@ -98,7 +105,7 @@ static ERR_STRING_DATA SCOSSL_ERR_reason_strings[] = {
 
 C_ASSERT( (sizeof(SCOSSL_ERR_reason_strings) / sizeof(ERR_STRING_DATA)) == SCOSSL_ERR_R_ENUM_END-SCOSSL_ERR_R_ENUM_START );
 
-void SCOSSL_ENGINE_setup_ERR()
+void scossl_setup_logging()
 {
     if( _scossl_err_library_code == 0 )
     {
@@ -115,14 +122,23 @@ void SCOSSL_ENGINE_setup_ERR()
     }
 }
 
-void SCOSSL_ENGINE_set_trace_level(int trace_level)
+void scossl_destroy_logging()
+{
+    CRYPTO_THREAD_lock_free(_loggingLock);
+}
+
+void SCOSSL_ENGINE_set_trace_level(int trace_level, int ossl_ERR_level)
 {
     if( trace_level >= SCOSSL_LOG_LEVEL_OFF &&
         trace_level <= SCOSSL_LOG_LEVEL_DEBUG )
     {
         _traceLogLevel = trace_level;
     }
-    return;
+    if( ossl_ERR_level >= SCOSSL_LOG_LEVEL_OFF &&
+        ossl_ERR_level <= SCOSSL_LOG_LEVEL_DEBUG )
+    {
+        _osslERRLogLevel = ossl_ERR_level;
+    }
 }
 
 void SCOSSL_ENGINE_set_trace_log_filename(const char *filename)
@@ -167,7 +183,7 @@ void _scossl_log_bytes(
     va_start(args, format);
     char *trace_level_prefix = "";
 
-    if( _traceLogLevel < trace_level )
+    if( SYMCRYPT_MAX(_traceLogLevel, _osslERRLogLevel) < trace_level )
     {
         return;
     }
@@ -196,18 +212,24 @@ void _scossl_log_bytes(
 
     if( CRYPTO_THREAD_write_lock(_loggingLock) )
     {
-        // Log an OpenSSL error, so calling applications can handle the log appropriately
-        ERR_put_error(_scossl_err_library_code, func_code, reason_code, file, line);
-        // Add error string indicating the error details as error data
-        ERR_add_error_data(1, paraBuf);
-
-        // Log details to stderr or a log file
-        ERR_error_string_n(ERR_PACK(_scossl_err_library_code, func_code, reason_code), errStringBuf, sizeof(errStringBuf));
-
-        fprintf(_traceLogFile, "[%s] %s:%s at %s, line %d\n", trace_level_prefix, errStringBuf, paraBuf, file, line);
-        if( s )
+        if( _osslERRLogLevel >= trace_level )
         {
-            fwrite(s, 1, len, _traceLogFile);
+            // Log an OpenSSL error, so calling applications can handle the log appropriately
+            ERR_put_error(_scossl_err_library_code, func_code, reason_code, file, line);
+            // Add error string indicating the error details as error data
+            ERR_add_error_data(1, paraBuf);
+        }
+
+        if( _traceLogLevel >= trace_level )
+        {
+            // Log details to stderr or a log file
+            ERR_error_string_n(ERR_PACK(_scossl_err_library_code, func_code, reason_code), errStringBuf, sizeof(errStringBuf));
+
+            fprintf(_traceLogFile, "[%s] %s:%s at %s, line %d\n", trace_level_prefix, errStringBuf, paraBuf, file, line);
+            if( s )
+            {
+                fwrite(s, 1, len, _traceLogFile);
+            }
         }
     }
     CRYPTO_THREAD_unlock(_loggingLock);
@@ -243,7 +265,7 @@ void _scossl_log_bignum(
     unsigned char *string = NULL;
     int length = 0;
 
-    if( _traceLogLevel < trace_level )
+    if( SYMCRYPT_MAX(_traceLogLevel, _osslERRLogLevel) < trace_level )
     {
         return;
     }

--- a/SymCryptEngine/src/scossl_helpers.h
+++ b/SymCryptEngine/src/scossl_helpers.h
@@ -27,11 +27,10 @@ typedef _Return_type_success_(return >= 0) int SCOSSL_RETURNLENGTH; // For funct
 // Only applies in certain contexts (used when implementing EVP-layer functionality)
 #define SCOSSL_UNSUPPORTED (-2)
 
-void* SCOSSL_ENGINE_zalloc(size_t num);
-void* SCOSSL_ENGINE_realloc(void *mem, size_t num);
-void SCOSSL_ENGINE_free(void *mem);
-
-void SCOSSL_ENGINE_setup_ERR();
+// Functions to set up and destroy SCOSSL logging static variables, locks, and integration with
+// OpenSSL ERR infrastructure. Should only be called in Engine bind / destroy.
+void scossl_setup_logging();
+void scossl_destroy_logging();
 
 // SCOSSL function codes
 typedef enum {


### PR DESCRIPTION
+ Do not leak CRYPTO_RWLOCK
+ Introduce ability to set different levels of logging verbosity for
  using OpenSSL ERR and stderr/logfile. Set default level of logging for
  OpenSSL ERR to ERROR to avoid problems in OpenSSL unit tests.
+ Update Engine id and name