### PR TITLE
Ensure that SymCrypt structures have sufficient alignment

### DIFF
--- a/ScosslCommon/inc/scossl_helpers.h
+++ b/ScosslCommon/inc/scossl_helpers.h
@@ -51,6 +51,9 @@ typedef _Return_type_success_(return >= 0) int SCOSSL_RETURNLENGTH; // For funct
 #define SCOSSL_ALIGNED_SIZEOF(typename)         (sizeof(typename) + SYMCRYPT_ALIGN_VALUE)
 #define SCOSSL_ALIGN_UP(ptr)                    (SYMCRYPT_ALIGN_UP(ptr))
 
+// We need to be able to represent the offset into our allocation in a single byte
+C_ASSERT( SYMCRYPT_ALIGN_VALUE < 256 );
+
 #define SCOSSL_COMMON_ALIGNED_ALLOC(ptr, allocator, typename)               \
     typename *ptr;                                                          \
     {                                                                       \

--- a/ScosslCommon/inc/scossl_helpers.h
+++ b/ScosslCommon/inc/scossl_helpers.h
@@ -51,20 +51,26 @@ typedef _Return_type_success_(return >= 0) int SCOSSL_RETURNLENGTH; // For funct
 #define SCOSSL_ALIGNED_SIZEOF(typename)         (sizeof(typename) + SYMCRYPT_ALIGN_VALUE)
 #define SCOSSL_ALIGN_UP(ptr)                    (SYMCRYPT_ALIGN_UP(ptr))
 
-#define SCOSSL_COMMON_ALIGNED_ALLOC(ptr, allocator, typename)   \
-    PBYTE alloc = allocator(SCOSSL_ALIGNED_SIZEOF(typename));   \
-    PBYTE aligned_alloc = NULL;                                 \
-    if (alloc)                                                  \
-    {                                                           \
-        aligned_alloc = SCOSSL_ALIGN_UP(alloc+1);               \
-        *(aligned_alloc - 1) = aligned_alloc - alloc;           \
-    }                                                           \
-    typename *ptr = (typename *) aligned_alloc;
+#define SCOSSL_COMMON_ALIGNED_ALLOC(ptr, allocator, typename)               \
+    typename *ptr;                                                          \
+    {                                                                       \
+        PBYTE scossl_alloc = allocator(SCOSSL_ALIGNED_SIZEOF(typename));    \
+        PBYTE scossl_aligned = NULL;                                        \
+        if (scossl_alloc)                                                   \
+        {                                                                   \
+            scossl_aligned = SCOSSL_ALIGN_UP(scossl_alloc+1);               \
+            *(scossl_aligned - 1) = scossl_aligned - scossl_alloc;          \
+        }                                                                   \
+        ptr = (typename *) scossl_aligned;                                  \
+    }
 
-#define SCOSSL_COMMON_ALIGNED_FREE(ptr, deallocator, typename)  \
-    PBYTE aligned_alloc = (PBYTE) ptr;                          \
-    PBYTE alloc = aligned_alloc - *(aligned_alloc-1);           \
-    deallocator(alloc, SCOSSL_ALIGNED_SIZEOF(typename));
+#define SCOSSL_COMMON_ALIGNED_FREE(ptr, deallocator, typename)      \
+    {                                                               \
+        PBYTE scossl_aligned = (PBYTE) ptr;                         \
+        PBYTE scossl_alloc = scossl_aligned - *(scossl_aligned-1);  \
+        deallocator(scossl_alloc, SCOSSL_ALIGNED_SIZEOF(typename)); \
+        ptr = NULL;                                                 \
+    }
 
 void SCOSSL_set_trace_level(int trace_level, int ossl_ERR_level);
 void SCOSSL_set_trace_log_filename(const char *filename);

--- a/SymCryptEngine/src/e_scossl_ciphers.c
+++ b/SymCryptEngine/src/e_scossl_ciphers.c
@@ -9,18 +9,18 @@
 extern "C" {
 #endif
 
-struct cipher_cbc_ctx {
+typedef struct {
     SYMCRYPT_AES_EXPANDED_KEY key;
-};
+} SCOSSL_CIPHER_CBC_CTX;
 
-struct cipher_ecb_ctx {
+typedef struct {
     SYMCRYPT_AES_EXPANDED_KEY key;
-};
+} SCOSSL_CIPHER_ECB_CTX;
 
-struct cipher_xts_ctx {
+typedef struct {
     BYTE iv[SYMCRYPT_AES_BLOCK_SIZE];
     SYMCRYPT_XTS_AES_EXPANDED_KEY key;
-};
+} SCOSSL_CIPHER_XTS_CTX;
 
 static int scossl_cipher_nids[] = {
     NID_aes_128_cbc,
@@ -71,7 +71,7 @@ static const EVP_CIPHER *e_scossl_aes_128_cbc(void)
         || !EVP_CIPHER_meth_set_init(_hidden_aes_128_cbc, e_scossl_aes_cbc_init_key)
         || !EVP_CIPHER_meth_set_do_cipher(_hidden_aes_128_cbc, e_scossl_aes_cbc_cipher)
         || !EVP_CIPHER_meth_set_ctrl(_hidden_aes_128_cbc, e_scossl_aes_cbc_ctrl)
-        || !EVP_CIPHER_meth_set_impl_ctx_size(_hidden_aes_128_cbc, sizeof(struct cipher_cbc_ctx)) )
+        || !EVP_CIPHER_meth_set_impl_ctx_size(_hidden_aes_128_cbc, SCOSSL_ALIGNED_SIZEOF(SCOSSL_CIPHER_CBC_CTX)) )
     {
         EVP_CIPHER_meth_free(_hidden_aes_128_cbc);
         _hidden_aes_128_cbc = NULL;
@@ -89,7 +89,7 @@ static const EVP_CIPHER *e_scossl_aes_192_cbc(void)
         || !EVP_CIPHER_meth_set_init(_hidden_aes_192_cbc, e_scossl_aes_cbc_init_key)
         || !EVP_CIPHER_meth_set_do_cipher(_hidden_aes_192_cbc, e_scossl_aes_cbc_cipher)
         || !EVP_CIPHER_meth_set_ctrl(_hidden_aes_192_cbc, e_scossl_aes_cbc_ctrl)
-        || !EVP_CIPHER_meth_set_impl_ctx_size(_hidden_aes_192_cbc, sizeof(struct cipher_cbc_ctx)) )
+        || !EVP_CIPHER_meth_set_impl_ctx_size(_hidden_aes_192_cbc, SCOSSL_ALIGNED_SIZEOF(SCOSSL_CIPHER_CBC_CTX)) )
     {
         EVP_CIPHER_meth_free(_hidden_aes_192_cbc);
         _hidden_aes_192_cbc = NULL;
@@ -107,7 +107,7 @@ static const EVP_CIPHER *e_scossl_aes_256_cbc(void)
         || !EVP_CIPHER_meth_set_init(_hidden_aes_256_cbc, e_scossl_aes_cbc_init_key)
         || !EVP_CIPHER_meth_set_do_cipher(_hidden_aes_256_cbc, e_scossl_aes_cbc_cipher)
         || !EVP_CIPHER_meth_set_ctrl(_hidden_aes_256_cbc, e_scossl_aes_cbc_ctrl)
-        || !EVP_CIPHER_meth_set_impl_ctx_size(_hidden_aes_256_cbc, sizeof(struct cipher_cbc_ctx)) )
+        || !EVP_CIPHER_meth_set_impl_ctx_size(_hidden_aes_256_cbc, SCOSSL_ALIGNED_SIZEOF(SCOSSL_CIPHER_CBC_CTX)) )
     {
         EVP_CIPHER_meth_free(_hidden_aes_256_cbc);
         _hidden_aes_256_cbc = NULL;
@@ -132,7 +132,7 @@ static const EVP_CIPHER *e_scossl_aes_128_ecb(void)
         || !EVP_CIPHER_meth_set_init(_hidden_aes_128_ecb, e_scossl_aes_ecb_init_key)
         || !EVP_CIPHER_meth_set_do_cipher(_hidden_aes_128_ecb, e_scossl_aes_ecb_cipher)
         || !EVP_CIPHER_meth_set_ctrl(_hidden_aes_128_ecb, e_scossl_aes_ecb_ctrl)
-        || !EVP_CIPHER_meth_set_impl_ctx_size(_hidden_aes_128_ecb, sizeof(struct cipher_ecb_ctx)) )
+        || !EVP_CIPHER_meth_set_impl_ctx_size(_hidden_aes_128_ecb, SCOSSL_ALIGNED_SIZEOF(SCOSSL_CIPHER_ECB_CTX)) )
     {
         EVP_CIPHER_meth_free(_hidden_aes_128_ecb);
         _hidden_aes_128_ecb = NULL;
@@ -149,7 +149,7 @@ static const EVP_CIPHER *e_scossl_aes_192_ecb(void)
         || !EVP_CIPHER_meth_set_init(_hidden_aes_192_ecb, e_scossl_aes_ecb_init_key)
         || !EVP_CIPHER_meth_set_do_cipher(_hidden_aes_192_ecb, e_scossl_aes_ecb_cipher)
         || !EVP_CIPHER_meth_set_ctrl(_hidden_aes_192_ecb, e_scossl_aes_ecb_ctrl)
-        || !EVP_CIPHER_meth_set_impl_ctx_size(_hidden_aes_192_ecb, sizeof(struct cipher_ecb_ctx)) )
+        || !EVP_CIPHER_meth_set_impl_ctx_size(_hidden_aes_192_ecb, SCOSSL_ALIGNED_SIZEOF(SCOSSL_CIPHER_ECB_CTX)) )
     {
         EVP_CIPHER_meth_free(_hidden_aes_192_ecb);
         _hidden_aes_192_ecb = NULL;
@@ -166,7 +166,7 @@ static const EVP_CIPHER *e_scossl_aes_256_ecb(void)
         || !EVP_CIPHER_meth_set_init(_hidden_aes_256_ecb, e_scossl_aes_ecb_init_key)
         || !EVP_CIPHER_meth_set_do_cipher(_hidden_aes_256_ecb, e_scossl_aes_ecb_cipher)
         || !EVP_CIPHER_meth_set_ctrl(_hidden_aes_256_ecb, e_scossl_aes_ecb_ctrl)
-        || !EVP_CIPHER_meth_set_impl_ctx_size(_hidden_aes_256_ecb, sizeof(struct cipher_ecb_ctx)) )
+        || !EVP_CIPHER_meth_set_impl_ctx_size(_hidden_aes_256_ecb, SCOSSL_ALIGNED_SIZEOF(SCOSSL_CIPHER_ECB_CTX)) )
     {
         EVP_CIPHER_meth_free(_hidden_aes_256_ecb);
         _hidden_aes_256_ecb = NULL;
@@ -194,7 +194,7 @@ static const EVP_CIPHER *e_scossl_aes_128_xts(void)
         || !EVP_CIPHER_meth_set_init(_hidden_aes_128_xts, e_scossl_aes_xts_init_key)
         || !EVP_CIPHER_meth_set_do_cipher(_hidden_aes_128_xts, e_scossl_aes_xts_cipher)
         || !EVP_CIPHER_meth_set_ctrl(_hidden_aes_128_xts, e_scossl_aes_xts_ctrl)
-        || !EVP_CIPHER_meth_set_impl_ctx_size(_hidden_aes_128_xts, sizeof(struct cipher_xts_ctx)) )
+        || !EVP_CIPHER_meth_set_impl_ctx_size(_hidden_aes_128_xts, SCOSSL_ALIGNED_SIZEOF(SCOSSL_CIPHER_XTS_CTX)) )
     {
         EVP_CIPHER_meth_free(_hidden_aes_128_xts);
         _hidden_aes_128_xts = NULL;
@@ -212,7 +212,7 @@ static const EVP_CIPHER *e_scossl_aes_256_xts(void)
         || !EVP_CIPHER_meth_set_init(_hidden_aes_256_xts, e_scossl_aes_xts_init_key)
         || !EVP_CIPHER_meth_set_do_cipher(_hidden_aes_256_xts, e_scossl_aes_xts_cipher)
         || !EVP_CIPHER_meth_set_ctrl(_hidden_aes_256_xts, e_scossl_aes_xts_ctrl)
-        || !EVP_CIPHER_meth_set_impl_ctx_size(_hidden_aes_256_xts, sizeof(struct cipher_xts_ctx)) )
+        || !EVP_CIPHER_meth_set_impl_ctx_size(_hidden_aes_256_xts, SCOSSL_ALIGNED_SIZEOF(SCOSSL_CIPHER_XTS_CTX)) )
     {
         EVP_CIPHER_meth_free(_hidden_aes_256_xts);
         _hidden_aes_256_xts = NULL;
@@ -241,7 +241,7 @@ static const EVP_CIPHER *e_scossl_aes_128_gcm(void)
         || !EVP_CIPHER_meth_set_init(_hidden_aes_128_gcm, e_scossl_aes_gcm_init_key)
         || !EVP_CIPHER_meth_set_do_cipher(_hidden_aes_128_gcm, e_scossl_aes_gcm_cipher)
         || !EVP_CIPHER_meth_set_ctrl(_hidden_aes_128_gcm, e_scossl_aes_gcm_ctrl)
-        || !EVP_CIPHER_meth_set_impl_ctx_size(_hidden_aes_128_gcm, sizeof(SCOSSL_CIPHER_GCM_CTX)) )
+        || !EVP_CIPHER_meth_set_impl_ctx_size(_hidden_aes_128_gcm, SCOSSL_ALIGNED_SIZEOF(SCOSSL_CIPHER_GCM_CTX)) )
     {
         EVP_CIPHER_meth_free(_hidden_aes_128_gcm);
         _hidden_aes_128_gcm = NULL;
@@ -258,7 +258,7 @@ static const EVP_CIPHER *e_scossl_aes_192_gcm(void)
         || !EVP_CIPHER_meth_set_init(_hidden_aes_192_gcm, e_scossl_aes_gcm_init_key)
         || !EVP_CIPHER_meth_set_do_cipher(_hidden_aes_192_gcm, e_scossl_aes_gcm_cipher)
         || !EVP_CIPHER_meth_set_ctrl(_hidden_aes_192_gcm, e_scossl_aes_gcm_ctrl)
-        || !EVP_CIPHER_meth_set_impl_ctx_size(_hidden_aes_192_gcm, sizeof(SCOSSL_CIPHER_GCM_CTX)) )
+        || !EVP_CIPHER_meth_set_impl_ctx_size(_hidden_aes_192_gcm, SCOSSL_ALIGNED_SIZEOF(SCOSSL_CIPHER_GCM_CTX)) )
     {
         EVP_CIPHER_meth_free(_hidden_aes_192_gcm);
         _hidden_aes_192_gcm = NULL;
@@ -275,7 +275,7 @@ static const EVP_CIPHER *e_scossl_aes_256_gcm(void)
         || !EVP_CIPHER_meth_set_init(_hidden_aes_256_gcm, e_scossl_aes_gcm_init_key)
         || !EVP_CIPHER_meth_set_do_cipher(_hidden_aes_256_gcm, e_scossl_aes_gcm_cipher)
         || !EVP_CIPHER_meth_set_ctrl(_hidden_aes_256_gcm, e_scossl_aes_gcm_ctrl)
-        || !EVP_CIPHER_meth_set_impl_ctx_size(_hidden_aes_256_gcm, sizeof(SCOSSL_CIPHER_GCM_CTX)) )
+        || !EVP_CIPHER_meth_set_impl_ctx_size(_hidden_aes_256_gcm, SCOSSL_ALIGNED_SIZEOF(SCOSSL_CIPHER_GCM_CTX)) )
     {
         EVP_CIPHER_meth_free(_hidden_aes_256_gcm);
         _hidden_aes_256_gcm = NULL;
@@ -302,7 +302,7 @@ static const EVP_CIPHER *e_scossl_aes_128_ccm(void)
         || !EVP_CIPHER_meth_set_init(_hidden_aes_128_ccm, e_scossl_aes_ccm_init_key)
         || !EVP_CIPHER_meth_set_do_cipher(_hidden_aes_128_ccm, e_scossl_aes_ccm_cipher)
         || !EVP_CIPHER_meth_set_ctrl(_hidden_aes_128_ccm, e_scossl_aes_ccm_ctrl)
-        || !EVP_CIPHER_meth_set_impl_ctx_size(_hidden_aes_128_ccm, sizeof(SCOSSL_CIPHER_CCM_CTX)) )
+        || !EVP_CIPHER_meth_set_impl_ctx_size(_hidden_aes_128_ccm, SCOSSL_ALIGNED_SIZEOF(SCOSSL_CIPHER_CCM_CTX)) )
     {
         EVP_CIPHER_meth_free(_hidden_aes_128_ccm);
         _hidden_aes_128_ccm = NULL;
@@ -319,7 +319,7 @@ static const EVP_CIPHER *e_scossl_aes_192_ccm(void)
         || !EVP_CIPHER_meth_set_init(_hidden_aes_192_ccm, e_scossl_aes_ccm_init_key)
         || !EVP_CIPHER_meth_set_do_cipher(_hidden_aes_192_ccm, e_scossl_aes_ccm_cipher)
         || !EVP_CIPHER_meth_set_ctrl(_hidden_aes_192_ccm, e_scossl_aes_ccm_ctrl)
-        || !EVP_CIPHER_meth_set_impl_ctx_size(_hidden_aes_192_ccm, sizeof(SCOSSL_CIPHER_CCM_CTX)) )
+        || !EVP_CIPHER_meth_set_impl_ctx_size(_hidden_aes_192_ccm, SCOSSL_ALIGNED_SIZEOF(SCOSSL_CIPHER_CCM_CTX)) )
     {
         EVP_CIPHER_meth_free(_hidden_aes_192_ccm);
         _hidden_aes_192_ccm = NULL;
@@ -336,7 +336,7 @@ static const EVP_CIPHER *e_scossl_aes_256_ccm(void)
         || !EVP_CIPHER_meth_set_init(_hidden_aes_256_ccm, e_scossl_aes_ccm_init_key)
         || !EVP_CIPHER_meth_set_do_cipher(_hidden_aes_256_ccm, e_scossl_aes_ccm_cipher)
         || !EVP_CIPHER_meth_set_ctrl(_hidden_aes_256_ccm, e_scossl_aes_ccm_ctrl)
-        || !EVP_CIPHER_meth_set_impl_ctx_size(_hidden_aes_256_ccm, sizeof(SCOSSL_CIPHER_CCM_CTX)) )
+        || !EVP_CIPHER_meth_set_impl_ctx_size(_hidden_aes_256_ccm, SCOSSL_ALIGNED_SIZEOF(SCOSSL_CIPHER_CCM_CTX)) )
     {
         EVP_CIPHER_meth_free(_hidden_aes_256_ccm);
         _hidden_aes_256_ccm = NULL;
@@ -473,7 +473,7 @@ int e_scossl_ciphers(ENGINE *e, const EVP_CIPHER **cipher,
 SCOSSL_STATUS e_scossl_aes_cbc_init_key(_Inout_ EVP_CIPHER_CTX *ctx, _In_ const unsigned char *key,
                              _In_ ossl_unused const unsigned char *iv, ossl_unused int enc)
 {
-    struct cipher_cbc_ctx *cipherCtx = (struct cipher_cbc_ctx *)EVP_CIPHER_CTX_get_cipher_data(ctx);
+    SCOSSL_CIPHER_CBC_CTX *cipherCtx = (SCOSSL_CIPHER_CBC_CTX *) SCOSSL_ALIGN_UP(EVP_CIPHER_CTX_get_cipher_data(ctx));
     SYMCRYPT_ERROR scError = SYMCRYPT_NO_ERROR;
     if( key )
     {
@@ -491,7 +491,7 @@ SCOSSL_STATUS e_scossl_aes_cbc_init_key(_Inout_ EVP_CIPHER_CTX *ctx, _In_ const 
 SCOSSL_STATUS e_scossl_aes_cbc_cipher(_Inout_ EVP_CIPHER_CTX *ctx, _Out_ unsigned char *out,
                                _In_reads_bytes_(inl) const unsigned char *in, size_t inl)
 {
-    struct cipher_cbc_ctx *cipherCtx = (struct cipher_cbc_ctx *)EVP_CIPHER_CTX_get_cipher_data(ctx);
+    SCOSSL_CIPHER_CBC_CTX *cipherCtx = (SCOSSL_CIPHER_CBC_CTX *) SCOSSL_ALIGN_UP(EVP_CIPHER_CTX_get_cipher_data(ctx));
     PBYTE ctx_iv = EVP_CIPHER_CTX_iv_noconst(ctx);
     if( EVP_CIPHER_CTX_encrypting(ctx) )
     {
@@ -510,8 +510,8 @@ SCOSSL_STATUS e_scossl_aes_cbc_cipher(_Inout_ EVP_CIPHER_CTX *ctx, _Out_ unsigne
 static SCOSSL_STATUS e_scossl_aes_cbc_ctrl(_In_ EVP_CIPHER_CTX *ctx, int type, ossl_unused int arg,
                                     _Inout_ void *ptr)
 {
-    struct cipher_cbc_ctx *srcCtx;
-    struct cipher_cbc_ctx *dstCtx;
+    SCOSSL_CIPHER_CBC_CTX *srcCtx;
+    SCOSSL_CIPHER_CBC_CTX *dstCtx;
     switch( type )
     {
     case EVP_CTRL_COPY:
@@ -519,8 +519,8 @@ static SCOSSL_STATUS e_scossl_aes_cbc_ctrl(_In_ EVP_CIPHER_CTX *ctx, int type, o
         // set EVP_CIPH_CUSTOM_COPY flag on all our AES ciphers
         // We must explicitly copy the AES key struct using SymCrypt as the AES key structure contains pointers
         // to itself, so a plain memcpy will maintain pointers to the source context
-        srcCtx = (struct cipher_cbc_ctx *)EVP_CIPHER_CTX_get_cipher_data(                  ctx);
-        dstCtx = (struct cipher_cbc_ctx *)EVP_CIPHER_CTX_get_cipher_data((EVP_CIPHER_CTX *)ptr);
+        srcCtx = (SCOSSL_CIPHER_CBC_CTX *) SCOSSL_ALIGN_UP(EVP_CIPHER_CTX_get_cipher_data(                  ctx));
+        dstCtx = (SCOSSL_CIPHER_CBC_CTX *) SCOSSL_ALIGN_UP(EVP_CIPHER_CTX_get_cipher_data((EVP_CIPHER_CTX *)ptr));
         SymCryptAesKeyCopy(&srcCtx->key, &dstCtx->key);
         break;
     default:
@@ -538,7 +538,7 @@ static SCOSSL_STATUS e_scossl_aes_cbc_ctrl(_In_ EVP_CIPHER_CTX *ctx, int type, o
 SCOSSL_STATUS e_scossl_aes_ecb_init_key(_Inout_ EVP_CIPHER_CTX *ctx, _In_ const unsigned char *key,
                              _In_ ossl_unused const unsigned char *iv, ossl_unused int enc)
 {
-    struct cipher_ecb_ctx *cipherCtx = (struct cipher_ecb_ctx *)EVP_CIPHER_CTX_get_cipher_data(ctx);
+    SCOSSL_CIPHER_ECB_CTX *cipherCtx = (SCOSSL_CIPHER_ECB_CTX *) SCOSSL_ALIGN_UP(EVP_CIPHER_CTX_get_cipher_data(ctx));
     SYMCRYPT_ERROR scError = SYMCRYPT_NO_ERROR;
     if( key )
     {
@@ -556,7 +556,7 @@ SCOSSL_STATUS e_scossl_aes_ecb_init_key(_Inout_ EVP_CIPHER_CTX *ctx, _In_ const 
 SCOSSL_STATUS e_scossl_aes_ecb_cipher(_Inout_ EVP_CIPHER_CTX *ctx, _Out_ unsigned char *out,
                                _In_reads_bytes_(inl) const unsigned char *in, size_t inl)
 {
-    struct cipher_ecb_ctx *cipherCtx = (struct cipher_ecb_ctx *)EVP_CIPHER_CTX_get_cipher_data(ctx);
+    SCOSSL_CIPHER_ECB_CTX *cipherCtx = (SCOSSL_CIPHER_ECB_CTX *) SCOSSL_ALIGN_UP(EVP_CIPHER_CTX_get_cipher_data(ctx));
     if( EVP_CIPHER_CTX_encrypting(ctx) )
     {
         SymCryptAesEcbEncrypt(&cipherCtx->key, in, out, inl);
@@ -574,8 +574,8 @@ SCOSSL_STATUS e_scossl_aes_ecb_cipher(_Inout_ EVP_CIPHER_CTX *ctx, _Out_ unsigne
 static SCOSSL_STATUS e_scossl_aes_ecb_ctrl(_In_ EVP_CIPHER_CTX *ctx, int type, ossl_unused int arg,
                                     _Inout_ void *ptr)
 {
-    struct cipher_ecb_ctx *srcCtx;
-    struct cipher_ecb_ctx *dstCtx;
+    SCOSSL_CIPHER_ECB_CTX *srcCtx;
+    SCOSSL_CIPHER_ECB_CTX *dstCtx;
     switch( type )
     {
     case EVP_CTRL_COPY:
@@ -583,8 +583,8 @@ static SCOSSL_STATUS e_scossl_aes_ecb_ctrl(_In_ EVP_CIPHER_CTX *ctx, int type, o
         // set EVP_CIPH_CUSTOM_COPY flag on all our AES ciphers
         // We must explicitly copy the AES key struct using SymCrypt as the AES key structure contains pointers
         // to itself, so a plain memcpy will maintain pointers to the source context
-        srcCtx = (struct cipher_ecb_ctx *)EVP_CIPHER_CTX_get_cipher_data(                  ctx);
-        dstCtx = (struct cipher_ecb_ctx *)EVP_CIPHER_CTX_get_cipher_data((EVP_CIPHER_CTX *)ptr);
+        srcCtx = (SCOSSL_CIPHER_ECB_CTX *) SCOSSL_ALIGN_UP(EVP_CIPHER_CTX_get_cipher_data(                  ctx));
+        dstCtx = (SCOSSL_CIPHER_ECB_CTX *) SCOSSL_ALIGN_UP(EVP_CIPHER_CTX_get_cipher_data((EVP_CIPHER_CTX *)ptr));
         SymCryptAesKeyCopy(&srcCtx->key, &dstCtx->key);
         break;
     default:
@@ -605,7 +605,7 @@ SCOSSL_STATUS e_scossl_aes_xts_init_key(_Inout_ EVP_CIPHER_CTX *ctx, _In_ const 
                              _In_ const unsigned char *iv, ossl_unused int enc)
 {
     SYMCRYPT_ERROR scError = SYMCRYPT_NO_ERROR;
-    struct cipher_xts_ctx *cipherCtx = (struct cipher_xts_ctx *)EVP_CIPHER_CTX_get_cipher_data(ctx);
+    SCOSSL_CIPHER_XTS_CTX *cipherCtx = (SCOSSL_CIPHER_XTS_CTX *) SCOSSL_ALIGN_UP(EVP_CIPHER_CTX_get_cipher_data(ctx));
     if( iv )
     {
         memcpy(cipherCtx->iv, iv, 8); // copy only the first 8B
@@ -632,7 +632,7 @@ SCOSSL_RETURNLENGTH e_scossl_aes_xts_cipher(_Inout_ EVP_CIPHER_CTX *ctx, _Out_ u
                                _In_reads_bytes_(inl) const unsigned char *in, size_t inl)
 {
     int ret = 0;
-    struct cipher_xts_ctx *cipherCtx = (struct cipher_xts_ctx *)EVP_CIPHER_CTX_get_cipher_data(ctx);
+    SCOSSL_CIPHER_XTS_CTX *cipherCtx = (SCOSSL_CIPHER_XTS_CTX *) SCOSSL_ALIGN_UP(EVP_CIPHER_CTX_get_cipher_data(ctx));
     if( inl > 0 )
     {
         if( (inl % SYMCRYPT_AES_BLOCK_SIZE) != 0 )
@@ -689,8 +689,8 @@ static SCOSSL_STATUS e_scossl_aes_xts_ctrl(_In_ EVP_CIPHER_CTX *ctx, int type, o
             "No copy method currently implemented");
         // We need a SymCryptXtsKeyCopy function for this as we don't have explicit control over the AES key
         // struct here
-        // srcCtx = (struct cipher_cbc_ctx *)EVP_CIPHER_CTX_get_cipher_data(                  ctx);
-        // dstCtx = (struct cipher_cbc_ctx *)EVP_CIPHER_CTX_get_cipher_data((EVP_CIPHER_CTX *)ptr);
+        // srcCtx = (SCOSSL_CIPHER_CBC_CTX *) SCOSSL_ALIGN_UP(EVP_CIPHER_CTX_get_cipher_data(                  ctx));
+        // dstCtx = (SCOSSL_CIPHER_CBC_CTX *) SCOSSL_ALIGN_UP(EVP_CIPHER_CTX_get_cipher_data((EVP_CIPHER_CTX *)ptr));
         // SymCryptXtsKeyCopy(&srcCtx->key, &dstCtx->key);
         return SCOSSL_FAILURE;
     default:
@@ -709,7 +709,7 @@ static SCOSSL_STATUS e_scossl_aes_xts_ctrl(_In_ EVP_CIPHER_CTX *ctx, int type, o
 SCOSSL_STATUS e_scossl_aes_gcm_init_key(_Inout_ EVP_CIPHER_CTX *ctx, _In_ const unsigned char *key,
                              _In_ const unsigned char *iv, ossl_unused int enc)
 {
-    SCOSSL_CIPHER_GCM_CTX *cipherCtx = (SCOSSL_CIPHER_GCM_CTX *)EVP_CIPHER_CTX_get_cipher_data(ctx);
+    SCOSSL_CIPHER_GCM_CTX *cipherCtx = (SCOSSL_CIPHER_GCM_CTX *) SCOSSL_ALIGN_UP(EVP_CIPHER_CTX_get_cipher_data(ctx));
     return scossl_aes_gcm_init_key(cipherCtx, key, EVP_CIPHER_CTX_key_length(ctx), iv, EVP_CIPHER_CTX_iv_length(ctx));
 }
 
@@ -722,7 +722,7 @@ SCOSSL_RETURNLENGTH e_scossl_aes_gcm_cipher(_Inout_ EVP_CIPHER_CTX *ctx, _Out_ u
 {
     int ret = -1;
     size_t outl;
-    SCOSSL_CIPHER_GCM_CTX *cipherCtx = (SCOSSL_CIPHER_GCM_CTX *)EVP_CIPHER_CTX_get_cipher_data(ctx);
+    SCOSSL_CIPHER_GCM_CTX *cipherCtx = (SCOSSL_CIPHER_GCM_CTX *) SCOSSL_ALIGN_UP(EVP_CIPHER_CTX_get_cipher_data(ctx));
 
     if ( scossl_aes_gcm_cipher(cipherCtx, EVP_CIPHER_CTX_encrypting(ctx), out, &outl, in, inl) )
     {
@@ -738,7 +738,7 @@ SCOSSL_RETURNLENGTH e_scossl_aes_gcm_cipher(_Inout_ EVP_CIPHER_CTX *ctx, _Out_ u
 static int e_scossl_aes_gcm_ctrl(_Inout_ EVP_CIPHER_CTX *ctx, int type, int arg,
                                     _Inout_ void *ptr)
 {
-    SCOSSL_CIPHER_GCM_CTX *cipherCtx = (SCOSSL_CIPHER_GCM_CTX *)EVP_CIPHER_CTX_get_cipher_data(ctx);
+    SCOSSL_CIPHER_GCM_CTX *cipherCtx = (SCOSSL_CIPHER_GCM_CTX *) SCOSSL_ALIGN_UP(EVP_CIPHER_CTX_get_cipher_data(ctx));
     SCOSSL_CIPHER_GCM_CTX *dstCtx;
     switch( type )
     {
@@ -766,7 +766,7 @@ static int e_scossl_aes_gcm_ctrl(_Inout_ EVP_CIPHER_CTX *ctx, int type, int arg,
         // set EVP_CIPH_CUSTOM_COPY flag on all our AES ciphers
         // We must explicitly copy the GCM structs using SymCrypt as the AES key structure contains pointers
         // to itself, so a plain memcpy will maintain pointers to the source context
-        dstCtx = (SCOSSL_CIPHER_GCM_CTX *)EVP_CIPHER_CTX_get_cipher_data((EVP_CIPHER_CTX *)ptr);
+        dstCtx = (SCOSSL_CIPHER_GCM_CTX *) SCOSSL_ALIGN_UP(EVP_CIPHER_CTX_get_cipher_data((EVP_CIPHER_CTX *)ptr));
         SymCryptGcmKeyCopy(&cipherCtx->key, &dstCtx->key);
         SymCryptGcmStateCopy(&cipherCtx->state, &dstCtx->key, &dstCtx->state);
         break;
@@ -795,7 +795,7 @@ static int e_scossl_aes_gcm_ctrl(_Inout_ EVP_CIPHER_CTX *ctx, int type, int arg,
 SCOSSL_STATUS e_scossl_aes_ccm_init_key(_Inout_ EVP_CIPHER_CTX *ctx, _In_ const unsigned char *key,
                              _In_ const unsigned char *iv, ossl_unused int enc)
 {
-    SCOSSL_CIPHER_CCM_CTX *cipherCtx = (SCOSSL_CIPHER_CCM_CTX *)EVP_CIPHER_CTX_get_cipher_data(ctx);
+    SCOSSL_CIPHER_CCM_CTX *cipherCtx = (SCOSSL_CIPHER_CCM_CTX *) SCOSSL_ALIGN_UP(EVP_CIPHER_CTX_get_cipher_data(ctx));
     return scossl_aes_ccm_init_key(cipherCtx, key, EVP_CIPHER_CTX_key_length(ctx), iv, cipherCtx->ivlen);
 }
 
@@ -806,7 +806,7 @@ SCOSSL_RETURNLENGTH e_scossl_aes_ccm_cipher(_Inout_ EVP_CIPHER_CTX *ctx, _Out_ u
 {
     int ret = -1;
     size_t outl;
-    SCOSSL_CIPHER_CCM_CTX *cipherCtx = (SCOSSL_CIPHER_CCM_CTX *)EVP_CIPHER_CTX_get_cipher_data(ctx);
+    SCOSSL_CIPHER_CCM_CTX *cipherCtx = (SCOSSL_CIPHER_CCM_CTX *) SCOSSL_ALIGN_UP(EVP_CIPHER_CTX_get_cipher_data(ctx));
 
     if ( scossl_aes_ccm_cipher(cipherCtx, EVP_CIPHER_CTX_encrypting(ctx), out, &outl, in, inl) )
     {
@@ -822,7 +822,7 @@ SCOSSL_RETURNLENGTH e_scossl_aes_ccm_cipher(_Inout_ EVP_CIPHER_CTX *ctx, _Out_ u
 static int e_scossl_aes_ccm_ctrl(_Inout_ EVP_CIPHER_CTX *ctx, int type, int arg,
                                     _Inout_ void *ptr)
 {
-    SCOSSL_CIPHER_CCM_CTX *cipherCtx = (SCOSSL_CIPHER_CCM_CTX *)EVP_CIPHER_CTX_get_cipher_data(ctx);
+    SCOSSL_CIPHER_CCM_CTX *cipherCtx = (SCOSSL_CIPHER_CCM_CTX *) SCOSSL_ALIGN_UP(EVP_CIPHER_CTX_get_cipher_data(ctx));
     SCOSSL_CIPHER_CCM_CTX *dstCtx;
 
     switch( type )
@@ -844,7 +844,7 @@ static int e_scossl_aes_ccm_ctrl(_Inout_ EVP_CIPHER_CTX *ctx, int type, int arg,
         // set EVP_CIPH_CUSTOM_COPY flag on all our AES ciphers
         // We must explicitly copy the AES key struct using SymCrypt as the AES key structure contains pointers
         // to itself, so a plain memcpy will maintain pointers to the source context
-        dstCtx = (SCOSSL_CIPHER_CCM_CTX *)EVP_CIPHER_CTX_get_cipher_data((EVP_CIPHER_CTX *)ptr);
+        dstCtx = (SCOSSL_CIPHER_CCM_CTX *) SCOSSL_ALIGN_UP(EVP_CIPHER_CTX_get_cipher_data((EVP_CIPHER_CTX *)ptr));
         SymCryptAesKeyCopy(&cipherCtx->key, &dstCtx->key);
         // make sure the dstCtx uses its copy of the expanded key TODO: implement SymCryptCcmStateCopy
         dstCtx->state = cipherCtx->state;

--- a/SymCryptEngine/src/e_scossl_digests.c
+++ b/SymCryptEngine/src/e_scossl_digests.c
@@ -27,7 +27,7 @@ static const EVP_MD *e_scossl_digest_md5(void)
     if ((_hidden_md5_md = EVP_MD_meth_new(NID_md5, NID_md5WithRSAEncryption)) == NULL
         || !EVP_MD_meth_set_result_size(_hidden_md5_md, MD5_DIGEST_LENGTH)
         || !EVP_MD_meth_set_input_blocksize(_hidden_md5_md, MD5_CBLOCK)
-        || !EVP_MD_meth_set_app_datasize(_hidden_md5_md, sizeof(SYMCRYPT_MD5_STATE))
+        || !EVP_MD_meth_set_app_datasize(_hidden_md5_md, SCOSSL_ALIGNED_SIZEOF(SYMCRYPT_MD5_STATE))
         || !EVP_MD_meth_set_flags(_hidden_md5_md, 0)
         || !EVP_MD_meth_set_init(_hidden_md5_md, e_scossl_digest_md5_init)
         || !EVP_MD_meth_set_update(_hidden_md5_md, e_scossl_digest_md5_update)
@@ -52,7 +52,7 @@ static const EVP_MD *e_scossl_digest_sha1(void)
     if( (_hidden_sha1_md = EVP_MD_meth_new(NID_sha1, NID_sha1WithRSAEncryption)) == NULL
         || !EVP_MD_meth_set_result_size(_hidden_sha1_md, SHA_DIGEST_LENGTH)
         || !EVP_MD_meth_set_input_blocksize(_hidden_sha1_md, SHA_CBLOCK)
-        || !EVP_MD_meth_set_app_datasize(_hidden_sha1_md, sizeof(SYMCRYPT_SHA1_STATE))
+        || !EVP_MD_meth_set_app_datasize(_hidden_sha1_md, SCOSSL_ALIGNED_SIZEOF(SYMCRYPT_SHA1_STATE))
         || !EVP_MD_meth_set_flags(_hidden_sha1_md, EVP_MD_FLAG_DIGALGID_ABSENT | EVP_MD_FLAG_FIPS)
         || !EVP_MD_meth_set_init(_hidden_sha1_md, e_scossl_digest_sha1_init)
         || !EVP_MD_meth_set_update(_hidden_sha1_md, e_scossl_digest_sha1_update)
@@ -77,7 +77,7 @@ static const EVP_MD *e_scossl_digest_sha256(void)
     if( (_hidden_sha256_md = EVP_MD_meth_new(NID_sha256, NID_sha256WithRSAEncryption)) == NULL
         || !EVP_MD_meth_set_result_size(_hidden_sha256_md, SHA256_DIGEST_LENGTH)
         || !EVP_MD_meth_set_input_blocksize(_hidden_sha256_md, SHA256_CBLOCK)
-        || !EVP_MD_meth_set_app_datasize(_hidden_sha256_md, sizeof(SYMCRYPT_SHA256_STATE))
+        || !EVP_MD_meth_set_app_datasize(_hidden_sha256_md, SCOSSL_ALIGNED_SIZEOF(SYMCRYPT_SHA256_STATE))
         || !EVP_MD_meth_set_flags(_hidden_sha256_md, EVP_MD_FLAG_DIGALGID_ABSENT | EVP_MD_FLAG_FIPS)
         || !EVP_MD_meth_set_init(_hidden_sha256_md, e_scossl_digest_sha256_init)
         || !EVP_MD_meth_set_update(_hidden_sha256_md, e_scossl_digest_sha256_update)
@@ -102,7 +102,7 @@ static const EVP_MD *e_scossl_digest_sha384(void)
     if( (_hidden_sha384_md = EVP_MD_meth_new(NID_sha384, NID_sha384WithRSAEncryption)) == NULL
         || !EVP_MD_meth_set_result_size(_hidden_sha384_md, SHA384_DIGEST_LENGTH)
         || !EVP_MD_meth_set_input_blocksize(_hidden_sha384_md, SHA512_CBLOCK)
-        || !EVP_MD_meth_set_app_datasize(_hidden_sha384_md, sizeof(SYMCRYPT_SHA384_STATE))
+        || !EVP_MD_meth_set_app_datasize(_hidden_sha384_md, SCOSSL_ALIGNED_SIZEOF(SYMCRYPT_SHA384_STATE))
         || !EVP_MD_meth_set_flags(_hidden_sha384_md, EVP_MD_FLAG_DIGALGID_ABSENT | EVP_MD_FLAG_FIPS)
         || !EVP_MD_meth_set_init(_hidden_sha384_md, e_scossl_digest_sha384_init)
         || !EVP_MD_meth_set_update(_hidden_sha384_md, e_scossl_digest_sha384_update)
@@ -127,7 +127,7 @@ static const EVP_MD *e_scossl_digest_sha512(void)
     if( (_hidden_sha512_md = EVP_MD_meth_new(NID_sha512, NID_sha512WithRSAEncryption)) == NULL
         || !EVP_MD_meth_set_result_size(_hidden_sha512_md, SHA512_DIGEST_LENGTH)
         || !EVP_MD_meth_set_input_blocksize(_hidden_sha512_md, SHA512_CBLOCK)
-        || !EVP_MD_meth_set_app_datasize(_hidden_sha512_md, sizeof(SYMCRYPT_SHA512_STATE))
+        || !EVP_MD_meth_set_app_datasize(_hidden_sha512_md, SCOSSL_ALIGNED_SIZEOF(SYMCRYPT_SHA512_STATE))
         || !EVP_MD_meth_set_flags(_hidden_sha512_md, EVP_MD_FLAG_DIGALGID_ABSENT | EVP_MD_FLAG_FIPS)
         || !EVP_MD_meth_set_init(_hidden_sha512_md, e_scossl_digest_sha512_init)
         || !EVP_MD_meth_set_update(_hidden_sha512_md, e_scossl_digest_sha512_update)
@@ -212,7 +212,7 @@ int e_scossl_digests(_Inout_ ENGINE *e, _Out_opt_ const EVP_MD **digest,
  */
 static SCOSSL_STATUS e_scossl_digest_md5_init(_Out_ EVP_MD_CTX *ctx)
 {
-    PSYMCRYPT_MD5_STATE state = (PSYMCRYPT_MD5_STATE)EVP_MD_CTX_md_data(ctx);
+    PSYMCRYPT_MD5_STATE state = (PSYMCRYPT_MD5_STATE) SCOSSL_ALIGN_UP(EVP_MD_CTX_md_data(ctx));
     if( state == NULL )
     {
         SCOSSL_LOG_ERROR(SCOSSL_ERR_F_DIGESTS, SCOSSL_ERR_R_MISSING_CTX_DATA, "No MD Data Present");
@@ -226,7 +226,7 @@ static SCOSSL_STATUS e_scossl_digest_md5_init(_Out_ EVP_MD_CTX *ctx)
 static SCOSSL_STATUS e_scossl_digest_md5_update(_Inout_ EVP_MD_CTX *ctx, _In_reads_bytes_(count) const void *data,
                              size_t count)
 {
-    PSYMCRYPT_MD5_STATE state = (PSYMCRYPT_MD5_STATE)EVP_MD_CTX_md_data(ctx);
+    PSYMCRYPT_MD5_STATE state = (PSYMCRYPT_MD5_STATE) SCOSSL_ALIGN_UP(EVP_MD_CTX_md_data(ctx));
     if( state == NULL )
     {
         SCOSSL_LOG_ERROR(SCOSSL_ERR_F_DIGESTS, SCOSSL_ERR_R_MISSING_CTX_DATA, "No MD Data Present");
@@ -239,7 +239,7 @@ static SCOSSL_STATUS e_scossl_digest_md5_update(_Inout_ EVP_MD_CTX *ctx, _In_rea
 
 static SCOSSL_STATUS e_scossl_digest_md5_final(_Inout_ EVP_MD_CTX *ctx, _Out_writes_(SYMCRYPT_MD5_RESULT_SIZE) unsigned char *md)
 {
-    PSYMCRYPT_MD5_STATE state = (PSYMCRYPT_MD5_STATE)EVP_MD_CTX_md_data(ctx);
+    PSYMCRYPT_MD5_STATE state = (PSYMCRYPT_MD5_STATE) SCOSSL_ALIGN_UP(EVP_MD_CTX_md_data(ctx));
     if( state == NULL )
     {
         SCOSSL_LOG_ERROR(SCOSSL_ERR_F_DIGESTS, SCOSSL_ERR_R_MISSING_CTX_DATA, "No MD Data Present");
@@ -252,8 +252,8 @@ static SCOSSL_STATUS e_scossl_digest_md5_final(_Inout_ EVP_MD_CTX *ctx, _Out_wri
 
 static SCOSSL_STATUS e_scossl_digest_md5_copy(_Out_ EVP_MD_CTX *to, _In_ const EVP_MD_CTX *from)
 {
-    PSYMCRYPT_MD5_STATE state_to = (PSYMCRYPT_MD5_STATE)EVP_MD_CTX_md_data(to);
-    PSYMCRYPT_MD5_STATE state_from = (PSYMCRYPT_MD5_STATE)EVP_MD_CTX_md_data(from);
+    PSYMCRYPT_MD5_STATE state_to = (PSYMCRYPT_MD5_STATE) SCOSSL_ALIGN_UP(EVP_MD_CTX_md_data(to));
+    PSYMCRYPT_MD5_STATE state_from = (PSYMCRYPT_MD5_STATE) SCOSSL_ALIGN_UP(EVP_MD_CTX_md_data(from));
     if( state_to == NULL || state_from == NULL )
     {
         return SCOSSL_SUCCESS;
@@ -268,7 +268,7 @@ static SCOSSL_STATUS e_scossl_digest_md5_copy(_Out_ EVP_MD_CTX *to, _In_ const E
  */
 static SCOSSL_STATUS e_scossl_digest_sha1_init(_Out_ EVP_MD_CTX *ctx)
 {
-    PSYMCRYPT_SHA1_STATE state = (PSYMCRYPT_SHA1_STATE)EVP_MD_CTX_md_data(ctx);
+    PSYMCRYPT_SHA1_STATE state = (PSYMCRYPT_SHA1_STATE) SCOSSL_ALIGN_UP(EVP_MD_CTX_md_data(ctx));
     if( state == NULL )
     {
         SCOSSL_LOG_ERROR(SCOSSL_ERR_F_DIGESTS, SCOSSL_ERR_R_MISSING_CTX_DATA, "No MD Data Present");
@@ -282,7 +282,7 @@ static SCOSSL_STATUS e_scossl_digest_sha1_init(_Out_ EVP_MD_CTX *ctx)
 static SCOSSL_STATUS e_scossl_digest_sha1_update(_Inout_ EVP_MD_CTX *ctx, _In_reads_bytes_(count) const void *data,
                               size_t count)
 {
-    PSYMCRYPT_SHA1_STATE state = (PSYMCRYPT_SHA1_STATE)EVP_MD_CTX_md_data(ctx);
+    PSYMCRYPT_SHA1_STATE state = (PSYMCRYPT_SHA1_STATE) SCOSSL_ALIGN_UP(EVP_MD_CTX_md_data(ctx));
     if( state == NULL )
     {
         SCOSSL_LOG_ERROR(SCOSSL_ERR_F_DIGESTS, SCOSSL_ERR_R_MISSING_CTX_DATA, "No MD Data Present");
@@ -295,7 +295,7 @@ static SCOSSL_STATUS e_scossl_digest_sha1_update(_Inout_ EVP_MD_CTX *ctx, _In_re
 
 static SCOSSL_STATUS e_scossl_digest_sha1_final(_Inout_ EVP_MD_CTX *ctx, _Out_writes_(SYMCRYPT_SHA1_RESULT_SIZE) unsigned char *md)
 {
-    PSYMCRYPT_SHA1_STATE state = (PSYMCRYPT_SHA1_STATE)EVP_MD_CTX_md_data(ctx);
+    PSYMCRYPT_SHA1_STATE state = (PSYMCRYPT_SHA1_STATE) SCOSSL_ALIGN_UP(EVP_MD_CTX_md_data(ctx));
     if( state == NULL )
     {
         SCOSSL_LOG_ERROR(SCOSSL_ERR_F_DIGESTS, SCOSSL_ERR_R_MISSING_CTX_DATA, "No MD Data Present");
@@ -308,8 +308,8 @@ static SCOSSL_STATUS e_scossl_digest_sha1_final(_Inout_ EVP_MD_CTX *ctx, _Out_wr
 
 static SCOSSL_STATUS e_scossl_digest_sha1_copy(_Out_ EVP_MD_CTX *to, _In_ const EVP_MD_CTX *from)
 {
-    PSYMCRYPT_SHA1_STATE state_to = (PSYMCRYPT_SHA1_STATE)EVP_MD_CTX_md_data(to);
-    PSYMCRYPT_SHA1_STATE state_from = (PSYMCRYPT_SHA1_STATE)EVP_MD_CTX_md_data(from);
+    PSYMCRYPT_SHA1_STATE state_to = (PSYMCRYPT_SHA1_STATE) SCOSSL_ALIGN_UP(EVP_MD_CTX_md_data(to));
+    PSYMCRYPT_SHA1_STATE state_from = (PSYMCRYPT_SHA1_STATE) SCOSSL_ALIGN_UP(EVP_MD_CTX_md_data(from));
     if( state_to == NULL || state_from == NULL )
     {
         return SCOSSL_SUCCESS;
@@ -325,7 +325,7 @@ static SCOSSL_STATUS e_scossl_digest_sha1_copy(_Out_ EVP_MD_CTX *to, _In_ const 
  */
 static SCOSSL_STATUS e_scossl_digest_sha256_init(_Out_ EVP_MD_CTX *ctx)
 {
-    PSYMCRYPT_SHA256_STATE state = (PSYMCRYPT_SHA256_STATE)EVP_MD_CTX_md_data(ctx);
+    PSYMCRYPT_SHA256_STATE state = (PSYMCRYPT_SHA256_STATE) SCOSSL_ALIGN_UP(EVP_MD_CTX_md_data(ctx));
     if( state == NULL )
     {
         SCOSSL_LOG_ERROR(SCOSSL_ERR_F_DIGESTS, SCOSSL_ERR_R_MISSING_CTX_DATA, "No MD Data Present");
@@ -339,7 +339,7 @@ static SCOSSL_STATUS e_scossl_digest_sha256_init(_Out_ EVP_MD_CTX *ctx)
 static SCOSSL_STATUS e_scossl_digest_sha256_update(_Inout_ EVP_MD_CTX *ctx, _In_reads_bytes_(count) const void *data,
                                 size_t count)
 {
-    PSYMCRYPT_SHA256_STATE state = (PSYMCRYPT_SHA256_STATE)EVP_MD_CTX_md_data(ctx);
+    PSYMCRYPT_SHA256_STATE state = (PSYMCRYPT_SHA256_STATE) SCOSSL_ALIGN_UP(EVP_MD_CTX_md_data(ctx));
     if( state == NULL )
     {
         SCOSSL_LOG_ERROR(SCOSSL_ERR_F_DIGESTS, SCOSSL_ERR_R_MISSING_CTX_DATA, "No MD Data Present");
@@ -352,7 +352,7 @@ static SCOSSL_STATUS e_scossl_digest_sha256_update(_Inout_ EVP_MD_CTX *ctx, _In_
 
 static SCOSSL_STATUS e_scossl_digest_sha256_final(_Inout_ EVP_MD_CTX *ctx, _Out_writes_(SYMCRYPT_SHA256_RESULT_SIZE) unsigned char *md)
 {
-    PSYMCRYPT_SHA256_STATE state = (PSYMCRYPT_SHA256_STATE)EVP_MD_CTX_md_data(ctx);
+    PSYMCRYPT_SHA256_STATE state = (PSYMCRYPT_SHA256_STATE) SCOSSL_ALIGN_UP(EVP_MD_CTX_md_data(ctx));
     if( state == NULL )
     {
         SCOSSL_LOG_ERROR(SCOSSL_ERR_F_DIGESTS, SCOSSL_ERR_R_MISSING_CTX_DATA, "No MD Data Present");
@@ -365,8 +365,8 @@ static SCOSSL_STATUS e_scossl_digest_sha256_final(_Inout_ EVP_MD_CTX *ctx, _Out_
 
 static SCOSSL_STATUS e_scossl_digest_sha256_copy(_Out_ EVP_MD_CTX *to, _In_ const EVP_MD_CTX *from)
 {
-    PSYMCRYPT_SHA256_STATE state_to = (PSYMCRYPT_SHA256_STATE)EVP_MD_CTX_md_data(to);
-    PSYMCRYPT_SHA256_STATE state_from = (PSYMCRYPT_SHA256_STATE)EVP_MD_CTX_md_data(from);
+    PSYMCRYPT_SHA256_STATE state_to = (PSYMCRYPT_SHA256_STATE) SCOSSL_ALIGN_UP(EVP_MD_CTX_md_data(to));
+    PSYMCRYPT_SHA256_STATE state_from = (PSYMCRYPT_SHA256_STATE) SCOSSL_ALIGN_UP(EVP_MD_CTX_md_data(from));
     if( state_to == NULL || state_from == NULL )
     {
         return SCOSSL_SUCCESS;
@@ -381,7 +381,7 @@ static SCOSSL_STATUS e_scossl_digest_sha256_copy(_Out_ EVP_MD_CTX *to, _In_ cons
  */
 static SCOSSL_STATUS e_scossl_digest_sha384_init(_Out_ EVP_MD_CTX *ctx)
 {
-    PSYMCRYPT_SHA384_STATE state = (PSYMCRYPT_SHA384_STATE)EVP_MD_CTX_md_data(ctx);
+    PSYMCRYPT_SHA384_STATE state = (PSYMCRYPT_SHA384_STATE) SCOSSL_ALIGN_UP(EVP_MD_CTX_md_data(ctx));
     if( state == NULL )
     {
         SCOSSL_LOG_ERROR(SCOSSL_ERR_F_DIGESTS, SCOSSL_ERR_R_MISSING_CTX_DATA, "No MD Data Present");
@@ -395,7 +395,7 @@ static SCOSSL_STATUS e_scossl_digest_sha384_init(_Out_ EVP_MD_CTX *ctx)
 static SCOSSL_STATUS e_scossl_digest_sha384_update(_Inout_ EVP_MD_CTX *ctx, _In_reads_bytes_(count) const void *data,
                                 size_t count)
 {
-    PSYMCRYPT_SHA384_STATE state = (PSYMCRYPT_SHA384_STATE)EVP_MD_CTX_md_data(ctx);
+    PSYMCRYPT_SHA384_STATE state = (PSYMCRYPT_SHA384_STATE) SCOSSL_ALIGN_UP(EVP_MD_CTX_md_data(ctx));
     if( state == NULL )
     {
         SCOSSL_LOG_ERROR(SCOSSL_ERR_F_DIGESTS, SCOSSL_ERR_R_MISSING_CTX_DATA, "No MD Data Present");
@@ -408,7 +408,7 @@ static SCOSSL_STATUS e_scossl_digest_sha384_update(_Inout_ EVP_MD_CTX *ctx, _In_
 
 static SCOSSL_STATUS e_scossl_digest_sha384_final(_Inout_ EVP_MD_CTX *ctx, _Out_writes_(SYMCRYPT_SHA384_RESULT_SIZE) unsigned char *md)
 {
-    PSYMCRYPT_SHA384_STATE state = (PSYMCRYPT_SHA384_STATE)EVP_MD_CTX_md_data(ctx);
+    PSYMCRYPT_SHA384_STATE state = (PSYMCRYPT_SHA384_STATE) SCOSSL_ALIGN_UP(EVP_MD_CTX_md_data(ctx));
     if( state == NULL )
     {
         SCOSSL_LOG_ERROR(SCOSSL_ERR_F_DIGESTS, SCOSSL_ERR_R_MISSING_CTX_DATA, "No MD Data Present");
@@ -421,8 +421,8 @@ static SCOSSL_STATUS e_scossl_digest_sha384_final(_Inout_ EVP_MD_CTX *ctx, _Out_
 
 static SCOSSL_STATUS e_scossl_digest_sha384_copy(_Out_ EVP_MD_CTX *to, _In_ const EVP_MD_CTX *from)
 {
-    PSYMCRYPT_SHA384_STATE state_to = (PSYMCRYPT_SHA384_STATE)EVP_MD_CTX_md_data(to);
-    PSYMCRYPT_SHA384_STATE state_from = (PSYMCRYPT_SHA384_STATE)EVP_MD_CTX_md_data(from);
+    PSYMCRYPT_SHA384_STATE state_to = (PSYMCRYPT_SHA384_STATE) SCOSSL_ALIGN_UP(EVP_MD_CTX_md_data(to));
+    PSYMCRYPT_SHA384_STATE state_from = (PSYMCRYPT_SHA384_STATE) SCOSSL_ALIGN_UP(EVP_MD_CTX_md_data(from));
     if( state_to == NULL || state_from == NULL )
     {
         return SCOSSL_SUCCESS;
@@ -437,7 +437,7 @@ static SCOSSL_STATUS e_scossl_digest_sha384_copy(_Out_ EVP_MD_CTX *to, _In_ cons
  */
 static SCOSSL_STATUS e_scossl_digest_sha512_init(_Out_ EVP_MD_CTX *ctx)
 {
-    PSYMCRYPT_SHA512_STATE state = (PSYMCRYPT_SHA512_STATE)EVP_MD_CTX_md_data(ctx);
+    PSYMCRYPT_SHA512_STATE state = (PSYMCRYPT_SHA512_STATE) SCOSSL_ALIGN_UP(EVP_MD_CTX_md_data(ctx));
     if( state == NULL )
     {
         SCOSSL_LOG_ERROR(SCOSSL_ERR_F_DIGESTS, SCOSSL_ERR_R_MISSING_CTX_DATA, "No MD Data Present");
@@ -451,7 +451,7 @@ static SCOSSL_STATUS e_scossl_digest_sha512_init(_Out_ EVP_MD_CTX *ctx)
 static SCOSSL_STATUS e_scossl_digest_sha512_update(_Inout_ EVP_MD_CTX *ctx, _In_reads_bytes_(count) const void *data,
                                 size_t count)
 {
-    PSYMCRYPT_SHA512_STATE state = (PSYMCRYPT_SHA512_STATE)EVP_MD_CTX_md_data(ctx);
+    PSYMCRYPT_SHA512_STATE state = (PSYMCRYPT_SHA512_STATE) SCOSSL_ALIGN_UP(EVP_MD_CTX_md_data(ctx));
     if( state == NULL )
     {
         SCOSSL_LOG_ERROR(SCOSSL_ERR_F_DIGESTS, SCOSSL_ERR_R_MISSING_CTX_DATA, "No MD Data Present");
@@ -464,7 +464,7 @@ static SCOSSL_STATUS e_scossl_digest_sha512_update(_Inout_ EVP_MD_CTX *ctx, _In_
 
 static SCOSSL_STATUS e_scossl_digest_sha512_final(_Inout_ EVP_MD_CTX *ctx, _Out_writes_(SYMCRYPT_SHA512_RESULT_SIZE) unsigned char *md)
 {
-    PSYMCRYPT_SHA512_STATE state = (PSYMCRYPT_SHA512_STATE)EVP_MD_CTX_md_data(ctx);
+    PSYMCRYPT_SHA512_STATE state = (PSYMCRYPT_SHA512_STATE) SCOSSL_ALIGN_UP(EVP_MD_CTX_md_data(ctx));
     if( state == NULL )
     {
         SCOSSL_LOG_ERROR(SCOSSL_ERR_F_DIGESTS, SCOSSL_ERR_R_MISSING_CTX_DATA, "No MD Data Present");
@@ -477,8 +477,8 @@ static SCOSSL_STATUS e_scossl_digest_sha512_final(_Inout_ EVP_MD_CTX *ctx, _Out_
 
 static SCOSSL_STATUS e_scossl_digest_sha512_copy(_Out_ EVP_MD_CTX *to, _In_ const EVP_MD_CTX *from)
 {
-    PSYMCRYPT_SHA512_STATE state_to = (PSYMCRYPT_SHA512_STATE)EVP_MD_CTX_md_data(to);
-    PSYMCRYPT_SHA512_STATE state_from = (PSYMCRYPT_SHA512_STATE)EVP_MD_CTX_md_data(from);
+    PSYMCRYPT_SHA512_STATE state_to = (PSYMCRYPT_SHA512_STATE) SCOSSL_ALIGN_UP(EVP_MD_CTX_md_data(to));
+    PSYMCRYPT_SHA512_STATE state_from = (PSYMCRYPT_SHA512_STATE) SCOSSL_ALIGN_UP(EVP_MD_CTX_md_data(from));
     if( state_to == NULL || state_from == NULL )
     {
         return SCOSSL_SUCCESS;

--- a/SymCryptProvider/src/ciphers/p_scossl_aes.c
+++ b/SymCryptProvider/src/ciphers/p_scossl_aes.c
@@ -55,12 +55,12 @@ static SCOSSL_STATUS p_scossl_aes_generic_set_ctx_params(_Inout_ SCOSSL_AES_CTX 
 
 static void p_scossl_aes_generic_freectx(SCOSSL_AES_CTX *ctx)
 {
-    OPENSSL_clear_free(ctx, sizeof(SCOSSL_AES_CTX));
+    SCOSSL_COMMON_ALIGNED_FREE(ctx, OPENSSL_clear_free, SCOSSL_AES_CTX);
 }
 
 static SCOSSL_AES_CTX *p_scossl_aes_generic_dupctx(SCOSSL_AES_CTX *ctx)
 {
-    SCOSSL_AES_CTX *copy_ctx = OPENSSL_malloc(sizeof(SCOSSL_AES_CTX));
+    SCOSSL_COMMON_ALIGNED_ALLOC(copy_ctx, OPENSSL_malloc, SCOSSL_AES_CTX);
     if (copy_ctx != NULL)
     { 
         memcpy(copy_ctx, ctx, sizeof(SCOSSL_AES_CTX));
@@ -541,7 +541,7 @@ static SCOSSL_STATUS scossl_aes_cfb8_cipher(_Inout_ SCOSSL_AES_CTX *ctx,
 #define IMPLEMENT_SCOSSL_AES_BLOCK_CIPHER(kbits, ivlen, lcmode, UCMODE)                                   \
     SCOSSL_AES_CTX *p_scossl_aes_##kbits##_##lcmode##_newctx()                                            \
     {                                                                                                     \
-        SCOSSL_AES_CTX *ctx = OPENSSL_zalloc(sizeof(SCOSSL_AES_CTX));                                     \
+        SCOSSL_COMMON_ALIGNED_ALLOC(ctx, OPENSSL_malloc, SCOSSL_AES_CTX);                                 \
         if (ctx != NULL)                                                                                  \
         {                                                                                                 \
             ctx->keylen = kbits >> 3;                                                                     \

--- a/SymCryptProvider/src/ciphers/p_scossl_aes.c
+++ b/SymCryptProvider/src/ciphers/p_scossl_aes.c
@@ -75,6 +75,7 @@ static SCOSSL_STATUS p_scossl_aes_generic_init_internal(_Inout_ SCOSSL_AES_CTX *
                                                         _In_ const OSSL_PARAM params[])
 {
     ctx->encrypt = encrypt;
+    ctx->cbBuf = 0;
 
     if (key != NULL)
     {

--- a/SymCryptProvider/src/ciphers/p_scossl_aes_aead.c
+++ b/SymCryptProvider/src/ciphers/p_scossl_aes_aead.c
@@ -56,7 +56,7 @@ static SCOSSL_STATUS p_scossl_aes_ccm_set_ctx_params(_Inout_ SCOSSL_CIPHER_CCM_C
  */
 static SCOSSL_CIPHER_GCM_CTX *p_scossl_aes_gcm_dupctx(_In_ SCOSSL_CIPHER_GCM_CTX *ctx)
 {
-    SCOSSL_CIPHER_GCM_CTX *copy_ctx = OPENSSL_malloc(sizeof(SCOSSL_CIPHER_GCM_CTX));
+    SCOSSL_COMMON_ALIGNED_ALLOC(copy_ctx, OPENSSL_malloc, SCOSSL_CIPHER_GCM_CTX);
     if (copy_ctx != NULL)
     {
         memcpy(copy_ctx, ctx, sizeof(SCOSSL_CIPHER_GCM_CTX));
@@ -72,7 +72,7 @@ static SCOSSL_CIPHER_GCM_CTX *p_scossl_aes_gcm_dupctx(_In_ SCOSSL_CIPHER_GCM_CTX
 
 static void p_scossl_aes_gcm_freectx(_Inout_ SCOSSL_CIPHER_GCM_CTX *ctx)
 {
-    OPENSSL_clear_free(ctx, sizeof(SCOSSL_CIPHER_GCM_CTX));
+    SCOSSL_COMMON_ALIGNED_FREE(ctx, OPENSSL_clear_free, SCOSSL_CIPHER_GCM_CTX);
 }
 
 static SCOSSL_STATUS p_scossl_aes_gcm_init_internal(_Inout_ SCOSSL_CIPHER_GCM_CTX *ctx, INT32 encrypt,
@@ -295,7 +295,7 @@ static SCOSSL_STATUS p_scossl_aes_gcm_set_ctx_params(_Inout_ SCOSSL_CIPHER_GCM_C
  */
 static SCOSSL_CIPHER_CCM_CTX *p_scossl_aes_ccm_dupctx(_In_ SCOSSL_CIPHER_CCM_CTX *ctx)
 {
-    SCOSSL_CIPHER_CCM_CTX *copy_ctx = OPENSSL_malloc(sizeof(SCOSSL_CIPHER_CCM_CTX));
+    SCOSSL_COMMON_ALIGNED_ALLOC(copy_ctx, OPENSSL_malloc, SCOSSL_CIPHER_CCM_CTX);
     if (copy_ctx != NULL)
     {
         memcpy(copy_ctx, ctx, sizeof(SCOSSL_CIPHER_CCM_CTX));
@@ -311,7 +311,7 @@ static SCOSSL_CIPHER_CCM_CTX *p_scossl_aes_ccm_dupctx(_In_ SCOSSL_CIPHER_CCM_CTX
 
 static void p_scossl_aes_ccm_freectx(_Inout_  SCOSSL_CIPHER_CCM_CTX *ctx)
 {
-    OPENSSL_clear_free(ctx, sizeof(SCOSSL_CIPHER_CCM_CTX));
+    SCOSSL_COMMON_ALIGNED_FREE(ctx, OPENSSL_clear_free, SCOSSL_CIPHER_CCM_CTX);
 }
 
 static SCOSSL_STATUS p_scossl_aes_ccm_init_internal(_Inout_ SCOSSL_CIPHER_CCM_CTX *ctx, INT32 encrypt,
@@ -524,7 +524,7 @@ static SCOSSL_STATUS p_scossl_aes_ccm_set_ctx_params(_Inout_ SCOSSL_CIPHER_CCM_C
 #define IMPLEMENT_SCOSSL_AES_AEAD_CIPHER(kbits, ivlen, lcmode, UCMODE)                                       \
     SCOSSL_CIPHER_##UCMODE##_CTX *p_scossl_aes_##kbits##_##lcmode##_newctx()                                 \
     {                                                                                                        \
-        SCOSSL_CIPHER_##UCMODE##_CTX *ctx = OPENSSL_malloc(sizeof(SCOSSL_CIPHER_##UCMODE##_CTX));            \
+        SCOSSL_COMMON_ALIGNED_ALLOC(ctx, OPENSSL_malloc, SCOSSL_CIPHER_##UCMODE##_CTX);                      \
         if (ctx != NULL)                                                                                     \
         {                                                                                                    \
             ctx->keylen = kbits >> 3;                                                                        \

--- a/SymCryptProvider/src/ciphers/p_scossl_aes_xts.c
+++ b/SymCryptProvider/src/ciphers/p_scossl_aes_xts.c
@@ -38,8 +38,8 @@ static SCOSSL_STATUS p_scossl_aes_xts_set_ctx_params(_Inout_ SCOSSL_AES_XTS_CTX 
 
 static SCOSSL_AES_XTS_CTX *p_scossl_aes_xtx_newctx_internal(size_t keylen)
 {
-    SCOSSL_AES_XTS_CTX *ctx = OPENSSL_zalloc(sizeof(SCOSSL_AES_XTS_CTX));
-    if (ctx != NULL)
+    SCOSSL_COMMON_ALIGNED_ALLOC(ctx, OPENSSL_malloc, SCOSSL_AES_XTS_CTX);
+    if (ctx != NULL)    
     {
         ctx->keylen = keylen;
     }
@@ -48,7 +48,7 @@ static SCOSSL_AES_XTS_CTX *p_scossl_aes_xtx_newctx_internal(size_t keylen)
 
 static SCOSSL_AES_XTS_CTX *p_scossl_aes_xts_dupctx(SCOSSL_AES_XTS_CTX *ctx)
 {
-    SCOSSL_AES_XTS_CTX *copy_ctx = OPENSSL_zalloc(sizeof(SCOSSL_AES_XTS_CTX));
+    SCOSSL_COMMON_ALIGNED_ALLOC(copy_ctx, OPENSSL_malloc, SCOSSL_AES_XTS_CTX);
     if (copy_ctx != NULL)
     {
         memcpy(copy_ctx, ctx, sizeof(SCOSSL_AES_XTS_CTX));
@@ -58,7 +58,7 @@ static SCOSSL_AES_XTS_CTX *p_scossl_aes_xts_dupctx(SCOSSL_AES_XTS_CTX *ctx)
 
 static void p_scossl_aes_xts_freectx(SCOSSL_AES_XTS_CTX *ctx)
 {
-    OPENSSL_clear_free(ctx, sizeof(SCOSSL_AES_XTS_CTX));
+    SCOSSL_COMMON_ALIGNED_FREE(ctx, OPENSSL_clear_free, SCOSSL_AES_XTS_CTX);
 }
 
 static SCOSSL_STATUS p_scossl_aes_xts_init_internal(_Inout_ SCOSSL_AES_XTS_CTX *ctx, INT32 encrypt,

--- a/SymCryptProvider/src/ciphers/p_scossl_aes_xts.c
+++ b/SymCryptProvider/src/ciphers/p_scossl_aes_xts.c
@@ -36,7 +36,7 @@ static const OSSL_PARAM p_scossl_aes_xts_settable_ctx_param_types[] = {
 
 static SCOSSL_STATUS p_scossl_aes_xts_set_ctx_params(_Inout_ SCOSSL_AES_XTS_CTX *ctx, _In_ const OSSL_PARAM params[]);
 
-static SCOSSL_AES_XTS_CTX *p_scossl_aes_xtx_newctx_internal(size_t keylen)
+static SCOSSL_AES_XTS_CTX *p_scossl_aes_xts_newctx_internal(size_t keylen)
 {
     SCOSSL_COMMON_ALIGNED_ALLOC(ctx, OPENSSL_malloc, SCOSSL_AES_XTS_CTX);
     if (ctx != NULL)    
@@ -218,7 +218,7 @@ static SCOSSL_STATUS p_scossl_aes_xts_get_ctx_params(_In_ SCOSSL_AES_XTS_CTX *ct
 #define IMPLEMENT_SCOSSL_AES_XTS_CIPHER(kbits)                                                        \
     SCOSSL_AES_XTS_CTX *p_scossl_aes_##kbits##_xts_newctx()                                           \
     {                                                                                                 \
-        return p_scossl_aes_xtx_newctx_internal(kbits >> 3);                                          \
+        return p_scossl_aes_xts_newctx_internal(kbits >> 3);                                          \
     }                                                                                                 \
     SCOSSL_STATUS p_scossl_aes_##kbits##_xts_get_params(_Inout_ OSSL_PARAM params[])                  \
     {                                                                                                 \

--- a/SymCryptProvider/src/p_scossl_base.c
+++ b/SymCryptProvider/src/p_scossl_base.c
@@ -249,22 +249,7 @@ SCOSSL_STATUS OSSL_provider_init(_In_ const OSSL_CORE_HANDLE *handle,
                                  _Out_ const OSSL_DISPATCH **out,
                                  _Out_ void **provctx)
 {
-    SCOSSL_PROVCTX *p_ctx = OPENSSL_malloc(sizeof(SCOSSL_PROVCTX));
-    if (p_ctx != NULL)
-    {
-        p_ctx->handle = handle;
-        *provctx = p_ctx;
-    }
-
-    *out = p_scossl_base_dispatch;
-
-    if (!scossl_prov_initialized)
-    {
-        SYMCRYPT_MODULE_INIT();
-        scossl_prov_initialized = 1;
-    }
-
-    scossl_setup_logging();
+    SCOSSL_PROVCTX *p_ctx;
 
     for (; in->function_id != 0; in++)
     {
@@ -284,6 +269,23 @@ SCOSSL_STATUS OSSL_provider_init(_In_ const OSSL_CORE_HANDLE *handle,
                 break;
         }
     }
+    
+    p_ctx = OPENSSL_malloc(sizeof(SCOSSL_PROVCTX));
+    if (p_ctx != NULL)
+    {
+        p_ctx->handle = handle;
+        *provctx = p_ctx;
+    }
+
+    *out = p_scossl_base_dispatch;
+
+    if (!scossl_prov_initialized)
+    {
+        SYMCRYPT_MODULE_INIT();
+        scossl_prov_initialized = 1;
+    }
+
+    scossl_setup_logging();
 
     return SCOSSL_SUCCESS;
 }

--- a/SymCryptProvider/src/p_scossl_digests.c
+++ b/SymCryptProvider/src/p_scossl_digests.c
@@ -46,12 +46,12 @@ SCOSSL_STATUS p_scossl_digest_get_params(_Inout_ OSSL_PARAM params[], size_t blo
 #define IMPLEMENT_SCOSSL_DIGEST(lcalg, CcAlg, UCALG)                                  \
     static void *p_scossl_##lcalg##_newctx(ossl_unused void *prov_ctx)                \
     {                                                                                 \
-        return OPENSSL_malloc(sizeof(SYMCRYPT_##UCALG##_STATE));                      \
+        SCOSSL_COMMON_ALIGNED_ALLOC(dctx, OPENSSL_malloc, SYMCRYPT_##UCALG##_STATE);  \
+        return (PBYTE)dctx;                                                           \
     }                                                                                 \
     static void *p_scossl_##lcalg##_dupctx(_In_ SYMCRYPT_##UCALG##_STATE *dctx)       \
     {                                                                                 \
-        SYMCRYPT_##UCALG##_STATE *copy_ctx =                                          \
-            OPENSSL_malloc(sizeof(SYMCRYPT_##UCALG##_STATE));                         \
+        SCOSSL_COMMON_ALIGNED_ALLOC(copy_ctx, OPENSSL_malloc, SYMCRYPT_##UCALG##_STATE);\
                                                                                       \
         if (copy_ctx != NULL)                                                         \
             SymCrypt##CcAlg##StateCopy(dctx, copy_ctx);                               \
@@ -60,7 +60,7 @@ SCOSSL_STATUS p_scossl_digest_get_params(_Inout_ OSSL_PARAM params[], size_t blo
     }                                                                                 \
     static void p_scossl_##lcalg##_freectx(_Inout_ SYMCRYPT_##UCALG##_STATE *dctx)    \
     {                                                                                 \
-        OPENSSL_clear_free(dctx, sizeof(SYMCRYPT_##UCALG##_STATE));                   \
+        SCOSSL_COMMON_ALIGNED_FREE(dctx, OPENSSL_clear_free, SYMCRYPT_##UCALG##_STATE);\
     }                                                                                 \
     static SCOSSL_STATUS p_scossl_##lcalg##_init(                                     \
         _Inout_ SYMCRYPT_##UCALG##_STATE *dctx,                                       \


### PR DESCRIPTION
+ Previously SCOSSL would rely on allocations made by libcrypto being at least 16-byte aligned for 64-bit platforms. This was normally true, but in some environments where the allocator is modified, only 8-byte alignment was being provided.
+ Should address #59