### PR TITLE
Prepare for upcoming SymCrypt API changes

### DIFF
--- a/SymCryptEngine/dynamic/CMakeLists.txt
+++ b/SymCryptEngine/dynamic/CMakeLists.txt
@@ -12,6 +12,8 @@ set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++1y -Wall -Wextra -Wno-unused-par
 find_package(OpenSSL REQUIRED)
 include_directories(${OPENSSL_INCLUDE_DIR})
 
+find_library(SYMCRYPT_LIBRARY symcrypt)
+
 add_library(scossl_dynamic SHARED
     ../src/scossl.c
     ../src/scossl_ciphers.c
@@ -39,7 +41,7 @@ set_target_properties(scossl_dynamic PROPERTIES PREFIX "")
 set_target_properties(scossl_dynamic PROPERTIES OUTPUT_NAME "symcryptengine")
 
 target_link_directories(scossl_dynamic PUBLIC ${CMAKE_SOURCE_DIR})
-target_link_libraries(scossl_dynamic PUBLIC symcrypt)
+target_link_libraries(scossl_dynamic PUBLIC ${SYMCRYPT_LIBRARY})
 target_link_libraries(scossl_dynamic PUBLIC ${OPENSSL_CRYPTO_LIBRARY})
 
 # Install the engine to the OpenSSL engines directory

--- a/SymCryptEngine/src/scossl.c
+++ b/SymCryptEngine/src/scossl.c
@@ -56,7 +56,7 @@ static SCOSSL_STATUS scossl_bind_engine(ENGINE* e)
 
     if( !scossl_module_initialized )
     {
-        SymCryptModuleInit(SYMCRYPT_CODE_VERSION_API, SYMCRYPT_CODE_VERSION_MINOR, SYMCRYPT_CODE_VERSION_PATCH);
+        SYMCRYPT_MODULE_INIT();
         scossl_module_initialized = 1;
     }
 

--- a/SymCryptEngine/src/scossl_helpers.c
+++ b/SymCryptEngine/src/scossl_helpers.c
@@ -316,9 +316,6 @@ void _scossl_log_SYMCRYPT_ERROR(
         case SYMCRYPT_NO_ERROR:
             scErrorString = "SYMCRYPT_NO_ERROR";
             break;
-        case SYMCRYPT_UNUSED:
-            scErrorString = "SYMCRYPT_UNUSED";
-            break;
         case SYMCRYPT_WRONG_KEY_SIZE:
             scErrorString = "SYMCRYPT_WRONG_KEY_SIZE";
             break;


### PR DESCRIPTION
This PR includes a few changes to prepare for some upcoming SymCrypt changes. It should be backwards-compatible with existing versions of SymCrypt.

- Use `SYMCRYPT_MODULE_INIT()` macro instead of explicitly calling `SymCryptModuleInit`. The macro automatically passes in the right arguments, and will work with the new version which is removing the patch version as an argument.
- Remove reference to `SYMCRYPT_UNUSED` error code, which is being removed,
- Use CMake's [find_library](https://cmake.org/cmake/help/latest/command/find_library.html) function to find the symcrypt library on the system. This will hopefully be slightly more robust than just directly specifying the library name in `target_link_libraries`. In the future, we may want to create a CMake package config for SymCrypt and use `find_package`, but this requires additional work.