### PR TITLE
Avoid redundant ECC tests on key generation

### DIFF
--- a/SymCryptEngine/src/scossl.c
+++ b/SymCryptEngine/src/scossl.c
@@ -29,23 +29,26 @@ static DH_METHOD* scossl_dh_method = NULL;
 
 SCOSSL_STATUS scossl_destroy(ENGINE* e)
 {
-    scossl_destroy_digests();
-    scossl_destroy_ciphers();
-    scossl_destroy_pkey_methods();
-    RSA_meth_free(scossl_rsa_method);
-    scossl_rsa_method = NULL;
-    scossl_destroy_ecc_curves();
-    EC_KEY_METHOD_free(scossl_eckey_method);
-    scossl_eckey_method = NULL;
-    CRYPTO_free_ex_index(CRYPTO_EX_INDEX_RSA, scossl_rsa_idx);
-    CRYPTO_free_ex_index(CRYPTO_EX_INDEX_EC_KEY, scossl_eckey_idx);
-    // DSA_meth_free(scossl_dsa_method);
-    // scossl_dsa_method = NULL;
-    scossl_destroy_safeprime_dlgroups();
-    DH_meth_free(scossl_dh_method);
-    scossl_dh_method = NULL;
-    CRYPTO_free_ex_index(CRYPTO_EX_INDEX_DH, scossl_dh_idx);
-    scossl_destroy_logging();
+    if( scossl_eckey_method != NULL )
+    {
+        scossl_destroy_digests();
+        scossl_destroy_ciphers();
+        scossl_destroy_pkey_methods();
+        RSA_meth_free(scossl_rsa_method);
+        scossl_rsa_method = NULL;
+        scossl_destroy_ecc_curves();
+        EC_KEY_METHOD_free(scossl_eckey_method);
+        scossl_eckey_method = NULL;
+        CRYPTO_free_ex_index(CRYPTO_EX_INDEX_RSA, scossl_rsa_idx);
+        CRYPTO_free_ex_index(CRYPTO_EX_INDEX_EC_KEY, scossl_eckey_idx);
+        // DSA_meth_free(scossl_dsa_method);
+        // scossl_dsa_method = NULL;
+        scossl_destroy_safeprime_dlgroups();
+        DH_meth_free(scossl_dh_method);
+        scossl_dh_method = NULL;
+        CRYPTO_free_ex_index(CRYPTO_EX_INDEX_DH, scossl_dh_idx);
+        scossl_destroy_logging();
+    }
 
     return SCOSSL_SUCCESS;
 }

