### PR TITLE
Various tidying to reduce warnings in build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,9 @@
 cmake_minimum_required(VERSION 3.13.0)
 
-project(scossl)
+project(SymCrypt-OpenSSL
+    VERSION 1.0.0
+    DESCRIPTION "The SymCrypt engine for OpenSSL (SCOSSL)"
+    HOMEPAGE_URL "https://github.com/microsoft/SymCrypt-OpenSSL")
 
 include_directories(${SYMCRYPT_ROOT_DIR}/inc)
 
@@ -26,5 +29,3 @@ endif()
 add_subdirectory (SymCryptEngine/static)
 add_subdirectory (SymCryptEngine/dynamic)
 add_subdirectory (SslPlay)
-
-

--- a/README.md
+++ b/README.md
@@ -43,19 +43,34 @@ Note that just because an algorithm is FIPS certifiable, does not mean it is rec
 2. Use of unsupported digests in RSA signatures and TLS PRF
 3. Use of multi-prime (more than 2-prime) RSA
 
+## Versioning and Servicing
+
+As of version 1.0.0, SCOSSL uses the versioning scheme defined by the [Semantic Versioning 2.0.0](https://semver.org/spec/v2.0.0.html) specification. This means:
+
+- Major version changes introduce ABI and/or API breaking changes
+- Minor version changes introduce backwards compatible additional functionality or improvements, and/or bug fixes
+- Patch version changes introduce backwards compatible bug fixes
+
+Regarding servicing, our strong recommendation is that distro vendors and application developers regularly
+update to the latest version of SymCrypt and SymCrypt engine for both security fixes and
+functionality/performance improvements.
+
+We will support long-term servicing of specific releases for security fixes. Details of this plan will be
+released publicly in the future.
+
 # Building Instructions
 ## Compilation Instructions
-## Prerequisite, need libssl installed to compile
 
-1. Follow Linux build instructions from SymCrypt repository [SymCrypt](https://github.com/Microsoft/SymCrypt) to build the Linux SymCrypt module
+1. Install libssl, or compile and install OpenSSL from source
+2. Follow Linux build instructions from SymCrypt repository [SymCrypt](https://github.com/Microsoft/SymCrypt) to build the Linux SymCrypt module
     * You can either install the Linux SymCrypt module (i.e libsymcrypt.so* to /usr/lib/, and inc/* to /usr/include/), or
     * Copy the built module to the root of the SymCrypt-OpenSSL repo `cp <SymCryptRepo>/bin/module/<arch>/LinuxUserMode/<module_name>/libsymcrypt.so ./`
-2. `mkdir bin; cd bin`
-3. `cmake .. -DCMAKE_TOOLCHAIN_FILE=../cmake-toolchain/LinuxUserMode-<arch>.cmake`
+3. `mkdir bin; cd bin`
+4. `cmake .. -DCMAKE_TOOLCHAIN_FILE=../cmake-toolchain/LinuxUserMode-<arch>.cmake`
     * If you have not installed SymCrypt header files, you can also specify the root directory `-DSYMCRYPT_ROOT_DIR=<SymCryptRepo>`
     * If you want to link to a specific OpenSSL installation, you can also specify `-DOPENSSL_ROOT_DIR=<OpensslInstallDirectory>`
     * Optionally, for a release build, specify `-DCMAKE_BUILD_TYPE=Release`
-4, `cmake --build .`
+5. `cmake --build .`
     * Optionally specify `-jN` where N is the number of processes you wish to spawn for the build
 
 ## Run Samples

--- a/README.md
+++ b/README.md
@@ -47,14 +47,16 @@ Note that just because an algorithm is FIPS certifiable, does not mean it is rec
 ## Compilation Instructions
 ## Prerequisite, need libssl installed to compile
 
-Follow Linux build instructions from SymCrypt repository [SymCrypt](https://github.com/Microsoft/SymCrypt) to build the Linux SymCrypt module.
-
-```
-cp <SymCryptRepo>/bin/module/<arch>/LinuxUserMode/<module_name>/libsymcrypt.so ./
-mkdir bin; cd bin
-cmake .. -DSYMCRYPT_ROOT_DIR=<SymCryptRepo> -DOPENSSL_ROOT_DIR=<OpensslInstallDirectory> -DCMAKE_TOOLCHAIN_FILE=../cmake-toolchain/LinuxUserMode-<arch>.cmake -DCMAKE_BUILD_TYPE=Release
-cmake --build .
-```
+1. Follow Linux build instructions from SymCrypt repository [SymCrypt](https://github.com/Microsoft/SymCrypt) to build the Linux SymCrypt module
+    * You can either install the Linux SymCrypt module (i.e libsymcrypt.so* to /usr/lib/, and inc/* to /usr/include/), or
+    * Copy the built module to the root of the SymCrypt-OpenSSL repo `cp <SymCryptRepo>/bin/module/<arch>/LinuxUserMode/<module_name>/libsymcrypt.so ./`
+2. `mkdir bin; cd bin`
+3. `cmake .. -DCMAKE_TOOLCHAIN_FILE=../cmake-toolchain/LinuxUserMode-<arch>.cmake`
+    * If you have not installed SymCrypt header files, you can also specify the root directory `-DSYMCRYPT_ROOT_DIR=<SymCryptRepo>`
+    * If you want to link to a specific OpenSSL installation, you can also specify `-DOPENSSL_ROOT_DIR=<OpensslInstallDirectory>`
+    * Optionally, for a release build, specify `-DCMAKE_BUILD_TYPE=Release`
+4, `cmake --build .`
+    * Optionally specify `-jN` where N is the number of processes you wish to spawn for the build
 
 ## Run Samples
 ```

--- a/SslPlay/SslPlay.cpp
+++ b/SslPlay/SslPlay.cpp
@@ -60,8 +60,6 @@ void TestEcdsa(EC_KEY* key)
         0x1, 0x54, 0xF, 0x2, 0xC9, 0xC, 0xFF, 0x31
     };
     unsigned char resultBytes[SCOSSL_ECDSA_MAX_DER_SIGNATURE_LEN] = { 0 };
-    bool result = true;
-    int currentIteration = 0;
     unsigned int signatureBytesCount = sizeof(resultBytes);
     ECDSA_SIG* ecdsaSig = NULL;
     printf("Command ECDSA_sign\n");
@@ -643,7 +641,6 @@ void TestRsaDigestSignVerify(
     size_t signature_len = 0;
     const unsigned char plaintext[] =
         "Message for testing EVP_PKEY_Encrypt* APIs for encryption/decryption";
-    size_t plaintext_len = sizeof(plaintext);
     const char message[] = "My EVP_DigestSign Message";
     size_t message_len = sizeof(message);
     bool authentic = false;
@@ -1140,7 +1137,6 @@ end:
 
 void TestDigests()
 {
-    EVP_MD *md = NULL;
     char mess1[] = "Test Message1234567";
     char mess2[] = "Hello World";
     unsigned int md_len=32, i;
@@ -1513,7 +1509,7 @@ end:
 void TestAesGcmCipher(
     const char* ciphername, const EVP_CIPHER *cipher, unsigned char *key, int key_length,
     unsigned char *iv, int iv_length, unsigned char *aad, int aad_length, unsigned char* plaintext,
-    int plaintext_len)
+    int plaintext_len, unsigned char *expected_tag=NULL, int expected_tag_length=0)
 {
     unsigned char ciphertext[8192];
     int ciphertext_len = 0;
@@ -1531,6 +1527,12 @@ void TestAesGcmCipher(
     BIO_dump_fp (stdout, (const char *)plaintext, plaintext_len);
     /* Encrypt the plaintext */
     ciphertext_len = encrypt_gcm(cipher, plaintext, plaintext_len, aad, aad_length, key, iv, ciphertext, tag);
+    /* Check the tag matches if not NULL */
+    if (expected_tag != NULL &&
+        memcmp(tag, expected_tag, expected_tag_length))
+    {
+        handleError("Expected tag not produced by encryption\n");
+    }
     /* Do something useful with the ciphertext here */
     printf("Ciphertext:\n");
     BIO_dump_fp (stdout, (const char *)ciphertext, ciphertext_len);
@@ -1573,7 +1575,7 @@ TestAesGcmGeneric()
     TestAesGcmCipher("EVP_aes_192_gcm", EVP_aes_192_gcm(), key, 24, iv, 12, aad, 16, plaintext, plaintext_len);
     TestAesGcmCipher("EVP_aes_256_gcm", EVP_aes_256_gcm(), key, 32, iv, 12, aad, 16, plaintext, plaintext_len);
 
-    TestAesGcmCipher("EVP_aes_256_gcm", EVP_aes_256_gcm(), gcm_key, 32, gcm_iv, 12, gcm_aad, 16, gcm_pt, 16);
+    TestAesGcmCipher("EVP_aes_256_gcm", EVP_aes_256_gcm(), gcm_key, 32, gcm_iv, 12, gcm_aad, 16, gcm_pt, 16, gcm_tag, 16);
 
     printf("%s", SeparatorLine);
     return;

--- a/SymCryptEngine/dynamic/CMakeLists.txt
+++ b/SymCryptEngine/dynamic/CMakeLists.txt
@@ -12,7 +12,7 @@ set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++1y -Wall -Wextra -Wno-unused-par
 find_package(OpenSSL REQUIRED)
 include_directories(${OPENSSL_INCLUDE_DIR})
 
-find_library(SYMCRYPT_LIBRARY symcrypt)
+find_library(SYMCRYPT_LIBRARY symcrypt PATHS ../../)
 
 add_library(scossl_dynamic SHARED
     ../src/scossl.c

--- a/SymCryptEngine/dynamic/CMakeLists.txt
+++ b/SymCryptEngine/dynamic/CMakeLists.txt
@@ -12,7 +12,7 @@ set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++1y -Wall -Wextra -Wno-unused-par
 find_package(OpenSSL REQUIRED)
 include_directories(${OPENSSL_INCLUDE_DIR})
 
-find_library(SYMCRYPT_LIBRARY symcrypt PATHS ../../)
+find_library(SYMCRYPT_LIBRARY symcrypt PATHS ${CMAKE_SOURCE_DIR})
 
 add_library(scossl_dynamic SHARED
     ../src/scossl.c
@@ -40,7 +40,6 @@ target_include_directories (scossl_dynamic PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
 set_target_properties(scossl_dynamic PROPERTIES PREFIX "")
 set_target_properties(scossl_dynamic PROPERTIES OUTPUT_NAME "symcryptengine")
 
-target_link_directories(scossl_dynamic PUBLIC ${CMAKE_SOURCE_DIR})
 target_link_libraries(scossl_dynamic PUBLIC ${SYMCRYPT_LIBRARY})
 target_link_libraries(scossl_dynamic PUBLIC ${OPENSSL_CRYPTO_LIBRARY})
 

--- a/SymCryptEngine/src/scossl_ecc.c
+++ b/SymCryptEngine/src/scossl_ecc.c
@@ -1161,8 +1161,8 @@ SCOSSL_RETURNLENGTH scossl_eckey_compute_key(_Out_writes_bytes_(*pseclen) unsign
         goto cleanup;
     }
 
-    if( (BN_bn2binpad(ec_pub_x, buf, cbPublicKey/2) != cbPublicKey/2) ||
-        (BN_bn2binpad(ec_pub_y, buf + (cbPublicKey/2), cbPublicKey/2) != cbPublicKey/2) )
+    if( (BN_bn2binpad(ec_pub_x, buf, cbPublicKey/2) != (int) cbPublicKey/2) ||
+        (BN_bn2binpad(ec_pub_y, buf + (cbPublicKey/2), cbPublicKey/2) != (int) cbPublicKey/2) )
     {
         SCOSSL_LOG_ERROR(SCOSSL_ERR_F_ECKEY_COMPUTE_KEY, ERR_R_OPERATION_FAIL,
             "BN_bn2binpad did not write expected number of public key bytes.");

--- a/SymCryptEngine/src/scossl_rsa.c
+++ b/SymCryptEngine/src/scossl_rsa.c
@@ -151,7 +151,7 @@ SCOSSL_RETURNLENGTH scossl_rsa_pub_enc(int flen, _In_reads_bytes_(flen) const un
         break;
     }
 
-    ret = (cbResult <= INT_MAX) ? cbResult : -1;
+    ret = (cbResult <= INT_MAX) ? (int) cbResult : -1;
 
 cleanup:
     return ret;
@@ -271,7 +271,7 @@ SCOSSL_RETURNLENGTH scossl_rsa_priv_dec(int flen, _In_reads_bytes_(flen) const u
         break;
     }
 
-    ret = (cbResult <= INT_MAX) ? cbResult : -1;
+    ret = (cbResult <= INT_MAX) ? (int) cbResult : -1;
 
 cleanup:
     return ret;
@@ -481,7 +481,6 @@ SCOSSL_STATUS scossl_rsa_verify(int dtype, _In_reads_bytes_(m_length) const unsi
     _In_reads_bytes_(siglen) const unsigned char* sigbuf,
     unsigned int siglen, _In_ const RSA* rsa)
 {
-    BN_ULONG cbModulus = 0;
     SCOSSL_STATUS ret = SCOSSL_FAILURE;
     SYMCRYPT_ERROR scError = SYMCRYPT_NO_ERROR;
     SCOSSL_RSA_KEY_CONTEXT *keyCtx = RSA_get_ex_data(rsa, scossl_rsa_idx);
@@ -500,7 +499,6 @@ SCOSSL_STATUS scossl_rsa_verify(int dtype, _In_reads_bytes_(m_length) const unsi
         }
     }
 
-    cbModulus = SymCryptRsakeySizeofModulus(keyCtx->key);
     switch( dtype )
     {
     case NID_md5_sha1:

--- a/SymCryptEngine/src/scossl_rsapss.c
+++ b/SymCryptEngine/src/scossl_rsapss.c
@@ -192,7 +192,6 @@ cleanup:
 SCOSSL_STATUS scossl_rsapss_verify(_Inout_ EVP_PKEY_CTX *ctx, _In_reads_bytes_(siglen) const unsigned char *sig, size_t siglen,
                                       _In_reads_bytes_(tbslen) const unsigned char *tbs, size_t tbslen)
 {
-    BN_ULONG cbModulus = 0;
     EVP_PKEY* pkey = NULL;
     RSA* rsa = NULL;
     int ret = SCOSSL_FAILURE;
@@ -281,8 +280,6 @@ SCOSSL_STATUS scossl_rsapss_verify(_Inout_ EVP_PKEY_CTX *ctx, _In_reads_bytes_(s
     {
         goto cleanup;
     }
-
-    cbModulus = SymCryptRsakeySizeofModulus(keyCtx->key);
 
     scossl_mac_algo = scossl_get_symcrypt_hash_algorithm(type);
     expectedTbsLength = scossl_get_expected_tbs_length(type);


### PR DESCRIPTION
+ Allow libsymcrypt to be found from root of SymCrypt-OpenSSL directory
+ Update README to make compilation instructions a little clearer
+ Add CMake project version/description