### PR TITLE
Do not set -DDBG=1 when build type is RelWithDebInfo

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,7 +19,7 @@ if (CMAKE_BUILD_TYPE MATCHES Sanitize)
     add_link_options(-fno-sanitize-recover=all)
 endif()
 
-if(CMAKE_BUILD_TYPE MATCHES Release)
+if(CMAKE_BUILD_TYPE MATCHES Release|RelWithDebInfo)
     message("Release mode")
 else()
     message("Debug mode")


### PR DESCRIPTION
In some environments, we use CMake's RelWithDebInfo build type so that we can do an optimized build but still get debug symbols, which we then copy and strip from the binary in a separate step. When building this way, we don't want the `DBG` flag to be set.