--- a/SymCryptEngine/src/scossl_ciphers.c
+++ b/SymCryptEngine/src/scossl_ciphers.c
@@ -939,7 +939,7 @@ SCOSSL_RETURNLENGTH scossl_aes_gcm_cipher(_Inout_ EVP_CIPHER_CTX *ctx, _Out_ uns
 
     if( EVP_CIPHER_CTX_encrypting(ctx) )
     {
-        if( inl > 0 )
+        if( in != NULL )
         {
             // Encrypt Part
             SymCryptGcmEncryptPart(&cipherCtx->state, in, out, inl);
@@ -954,7 +954,7 @@ SCOSSL_RETURNLENGTH scossl_aes_gcm_cipher(_Inout_ EVP_CIPHER_CTX *ctx, _Out_ uns
     }
     else
     {
-        if( inl > 0 )
+        if( in != NULL )
         {
             // Decrypt Part
             SymCryptGcmDecryptPart(&cipherCtx->state, in, out, inl);

--- a/SymCryptEngine/src/scossl_dh.c
+++ b/SymCryptEngine/src/scossl_dh.c
@@ -98,9 +98,7 @@ SCOSSL_STATUS scossl_dh_generate_keypair(
         goto cleanup;
     }
 
-    scError = SymCryptDlkeyGenerate(
-        SYMCRYPT_FLAG_KEY_RANGE_AND_PUBLIC_KEY_ORDER_VALIDATION | SYMCRYPT_FLAG_DLKEY_SELFTEST_DH,
-        pKeyCtx->dlkey );
+    scError = SymCryptDlkeyGenerate( SYMCRYPT_FLAG_DLKEY_DH, pKeyCtx->dlkey );
     if( scError != SYMCRYPT_NO_ERROR )
     {
         SCOSSL_LOG_SYMCRYPT_ERROR(SCOSSL_ERR_F_DH_GENERATE_KEYPAIR, SCOSSL_ERR_R_SYMCRYPT_FAILURE,
@@ -267,7 +265,7 @@ SCOSSL_STATUS scossl_dh_import_keypair(
         pbPrivateKey, cbPrivateKey,
         pbPublicKey, cbPublicKey,
         SYMCRYPT_NUMBER_FORMAT_MSB_FIRST,
-        SYMCRYPT_FLAG_KEY_RANGE_AND_PUBLIC_KEY_ORDER_VALIDATION | SYMCRYPT_FLAG_KEY_KEYPAIR_REGENERATION_VALIDATION | SYMCRYPT_FLAG_DLKEY_SELFTEST_DH,
+        SYMCRYPT_FLAG_DLKEY_DH,
         pKeyCtx->dlkey );
     if( scError != SYMCRYPT_NO_ERROR )
     {
@@ -578,7 +576,7 @@ SCOSSL_RETURNLENGTH scossl_dh_compute_key(_Out_writes_bytes_(DH_size(dh)) unsign
         NULL, 0,
         buf, cbPublicKey,
         SYMCRYPT_NUMBER_FORMAT_MSB_FIRST,
-        SYMCRYPT_FLAG_KEY_RANGE_AND_PUBLIC_KEY_ORDER_VALIDATION | SYMCRYPT_FLAG_DLKEY_SELFTEST_DH,
+        SYMCRYPT_FLAG_DLKEY_DH,
         pkPublic );
     if( scError != SYMCRYPT_NO_ERROR )
     {

--- a/SymCryptEngine/src/scossl_pkey_meths.c
+++ b/SymCryptEngine/src/scossl_pkey_meths.c
@@ -260,7 +260,8 @@ int scossl_pkey_methods(_Inout_ ENGINE *e, _Out_opt_ EVP_PKEY_METHOD **pmeth,
 
 void scossl_destroy_pkey_methods(void)
 {
-    // It seems that explicitly freeing these methods in the destroy method causes a double free
+    // It seems that explicitly freeing these methods in the destroy method causes a double free as
+    // OpenSSL automatically frees pkey methods associated with an engine in destroying the engine
     // (seen in SslPlay with sanitizers on, or in OpenSSL applications using the engine)
     // For now just don't free these methods here, but keep an eye out for memory leaks
 

--- a/SymCryptEngine/src/scossl_rsa.c
+++ b/SymCryptEngine/src/scossl_rsa.c
@@ -696,7 +696,7 @@ SCOSSL_STATUS scossl_rsa_keygen(_Out_ RSA* rsa, int bits, _In_ BIGNUM* e,
             "SymCryptLoadMsbFirstUint64 failed");
         goto cleanup;
     }
-    scError = SymCryptRsakeyGenerate(keyCtx->key, &pubExp64, 1, SYMCRYPT_FLAG_RSAKEY_SELFTEST);
+    scError = SymCryptRsakeyGenerate(keyCtx->key, &pubExp64, 1, SYMCRYPT_FLAG_RSAKEY_SIGN | SYMCRYPT_FLAG_RSAKEY_ENCRYPT);
     if( scError != SYMCRYPT_NO_ERROR )
     {
         SCOSSL_LOG_SYMCRYPT_ERROR(SCOSSL_ERR_F_RSA_KEYGEN, SCOSSL_ERR_R_SYMCRYPT_FAILURE,
@@ -984,7 +984,7 @@ SCOSSL_STATUS scossl_initialize_rsa_key(_In_ RSA* rsa, _Out_ SCOSSL_RSA_KEY_CONT
                    (SIZE_T *)pcbPrimes,
                    nPrimes,
                    SYMCRYPT_NUMBER_FORMAT_MSB_FIRST,
-                   SYMCRYPT_FLAG_RSAKEY_SELFTEST,
+                   SYMCRYPT_FLAG_RSAKEY_SIGN | SYMCRYPT_FLAG_RSAKEY_ENCRYPT,
                    keyCtx->key);
     if( scError != SYMCRYPT_NO_ERROR )
     {

--- a/SymCryptEngine/src/scossl_rsapss.c
+++ b/SymCryptEngine/src/scossl_rsapss.c
@@ -105,7 +105,8 @@ SCOSSL_STATUS scossl_rsapss_sign(_Inout_ EVP_PKEY_CTX *ctx, _Out_writes_opt_(*si
     {
         cbSalt = RSA_size(rsa) - EVP_MD_size(messageDigest) - 2;
     }
-    else if ( (cbSalt < 0) || (cbSalt > (RSA_size(rsa) - EVP_MD_size(messageDigest) - 2)) )
+    
+    if ( (cbSalt < 0) || (cbSalt > (RSA_size(rsa) - EVP_MD_size(messageDigest) - 2)) )
     {
         SCOSSL_LOG_ERROR(SCOSSL_ERR_F_RSAPSS_SIGN, ERR_R_PASSED_INVALID_ARGUMENT,
             "Invalid cbSalt");
@@ -254,7 +255,8 @@ SCOSSL_STATUS scossl_rsapss_verify(_Inout_ EVP_PKEY_CTX *ctx, _In_reads_bytes_(s
             "SymCrypt Engine does not support RSA_PSS_SALTLEN_AUTO saltlen");
         return SCOSSL_UNSUPPORTED;
     }
-    else if ( (cbSalt < 0) || (cbSalt > (RSA_size(rsa) - EVP_MD_size(messageDigest) - 2)) )
+    
+    if ( (cbSalt < 0) || (cbSalt > (RSA_size(rsa) - EVP_MD_size(messageDigest) - 2)) )
     {
         SCOSSL_LOG_ERROR(SCOSSL_ERR_F_RSAPSS_VERIFY, ERR_R_PASSED_INVALID_ARGUMENT,
             "Invalid cbSalt");


### PR DESCRIPTION
+ Use new SymCrypt flags to specify asymmetric key purposes
+ Avoid crash on invalid RSA-PSS input
+ Avoid double free if Engine is destroyed multiple times
+ Tweak AES-GCM to only Finalize when passed `in` pointer of NULL