### PR TITLE
Provider DH

### DIFF
--- a/ScosslCommon/CMakeLists.txt
+++ b/ScosslCommon/CMakeLists.txt
@@ -11,6 +11,7 @@ include_directories(${OPENSSL_INCLUDE_DIR})
 set(SCOSSL_SOURCES
     ./src/scossl_helpers.c
     ./src/scossl_aes_aead.c
+    ./src/scossl_dh.c
     ./src/scossl_ecc.c
     ./src/scossl_hkdf.c
     ./src/scossl_rsa.c

--- a/ScosslCommon/inc/scossl_dh.h
+++ b/ScosslCommon/inc/scossl_dh.h
@@ -19,9 +19,10 @@ void scossl_dh_free_key_ctx(_Inout_ SCOSSL_DH_KEY_CTX *ctx);
 SCOSSL_DH_KEY_CTX *scossl_dh_dup_key_ctx(_In_ SCOSSL_DH_KEY_CTX *ctx, BOOL copyGroup);
 
 SCOSSL_STATUS scossl_dh_import_keypair(_Inout_ SCOSSL_DH_KEY_CTX *ctx, UINT32 nBitsPriv,
-                                        _In_ PCSYMCRYPT_DLGROUP pDlgroup, BOOL skipGroupValidation,
+                                       _In_ PCSYMCRYPT_DLGROUP pDlgroup, BOOL skipGroupValidation,
                                        _In_ const BIGNUM *privateKey, _In_ const BIGNUM *publicKey);
-SCOSSL_STATUS scossl_dh_create_key(_Inout_ SCOSSL_DH_KEY_CTX *ctx, _In_ PCSYMCRYPT_DLGROUP pDlgroup, UINT32 nBitsPriv, BOOL generatKeyPair);
+SCOSSL_STATUS scossl_dh_generate_keypair(_Inout_ SCOSSL_DH_KEY_CTX *ctx, UINT32 nBitsPriv,
+                                         _In_ PCSYMCRYPT_DLGROUP pDlgroup);
 
 SCOSSL_STATUS scossl_dh_init_static(void);
 void scossl_destroy_safeprime_dlgroups(void);

--- a/ScosslCommon/inc/scossl_dh.h
+++ b/ScosslCommon/inc/scossl_dh.h
@@ -16,7 +16,7 @@ typedef struct
 
 SCOSSL_DH_KEY_CTX *scossl_dh_new_key_ctx(void);
 void scossl_dh_free_key_ctx(_Inout_ SCOSSL_DH_KEY_CTX *ctx);
-SCOSSL_DH_KEY_CTX *scossl_dh_dup_key_ctx(_In_ SCOSSL_DH_KEY_CTX *ctx);
+SCOSSL_DH_KEY_CTX *scossl_dh_dup_key_ctx(_In_ SCOSSL_DH_KEY_CTX *ctx, BOOL copyGroup);
 
 SCOSSL_STATUS scossl_dh_import_keypair(_Inout_ SCOSSL_DH_KEY_CTX *ctx, _In_ PCSYMCRYPT_DLGROUP pDlgroup, UINT32 nBitsPriv,
                                        _In_ const BIGNUM *privateKey, _In_ const BIGNUM *publicKey);

--- a/ScosslCommon/inc/scossl_dh.h
+++ b/ScosslCommon/inc/scossl_dh.h
@@ -28,7 +28,8 @@ SCOSSL_STATUS scossl_dh_init_static(void);
 void scossl_destroy_safeprime_dlgroups(void);
 
 PCSYMCRYPT_DLGROUP scossl_dh_get_known_group(_In_ PCSYMCRYPT_DLGROUP pDlGroup);
-PCSYMCRYPT_DLGROUP scossl_dh_get_group_by_nid(int dlGroupNid, _In_opt_ const BIGNUM* p);
+SCOSSL_STATUS scossl_dh_get_group_by_nid(int dlGroupNid, _In_opt_ const BIGNUM* p,
+                                         _Out_ PCSYMCRYPT_DLGROUP *ppDlGroup);
 int scossl_dh_get_group_nid(_In_ PCSYMCRYPT_DLGROUP pDlGroup);
 
 #ifdef __cplusplus

--- a/ScosslCommon/inc/scossl_dh.h
+++ b/ScosslCommon/inc/scossl_dh.h
@@ -1,0 +1,32 @@
+//
+// Copyright (c) Microsoft Corporation. Licensed under the MIT license.
+//
+
+#include "scossl_helpers.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+typedef struct
+{
+    BOOL initialized;
+    PSYMCRYPT_DLKEY dlkey;
+} SCOSSL_DH_KEY_CTX;
+
+SCOSSL_DH_KEY_CTX *scossl_dh_new_key_ctx(void);
+void scossl_dh_free_key_ctx(_Inout_ SCOSSL_DH_KEY_CTX *ctx);
+SCOSSL_DH_KEY_CTX *scossl_dh_dup_key_ctx(_In_ SCOSSL_DH_KEY_CTX *ctx);
+
+SCOSSL_STATUS scossl_dh_import_keypair(_Inout_ SCOSSL_DH_KEY_CTX *ctx, _In_ PCSYMCRYPT_DLGROUP pDlgroup, UINT32 nBitsPriv,
+                                       _In_ const BIGNUM *privateKey, _In_ const BIGNUM *publicKey);
+SCOSSL_STATUS scossl_dh_create_key(_Inout_ SCOSSL_DH_KEY_CTX *ctx, _In_ PCSYMCRYPT_DLGROUP pDlgroup, UINT32 nBitsPriv, BOOL generatKeyPair);
+
+SCOSSL_STATUS scossl_dh_init_static(void);
+void scossl_destroy_safeprime_dlgroups(void);
+SCOSSL_STATUS scossl_dh_get_group(int dlGroupNid, _In_opt_ const BIGNUM* p, _Out_ PCSYMCRYPT_DLGROUP *ppDlGroup);
+int scossl_dh_get_group_nid(_In_ PCSYMCRYPT_DLGROUP pDlGroup);
+
+#ifdef __cplusplus
+}
+#endif

--- a/ScosslCommon/inc/scossl_dh.h
+++ b/ScosslCommon/inc/scossl_dh.h
@@ -18,13 +18,16 @@ SCOSSL_DH_KEY_CTX *scossl_dh_new_key_ctx(void);
 void scossl_dh_free_key_ctx(_Inout_ SCOSSL_DH_KEY_CTX *ctx);
 SCOSSL_DH_KEY_CTX *scossl_dh_dup_key_ctx(_In_ SCOSSL_DH_KEY_CTX *ctx, BOOL copyGroup);
 
-SCOSSL_STATUS scossl_dh_import_keypair(_Inout_ SCOSSL_DH_KEY_CTX *ctx, _In_ PCSYMCRYPT_DLGROUP pDlgroup, UINT32 nBitsPriv,
+SCOSSL_STATUS scossl_dh_import_keypair(_Inout_ SCOSSL_DH_KEY_CTX *ctx, UINT32 nBitsPriv,
+                                        _In_ PCSYMCRYPT_DLGROUP pDlgroup, BOOL skipGroupValidation,
                                        _In_ const BIGNUM *privateKey, _In_ const BIGNUM *publicKey);
 SCOSSL_STATUS scossl_dh_create_key(_Inout_ SCOSSL_DH_KEY_CTX *ctx, _In_ PCSYMCRYPT_DLGROUP pDlgroup, UINT32 nBitsPriv, BOOL generatKeyPair);
 
 SCOSSL_STATUS scossl_dh_init_static(void);
 void scossl_destroy_safeprime_dlgroups(void);
-SCOSSL_STATUS scossl_dh_get_group(int dlGroupNid, _In_opt_ const BIGNUM* p, _Out_ PCSYMCRYPT_DLGROUP *ppDlGroup);
+
+PCSYMCRYPT_DLGROUP scossl_dh_get_known_group(_In_ PCSYMCRYPT_DLGROUP pDlGroup);
+PCSYMCRYPT_DLGROUP scossl_dh_get_group_by_nid(int dlGroupNid, _In_opt_ const BIGNUM* p);
 int scossl_dh_get_group_nid(_In_ PCSYMCRYPT_DLGROUP pDlGroup);
 
 #ifdef __cplusplus

--- a/ScosslCommon/inc/scossl_helpers.h
+++ b/ScosslCommon/inc/scossl_helpers.h
@@ -247,6 +247,7 @@ void _scossl_log_SYMCRYPT_ERROR(
 BOOL scossl_is_md_supported(int mdnid);
 PCSYMCRYPT_MAC scossl_get_symcrypt_hmac_algorithm(int mdnid);
 PCSYMCRYPT_HASH scossl_get_symcrypt_hash_algorithm(int mdnid);
+int scossl_get_mdnid_from_symcrypt_hash_algorithm(_In_ PCSYMCRYPT_HASH symCryptHash);
 
 #ifdef __cplusplus
 }

--- a/ScosslCommon/src/scossl_dh.c
+++ b/ScosslCommon/src/scossl_dh.c
@@ -39,8 +39,8 @@ void scossl_dh_free_key_ctx(SCOSSL_DH_KEY_CTX *ctx)
 SCOSSL_DH_KEY_CTX *scossl_dh_dup_key_ctx(SCOSSL_DH_KEY_CTX *ctx, BOOL copyGroup)
 {
     SCOSSL_DH_KEY_CTX *copyCtx = OPENSSL_malloc(sizeof(SCOSSL_DH_KEY_CTX));
+    PSYMCRYPT_DLGROUP pDlgroupCopy = NULL;
     PCSYMCRYPT_DLGROUP pDlgroup;
-    PSYMCRYPT_DLGROUP pDlgroupCopy;
 
     if (copyCtx != NULL)
     {

--- a/ScosslCommon/src/scossl_dh.c
+++ b/ScosslCommon/src/scossl_dh.c
@@ -407,6 +407,7 @@ SCOSSL_STATUS scossl_dh_get_group_by_nid(int dlGroupNid, const BIGNUM* p,
     case NID_ffdhe4096:
         *ppDlGroup = _hidden_dlgroup_ffdhe4096;
         break;
+#if OPENSSL_VERSION_MAJOR >= 3
     case NID_modp_2048:
         *ppDlGroup = _hidden_dlgroup_modp2048;
         break;
@@ -416,6 +417,7 @@ SCOSSL_STATUS scossl_dh_get_group_by_nid(int dlGroupNid, const BIGNUM* p,
     case NID_modp_4096:
         *ppDlGroup = _hidden_dlgroup_modp4096;
         break;
+#endif // OPENSSL_VERSION_MAJOR >= 3
     default:
         // Not one of the supported ffdhe groups, but may still be a supported MODP group
         // Given we know the generator is 2, we can now check whether P corresponds to a MODP group
@@ -470,6 +472,7 @@ int scossl_dh_get_group_nid(PCSYMCRYPT_DLGROUP pDlGroup)
     {
         dlGroupNid = NID_ffdhe4096;
     }
+#if OPENSSL_VERSION_MAJOR >= 3
     else if (pDlGroup == _hidden_dlgroup_modp2048)
     {
         dlGroupNid = NID_modp_2048;
@@ -482,6 +485,7 @@ int scossl_dh_get_group_nid(PCSYMCRYPT_DLGROUP pDlGroup)
     {
         dlGroupNid = NID_modp_4096;
     }
+#endif // OPENSSL_VERSION_MAJOR >= 3
 
     return dlGroupNid;
 }

--- a/ScosslCommon/src/scossl_dh.c
+++ b/ScosslCommon/src/scossl_dh.c
@@ -1,0 +1,391 @@
+//
+// Copyright (c) Microsoft Corporation. Licensed under the MIT license.
+//
+
+#include "scossl_dh.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+static PSYMCRYPT_DLGROUP _hidden_dlgroup_ffdhe2048 = NULL;
+static PSYMCRYPT_DLGROUP _hidden_dlgroup_ffdhe3072 = NULL;
+static PSYMCRYPT_DLGROUP _hidden_dlgroup_ffdhe4096 = NULL;
+static PSYMCRYPT_DLGROUP _hidden_dlgroup_modp2048 = NULL;
+static PSYMCRYPT_DLGROUP _hidden_dlgroup_modp3072 = NULL;
+static PSYMCRYPT_DLGROUP _hidden_dlgroup_modp4096 = NULL;
+static BIGNUM* _hidden_bignum_modp2048 = NULL;
+static BIGNUM* _hidden_bignum_modp3072 = NULL;
+static BIGNUM* _hidden_bignum_modp4096 = NULL;
+
+SCOSSL_DH_KEY_CTX *scossl_dh_new_key_ctx(void)
+{
+    return OPENSSL_zalloc(sizeof(SCOSSL_DH_KEY_CTX));
+}
+
+void scossl_dh_free_key_ctx(SCOSSL_DH_KEY_CTX *ctx)
+{
+    if (ctx == NULL)
+        return;
+
+    if (ctx->dlkey != NULL)
+    {
+        SymCryptDlkeyFree(ctx->dlkey);
+    }
+
+    OPENSSL_free(ctx);
+}
+
+SCOSSL_DH_KEY_CTX *scossl_dh_dup_key_ctx(SCOSSL_DH_KEY_CTX *ctx)
+{
+    SCOSSL_DH_KEY_CTX *copyCtx = OPENSSL_malloc(sizeof(SCOSSL_DH_KEY_CTX));
+
+    if (copyCtx != NULL)
+    {
+        copyCtx->initialized = ctx->initialized;
+        if (ctx->initialized)
+        {
+            if ((copyCtx->dlkey = SymCryptDlkeyAllocate(ctx->dlkey->pDlgroup)) == NULL)
+            {
+                OPENSSL_free(copyCtx);
+                copyCtx = NULL;
+            }
+            else
+            {
+                SymCryptDlkeyCopy(ctx->dlkey, copyCtx->dlkey);
+            }
+        }
+        else
+        {
+            copyCtx->dlkey = NULL;
+        }
+    }
+
+    return copyCtx;
+}
+
+_Use_decl_annotations_
+SCOSSL_STATUS scossl_dh_import_keypair(SCOSSL_DH_KEY_CTX *ctx, PCSYMCRYPT_DLGROUP pDlgroup, UINT32 nBitsPriv,
+                                       const BIGNUM *privateKey, const BIGNUM *publicKey)
+{
+    SYMCRYPT_ERROR scError = SYMCRYPT_NO_ERROR;
+    PBYTE  pbData = NULL;
+    SIZE_T cbData = 0;
+    PBYTE  pbPrivateKey = NULL;
+    PBYTE  pbPublicKey = NULL;
+    SIZE_T cbPrivateKey;
+    SIZE_T cbPublicKey;
+    SCOSSL_STATUS ret = SCOSSL_FAILURE;
+
+    if (ctx->dlkey != NULL)
+    {
+        SymCryptDlkeyFree(ctx->dlkey);
+    }
+
+    ctx->dlkey = SymCryptDlkeyAllocate(pDlgroup);
+    if (ctx->dlkey == NULL)
+    {
+        SCOSSL_LOG_ERROR(SCOSSL_ERR_F_DH_IMPORT_KEYPAIR, SCOSSL_ERR_R_SYMCRYPT_FAILURE,
+                         "SymCryptDlkeyAllocate returned NULL.");
+        goto cleanup;
+    }
+
+    if (nBitsPriv != 0)
+    {
+        scError = SymCryptDlkeySetPrivateKeyLength(ctx->dlkey, nBitsPriv, 0);
+        if (scError != SYMCRYPT_NO_ERROR)
+        {
+            SCOSSL_LOG_SYMCRYPT_ERROR(SCOSSL_ERR_F_DH_IMPORT_KEYPAIR, SCOSSL_ERR_R_SYMCRYPT_FAILURE,
+                "SymCryptDlkeySetPrivateKeyLength failed", scError);
+            goto cleanup;
+        }
+    }
+
+    if (privateKey != NULL || publicKey != NULL)
+    {
+        cbPrivateKey = SymCryptDlkeySizeofPrivateKey(ctx->dlkey);
+        cbPublicKey = SymCryptDlkeySizeofPublicKey(ctx->dlkey);
+        // For simplicity, always allocate enough space for a private key and a public key, even if we may only use one
+        cbData = cbPublicKey + cbPrivateKey;
+        if ((pbData = OPENSSL_zalloc(cbData)) == NULL)
+        {
+            SCOSSL_LOG_ERROR(SCOSSL_ERR_F_DH_IMPORT_KEYPAIR, ERR_R_MALLOC_FAILURE,
+                            "OPENSSL_zalloc returned NULL.");
+            goto cleanup;
+        }
+
+        if (privateKey != NULL)
+        {
+            pbPrivateKey = pbData;
+            if ((SIZE_T)BN_bn2binpad(privateKey, pbPrivateKey, cbPrivateKey) != cbPrivateKey)
+            {
+                SCOSSL_LOG_ERROR(SCOSSL_ERR_F_DH_IMPORT_KEYPAIR, ERR_R_INTERNAL_ERROR,
+                                "BN_bn2binpad did not write expected number of private key bytes.");
+                goto cleanup;
+            }
+        }
+        else
+        {
+            cbPrivateKey = 0;
+        }
+
+        if (pbPublicKey != NULL)
+        {
+            pbPublicKey = pbData + cbPrivateKey;
+            if ((SIZE_T)BN_bn2binpad(publicKey, pbPublicKey, cbPublicKey) != cbPublicKey)
+            {
+                SCOSSL_LOG_ERROR(SCOSSL_ERR_F_DH_IMPORT_KEYPAIR, ERR_R_INTERNAL_ERROR,
+                                "BN_bn2binpad did not write expected number of public key bytes.");
+                goto cleanup;
+            }
+        }
+        else
+        {
+            cbPublicKey = 0;
+        }
+
+        scError = SymCryptDlkeySetValue(
+            pbPrivateKey, cbPrivateKey,
+            pbPublicKey, cbPublicKey,
+            SYMCRYPT_NUMBER_FORMAT_MSB_FIRST,
+            SYMCRYPT_FLAG_DLKEY_DH,
+            ctx->dlkey);
+        if (scError != SYMCRYPT_NO_ERROR)
+        {
+            SCOSSL_LOG_SYMCRYPT_ERROR(SCOSSL_ERR_F_DH_IMPORT_KEYPAIR, SCOSSL_ERR_R_SYMCRYPT_FAILURE,
+                                    "SymCryptDlkeySetValue failed", scError);
+            goto cleanup;
+        }
+
+        ctx->initialized = TRUE;
+    }
+    ret = SCOSSL_SUCCESS;
+
+cleanup:
+    if (!ret)
+    {
+        ctx->initialized = FALSE;
+        SymCryptDlkeyFree(ctx->dlkey);
+    }
+
+    if (pbData != NULL)
+    {
+        OPENSSL_clear_free( pbData, cbData );
+    }
+
+    return ret;
+}
+
+_Use_decl_annotations_
+SCOSSL_STATUS scossl_dh_create_key(SCOSSL_DH_KEY_CTX *ctx, PCSYMCRYPT_DLGROUP pDlgroup, UINT32 nBitsPriv, BOOL generateKeyPair)
+{
+    SYMCRYPT_ERROR scError = SYMCRYPT_NO_ERROR;
+
+    ctx->dlkey = SymCryptDlkeyAllocate(pDlgroup);
+    if (ctx->dlkey == NULL)
+    {
+        SCOSSL_LOG_ERROR(SCOSSL_ERR_F_DH_GENERATE_KEYPAIR, SCOSSL_ERR_R_SYMCRYPT_FAILURE,
+                         "SymCryptDlkeyAllocate returned NULL.");
+        return SCOSSL_FAILURE;
+    }
+
+    if (nBitsPriv != 0)
+    {
+        scError = SymCryptDlkeySetPrivateKeyLength(ctx->dlkey, nBitsPriv, 0);
+        if (scError != SYMCRYPT_NO_ERROR)
+        {
+            SCOSSL_LOG_SYMCRYPT_ERROR(SCOSSL_ERR_F_DH_GENERATE_KEYPAIR, SCOSSL_ERR_R_SYMCRYPT_FAILURE,
+                                      "SymCryptDlkeySetPrivateKeyLength failed", scError);
+            return SCOSSL_FAILURE;
+        }
+    }
+
+    if (generateKeyPair)
+    {
+        scError = SymCryptDlkeyGenerate(SYMCRYPT_FLAG_DLKEY_DH, ctx->dlkey);
+        if (scError != SYMCRYPT_NO_ERROR)
+        {
+            SCOSSL_LOG_SYMCRYPT_ERROR(SCOSSL_ERR_F_DH_GENERATE_KEYPAIR, SCOSSL_ERR_R_SYMCRYPT_FAILURE,
+                                    "SymCryptDlkeyGenerate failed", scError);
+            return SCOSSL_FAILURE;
+        }
+
+        ctx->initialized = TRUE;
+    }
+
+    return SCOSSL_SUCCESS;
+}
+
+static PSYMCRYPT_DLGROUP scossl_initialize_safeprime_dlgroup(SYMCRYPT_DLGROUP_DH_SAFEPRIMETYPE dhSafePrimeType,
+                                                             UINT32 nBitsOfP)
+{
+    PSYMCRYPT_DLGROUP pDlgroup;
+    SYMCRYPT_ERROR scError = SYMCRYPT_NO_ERROR;
+
+    pDlgroup = SymCryptDlgroupAllocate( nBitsOfP, nBitsOfP-1 );
+    if (pDlgroup == NULL)
+    {
+        goto cleanup;
+    }
+
+    scError = SymCryptDlgroupSetValueSafePrime(dhSafePrimeType, pDlgroup);
+
+cleanup:
+    if (pDlgroup != NULL && scError != SYMCRYPT_NO_ERROR)
+    {
+        SymCryptDlgroupFree(pDlgroup);
+        pDlgroup = NULL;
+    }
+
+    return pDlgroup;
+}
+
+SCOSSL_STATUS scossl_dh_init_static(void)
+{
+    if (((_hidden_dlgroup_ffdhe2048 = scossl_initialize_safeprime_dlgroup(SYMCRYPT_DLGROUP_DH_SAFEPRIMETYPE_TLS_7919, 2048)) == NULL) ||
+        ((_hidden_dlgroup_ffdhe3072 = scossl_initialize_safeprime_dlgroup(SYMCRYPT_DLGROUP_DH_SAFEPRIMETYPE_TLS_7919, 3072)) == NULL) ||
+        ((_hidden_dlgroup_ffdhe4096 = scossl_initialize_safeprime_dlgroup(SYMCRYPT_DLGROUP_DH_SAFEPRIMETYPE_TLS_7919, 4096)) == NULL) ||
+        ((_hidden_dlgroup_modp2048 = scossl_initialize_safeprime_dlgroup(SYMCRYPT_DLGROUP_DH_SAFEPRIMETYPE_IKE_3526, 2048)) == NULL) ||
+        ((_hidden_dlgroup_modp3072 = scossl_initialize_safeprime_dlgroup(SYMCRYPT_DLGROUP_DH_SAFEPRIMETYPE_IKE_3526, 3072)) == NULL) ||
+        ((_hidden_dlgroup_modp4096 = scossl_initialize_safeprime_dlgroup(SYMCRYPT_DLGROUP_DH_SAFEPRIMETYPE_IKE_3526, 4096)) == NULL) ||
+        ((_hidden_bignum_modp2048 = BN_get_rfc3526_prime_2048(NULL)) == NULL) ||
+        ((_hidden_bignum_modp3072 = BN_get_rfc3526_prime_3072(NULL)) == NULL) ||
+        ((_hidden_bignum_modp4096 = BN_get_rfc3526_prime_4096(NULL)) == NULL) )
+    {
+        return SCOSSL_FAILURE;
+    }
+    return SCOSSL_SUCCESS;
+}
+
+void scossl_destroy_safeprime_dlgroups(void)
+{
+    if (_hidden_dlgroup_ffdhe2048)
+    {
+        SymCryptDlgroupFree(_hidden_dlgroup_ffdhe2048);
+        _hidden_dlgroup_ffdhe2048 = NULL;
+    }
+    if (_hidden_dlgroup_ffdhe3072)
+    {
+        SymCryptDlgroupFree(_hidden_dlgroup_ffdhe3072);
+        _hidden_dlgroup_ffdhe3072 = NULL;
+    }
+    if (_hidden_dlgroup_ffdhe4096)
+    {
+        SymCryptDlgroupFree(_hidden_dlgroup_ffdhe4096);
+        _hidden_dlgroup_ffdhe4096 = NULL;
+    }
+    if (_hidden_dlgroup_modp2048)
+    {
+        SymCryptDlgroupFree(_hidden_dlgroup_modp2048);
+        _hidden_dlgroup_modp2048 = NULL;
+    }
+    if (_hidden_dlgroup_modp3072)
+    {
+        SymCryptDlgroupFree(_hidden_dlgroup_modp3072);
+        _hidden_dlgroup_modp3072 = NULL;
+    }
+    if (_hidden_dlgroup_modp4096)
+    {
+        SymCryptDlgroupFree(_hidden_dlgroup_modp4096);
+        _hidden_dlgroup_modp4096 = NULL;
+    }
+    BN_free(_hidden_bignum_modp2048);
+    _hidden_bignum_modp2048 = NULL;
+    BN_free(_hidden_bignum_modp3072);
+    _hidden_bignum_modp3072 = NULL;
+    BN_free(_hidden_bignum_modp4096);
+    _hidden_bignum_modp4096 = NULL;
+}
+
+_Use_decl_annotations_
+SCOSSL_STATUS scossl_dh_get_group(int dlGroupNid, const BIGNUM* p, PCSYMCRYPT_DLGROUP *ppDlGroup)
+{
+    *ppDlGroup = NULL;
+    switch (dlGroupNid)
+    {
+    case NID_ffdhe2048:
+        *ppDlGroup = _hidden_dlgroup_ffdhe2048;
+        break;
+    case NID_ffdhe3072:
+        *ppDlGroup = _hidden_dlgroup_ffdhe3072;
+        break;
+    case NID_ffdhe4096:
+        *ppDlGroup = _hidden_dlgroup_ffdhe4096;
+        break;
+#if OPENSSL_VERSION_MAJOR >= 3
+    case NID_modp_2048:
+        *ppDlGroup = _hidden_dlgroup_modp2048;
+        break;
+    case NID_modp_3072:
+        *ppDlGroup = _hidden_dlgroup_modp3072;
+        break;
+    case NID_modp_4096:
+        *ppDlGroup = _hidden_dlgroup_modp4096;
+        break;
+#endif // OPENSSL_VERSION_MAJOR >= 3
+    default:
+        // Not one of the supported ffdhe groups, but may still be a supported MODP group
+        // Given we know the generator is 2, we can now check whether P corresponds to a MODP group
+        if (p != NULL)
+        {
+            if (BN_cmp(p, _hidden_bignum_modp2048) == 0)
+            {
+                *ppDlGroup = _hidden_dlgroup_modp2048;
+            }
+            else if (BN_cmp(p, _hidden_bignum_modp3072) == 0)
+            {
+                *ppDlGroup = _hidden_dlgroup_modp3072;
+            }
+            else if (BN_cmp(p, _hidden_bignum_modp4096) == 0)
+            {
+                *ppDlGroup = _hidden_dlgroup_modp4096;
+            }
+        }
+
+        if (*ppDlGroup == NULL)
+        {
+            return SCOSSL_FAILURE;
+        }
+    }
+
+    return SCOSSL_SUCCESS;
+}
+
+_Use_decl_annotations_
+int scossl_dh_get_group_nid(PCSYMCRYPT_DLGROUP pDlGroup)
+{
+    int dlGroupNid = 0;
+
+    if (pDlGroup == _hidden_dlgroup_ffdhe2048)
+    {
+        dlGroupNid = NID_ffdhe2048;
+    }
+    else if (pDlGroup == _hidden_dlgroup_ffdhe3072)
+    {
+        dlGroupNid = NID_ffdhe3072;
+    }
+    else if (pDlGroup == _hidden_dlgroup_ffdhe4096)
+    {
+        dlGroupNid = NID_ffdhe4096;
+    }
+#if OPENSSL_VERSION_MAJOR >= 3
+    else if (pDlGroup == _hidden_dlgroup_modp2048)
+    {
+        dlGroupNid = NID_modp_2048;
+    }
+    else if (pDlGroup == _hidden_dlgroup_modp3072)
+    {
+        dlGroupNid = NID_modp_3072;
+    }
+    else if (pDlGroup == _hidden_dlgroup_modp4096)
+    {
+        dlGroupNid = NID_modp_4096;
+    }
+#endif // OPENSSL_VERSION_MAJOR >= 3
+
+    return dlGroupNid;
+}
+
+#ifdef __cplusplus
+}
+#endif

--- a/ScosslCommon/src/scossl_helpers.c
+++ b/ScosslCommon/src/scossl_helpers.c
@@ -394,7 +394,6 @@ void _scossl_log_SYMCRYPT_ERROR(
     _scossl_log(trace_level, func_code, reason_code, file, line, "%s - %s (0x%x)", description, scErrorString, scError);
 }
 
-_Use_decl_annotations_
 BOOL scossl_is_md_supported(int mdnid)
 {
     switch (mdnid)
@@ -412,7 +411,6 @@ BOOL scossl_is_md_supported(int mdnid)
     return FALSE;
 }
 
-_Use_decl_annotations_
 PCSYMCRYPT_MAC scossl_get_symcrypt_hmac_algorithm(int mdnid)
 {
     switch(mdnid)
@@ -437,7 +435,6 @@ PCSYMCRYPT_MAC scossl_get_symcrypt_hmac_algorithm(int mdnid)
     return NULL;
 }
 
-_Use_decl_annotations_
 PCSYMCRYPT_HASH scossl_get_symcrypt_hash_algorithm(int mdnid)
 {
     switch (mdnid)
@@ -460,6 +457,41 @@ PCSYMCRYPT_HASH scossl_get_symcrypt_hash_algorithm(int mdnid)
     SCOSSL_LOG_ERROR(SCOSSL_ERR_F_GET_SYMCRYPT_HASH_ALGORITHM, SCOSSL_ERR_R_NOT_IMPLEMENTED,
         "SCOSSL does not support hash algorithm %d", mdnid);
     return NULL;
+}
+
+_Use_decl_annotations_
+int scossl_get_mdnid_from_symcrypt_hash_algorithm(PCSYMCRYPT_HASH symCryptHash)
+{
+    if (symCryptHash == SymCryptSha1Algorithm)
+    {
+        return NID_sha1;
+    }
+    else if (symCryptHash == SymCryptSha256Algorithm)
+    {
+        return NID_sha256;
+    }
+    else if (symCryptHash == SymCryptSha384Algorithm)
+    {
+        return NID_sha384;
+    }
+    else if (symCryptHash == SymCryptSha512Algorithm)
+    {
+        return NID_sha512;
+    }
+    else if (symCryptHash == SymCryptSha3_256Algorithm)
+    {
+        return NID_sha3_256;
+    }
+    else if (symCryptHash == SymCryptSha3_384Algorithm)
+    {
+        return NID_sha3_384;
+    }
+    else if (symCryptHash == SymCryptSha3_512Algorithm)
+    {
+        return NID_sha3_512;
+    }
+
+    return NID_undef;
 }
 
 #ifdef __cplusplus

--- a/ScosslCommon/src/scossl_helpers.c
+++ b/ScosslCommon/src/scossl_helpers.c
@@ -433,7 +433,7 @@ PCSYMCRYPT_MAC scossl_get_symcrypt_hmac_algorithm(int mdnid)
         return SymCryptHmacSha3_512Algorithm;
     }
     SCOSSL_LOG_ERROR(SCOSSL_ERR_F_GET_SYMCRYPT_MAC_ALGORITHM, SCOSSL_ERR_R_NOT_IMPLEMENTED,
-        "SymCrypt-OpenSSL does not support hmac algorithm %d", mdnid);
+        "SCOSSL does not support hmac algorithm %d", mdnid);
     return NULL;
 }
 
@@ -458,7 +458,7 @@ PCSYMCRYPT_HASH scossl_get_symcrypt_hash_algorithm(int mdnid)
         return SymCryptSha3_512Algorithm;
     }
     SCOSSL_LOG_ERROR(SCOSSL_ERR_F_GET_SYMCRYPT_HASH_ALGORITHM, SCOSSL_ERR_R_NOT_IMPLEMENTED,
-        "SymCrypt-OpenSSL does not support hash algorithm %d", mdnid);
+        "SCOSSL does not support hash algorithm %d", mdnid);
     return NULL;
 }
 

--- a/SymCryptEngine/src/e_scossl_dh.c
+++ b/SymCryptEngine/src/e_scossl_dh.c
@@ -229,7 +229,7 @@ SCOSSL_STATUS e_scossl_dh_init_static()
 SCOSSL_STATUS e_scossl_get_dh_context_ex(_Inout_ DH* dh, _Out_ SCOSSL_DH_KEY_CTX** ppKeyCtx, BOOL generate)
 {
     SCOSSL_STATUS status;
-    PSYMCRYPT_DLGROUP pDlgroup = NULL;
+    PCSYMCRYPT_DLGROUP pDlgroup = NULL;
 
     const BIGNUM* p = NULL;
     const BIGNUM* g = NULL;

--- a/SymCryptProvider/CMakeLists.txt
+++ b/SymCryptProvider/CMakeLists.txt
@@ -24,7 +24,9 @@ set(SCOSSL_SOURCES
     ./src/kdf/p_scossl_hkdf.c
     ./src/kdf/p_scossl_sshkdf.c
     ./src/kdf/p_scossl_tls1prf.c
+    ./src/keyexch/p_scossl_dh_keyexch.c
     ./src/keyexch/p_scossl_ecdh.c
+    ./src/keymgmt/p_scossl_dh_keymgmt.c
     ./src/keymgmt/p_scossl_ecc_keymgmt.c
     ./src/keymgmt/p_scossl_rsa_keymgmt.c
     ./src/signature/p_scossl_ecdsa_signature.c

--- a/SymCryptProvider/CMakeLists.txt
+++ b/SymCryptProvider/CMakeLists.txt
@@ -24,7 +24,7 @@ set(SCOSSL_SOURCES
     ./src/kdf/p_scossl_hkdf.c
     ./src/kdf/p_scossl_sshkdf.c
     ./src/kdf/p_scossl_tls1prf.c
-    ./src/keyexch/p_scossl_dh_keyexch.c
+    ./src/keyexch/p_scossl_dh.c
     ./src/keyexch/p_scossl_ecdh.c
     ./src/keymgmt/p_scossl_dh_keymgmt.c
     ./src/keymgmt/p_scossl_ecc_keymgmt.c

--- a/SymCryptProvider/src/keyexch/p_scossl_dh.c
+++ b/SymCryptProvider/src/keyexch/p_scossl_dh.c
@@ -3,7 +3,9 @@
 //
 
 #include "scossl_helpers.h"
+#include "p_scossl_dh.h"
 
+#include <openssl/core_names.h>
 #include <openssl/proverr.h>
 
 #ifdef __cplusplus
@@ -12,23 +14,22 @@ extern "C" {
 
 typedef struct
 {
+    SCOSSL_PROV_DH_KEY_CTX *provKey;
+    SCOSSL_PROV_DH_KEY_CTX *peerProvKey;
 
+    unsigned int pad;
 } SCOSSL_DH_CTX;
 
 static const OSSL_PARAM p_scossl_dh_ctx_param_types[] = {
+    OSSL_PARAM_int(OSSL_EXCHANGE_PARAM_PAD, NULL),
+    OSSL_PARAM_utf8_string(OSSL_EXCHANGE_PARAM_KDF_TYPE, NULL, 0),
     OSSL_PARAM_END};
 
-static SCOSSL_STATUS p_scossl_dh_set_ctx_params(ossl_unused void *ctx, const ossl_unused OSSL_PARAM params[]);
+static SCOSSL_STATUS p_scossl_dh_set_ctx_params(_Inout_ SCOSSL_DH_CTX *ctx, _In_ const OSSL_PARAM params[]);
 
 static SCOSSL_DH_CTX *p_scossl_dh_newctx(ossl_unused void *provctx)
 {
-    SCOSSL_DH_CTX *ctx = OPENSSL_malloc(sizeof(SCOSSL_DH_CTX));
-    if (ctx != NULL)
-    {
-
-    }
-
-    return ctx;
+    return OPENSSL_zalloc(sizeof(SCOSSL_DH_CTX));
 }
 
 static void p_scossl_dh_freectx(_In_ SCOSSL_DH_CTX *ctx)
@@ -41,39 +42,161 @@ static SCOSSL_DH_CTX *p_scossl_dh_dupctx(_In_ SCOSSL_DH_CTX *ctx)
     SCOSSL_DH_CTX *copyCtx = OPENSSL_malloc(sizeof(SCOSSL_DH_CTX));
     if (copyCtx != NULL)
     {
-        copyCtx->libctx = ctx->libctx;
-        copyCtx->keyCtx = ctx->keyCtx;
-        copyCtx->peerKeyCtx = ctx->peerKeyCtx;
+        copyCtx->provKey = ctx->provKey;
+        copyCtx->peerProvKey = ctx->peerProvKey;
+        copyCtx->pad = ctx->pad;
     }
 
     return copyCtx;
 }
 
-static SCOSSL_STATUS p_scossl_dh_init(_In_ SCOSSL_DH_CTX *ctx, _In_ SCOSSL_ECC_KEY_CTX *keyCtx,
+static SCOSSL_STATUS p_scossl_dh_init(_In_ SCOSSL_DH_CTX *ctx, _In_ SCOSSL_PROV_DH_KEY_CTX *provKey,
                                       ossl_unused const OSSL_PARAM params[])
 {
-    return SCOSSL_FAILURE;
+    if (ctx == NULL ||
+        provKey == NULL)
+    {
+        return SCOSSL_FAILURE;
+    }
+
+    ctx->provKey = provKey;
+
+    return p_scossl_dh_set_ctx_params(ctx, params);
 }
 
-static SCOSSL_STATUS p_scossl_dh_set_peer(_Inout_ SCOSSL_DH_CTX *ctx, _In_ SCOSSL_ECC_KEY_CTX *peerKeyCtx)
+static SCOSSL_STATUS p_scossl_dh_set_peer(_Inout_ SCOSSL_DH_CTX *ctx, _In_ SCOSSL_PROV_DH_KEY_CTX *peerProvKey)
 {
-    return SCOSSL_FAILURE;
+    if (!SymCryptDlgroupIsSame(ctx->provKey->keyCtx->dlkey->pDlgroup, peerProvKey->keyCtx->dlkey->pDlgroup))
+    {
+        ERR_raise(ERR_LIB_PROV, PROV_R_MISMATCHING_DOMAIN_PARAMETERS);
+        return SCOSSL_FAILURE;
+    }
+
+    ctx->peerProvKey = peerProvKey;
+
+    return SCOSSL_SUCCESS;
 }
 
 static SCOSSL_STATUS p_scossl_dh_derive(_In_ SCOSSL_DH_CTX *ctx,
                                         _Out_writes_bytes_opt_(*secretlen) unsigned char *secret, _Out_ size_t *secretlen,
                                         size_t outlen)
 {
-    return SCOSSL_FAILURE;
-}
+    int cbAgreedSecret;
+    size_t npad = 0;
+    size_t mask = 1;
 
-static SCOSSL_STATUS p_scossl_dh_set_ctx_params(ossl_unused void *ctx, ossl_unused const OSSL_PARAM params[])
-{
+    SYMCRYPT_ERROR scError = SYMCRYPT_NO_ERROR;
+
+    if (ctx == NULL || secretlen == NULL)
+    {
+        ERR_raise(ERR_LIB_PROV, ERR_R_PASSED_NULL_PARAMETER);
+        return SCOSSL_FAILURE;
+    }
+
+    if (ctx->provKey == NULL || ctx->peerProvKey == NULL)
+    {
+        ERR_raise(ERR_LIB_PROV, PROV_R_MISSING_KEY);
+        return SCOSSL_FAILURE;
+    }
+
+    cbAgreedSecret = SymCryptDlkeySizeofPublicKey(ctx->provKey->keyCtx->dlkey);
+
+    if (secret != NULL)
+    {
+        scError = SymCryptDhSecretAgreement(
+            ctx->provKey->keyCtx->dlkey,
+            ctx->peerProvKey->keyCtx->dlkey,
+            SYMCRYPT_NUMBER_FORMAT_MSB_FIRST,
+            0,
+            secret,
+            outlen);
+        if (scError != SYMCRYPT_NO_ERROR)
+        {
+            ERR_raise(ERR_LIB_PROV, ERR_R_INTERNAL_ERROR);
+            return SCOSSL_FAILURE;
+        }
+
+        // Padding removal code from DH_compute_key to ensure
+        // consistency between implementations. This is
+        // inherently not constant time due to the RFC 5246 (8.1.2)
+        // padding style that strips leading zero bytes.
+        if (!ctx->pad)
+        {
+            for (int i = 0; i < cbAgreedSecret; i++)
+            {
+                mask &= !secret[i];
+                npad += mask;
+            }
+
+            /* unpad key */
+            cbAgreedSecret -= npad;
+            /* key-dependent memory access, potentially leaking npad / ret */
+            memmove(secret, secret + npad, cbAgreedSecret);
+            /* key-dependent memory access, potentially leaking npad / ret */
+            memset(secret + cbAgreedSecret, 0, npad);
+        }
+    }
+
+    *secretlen = cbAgreedSecret;
+
     return SCOSSL_SUCCESS;
 }
 
-static SCOSSL_STATUS p_scossl_dh_get_ctx_params(ossl_unused void *ctx, ossl_unused OSSL_PARAM params[])
+static SCOSSL_STATUS p_scossl_dh_set_ctx_params(_Inout_ SCOSSL_DH_CTX *ctx, _In_ const OSSL_PARAM params[])
 {
+    const OSSL_PARAM *p = NULL;
+
+    if ((p = OSSL_PARAM_locate_const(params, OSSL_EXCHANGE_PARAM_KDF_TYPE)) != NULL)
+    {
+        const char *kdfType;
+        if (!OSSL_PARAM_get_utf8_string_ptr(p, &kdfType))
+        {
+            ERR_raise(ERR_LIB_PROV, PROV_R_FAILED_TO_GET_PARAMETER);
+            return SCOSSL_FAILURE;
+        }
+
+        // We don't support other types such as x9.42 for now
+        if (kdfType == NULL ||
+            kdfType[0] !=-'\0')
+        {
+            ERR_raise(ERR_LIB_PROV, PROV_R_NOT_SUPPORTED);
+            return SCOSSL_FAILURE;
+        }
+    }
+
+    if ((p = OSSL_PARAM_locate_const(params, OSSL_EXCHANGE_PARAM_PAD)) != NULL)
+    {
+        unsigned int pad;
+        if (!OSSL_PARAM_get_uint(p, &pad))
+        {
+            ERR_raise(ERR_LIB_PROV, PROV_R_FAILED_TO_GET_PARAMETER);
+            return SCOSSL_FAILURE;
+        }
+
+        ctx->pad = pad ? 1 : 0;
+    }
+
+    return SCOSSL_SUCCESS;
+}
+
+static SCOSSL_STATUS p_scossl_dh_get_ctx_params(_In_ SCOSSL_DH_CTX *ctx, _Inout_ OSSL_PARAM params[])
+{
+    OSSL_PARAM *p = NULL;
+
+    if ((p = OSSL_PARAM_locate(params, OSSL_EXCHANGE_PARAM_KDF_TYPE)) != NULL &&
+        !OSSL_PARAM_set_utf8_string(p, ""))
+    {
+        ERR_raise(ERR_LIB_PROV, PROV_R_FAILED_TO_SET_PARAMETER);
+        return SCOSSL_FAILURE;
+    }
+
+    if ((p = OSSL_PARAM_locate(params, OSSL_EXCHANGE_PARAM_PAD)) != NULL &&
+        !OSSL_PARAM_set_uint(p, ctx->pad))
+    {
+        ERR_raise(ERR_LIB_PROV, PROV_R_FAILED_TO_SET_PARAMETER);
+        return SCOSSL_FAILURE;
+    }
+
     return SCOSSL_SUCCESS;
 }
 

--- a/SymCryptProvider/src/keyexch/p_scossl_dh.c
+++ b/SymCryptProvider/src/keyexch/p_scossl_dh.c
@@ -115,6 +115,13 @@ static SCOSSL_STATUS p_scossl_dh_init(_In_ SCOSSL_DH_CTX *ctx, _In_ SCOSSL_PROV_
 {
     if (ctx == NULL || provKey == NULL)
     {
+        ERR_raise(ERR_LIB_PROV, ERR_R_PASSED_NULL_PARAMETER);
+        return SCOSSL_FAILURE;
+    }
+
+    if (provKey->keyCtx == NULL ||!provKey->keyCtx->initialized)
+    {
+        ERR_raise(ERR_LIB_PROV, PROV_R_INVALID_KEY);
         return SCOSSL_FAILURE;
     }
 
@@ -126,11 +133,15 @@ static SCOSSL_STATUS p_scossl_dh_init(_In_ SCOSSL_DH_CTX *ctx, _In_ SCOSSL_PROV_
 static SCOSSL_STATUS p_scossl_dh_set_peer(_Inout_ SCOSSL_DH_CTX *ctx, _In_ SCOSSL_PROV_DH_KEY_CTX *peerProvKey)
 {
 
-    if (ctx == NULL ||
-        ctx->provKey == NULL || peerProvKey == NULL ||
-        !ctx->provKey->keyCtx->initialized || !peerProvKey->keyCtx->initialized)
+    if (ctx == NULL || peerProvKey == NULL)
     {
         ERR_raise(ERR_LIB_PROV, ERR_R_PASSED_NULL_PARAMETER);
+        return SCOSSL_FAILURE;
+    }
+
+    if (peerProvKey->keyCtx == NULL || !peerProvKey->keyCtx->initialized)
+    {
+        ERR_raise(ERR_LIB_PROV, PROV_R_INVALID_KEY);
         return SCOSSL_FAILURE;
     }
 

--- a/SymCryptProvider/src/keyexch/p_scossl_dh.c
+++ b/SymCryptProvider/src/keyexch/p_scossl_dh.c
@@ -1,0 +1,100 @@
+//
+// Copyright (c) Microsoft Corporation. Licensed under the MIT license.
+//
+
+#include "scossl_helpers.h"
+
+#include <openssl/proverr.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+typedef struct
+{
+
+} SCOSSL_DH_CTX;
+
+static const OSSL_PARAM p_scossl_dh_ctx_param_types[] = {
+    OSSL_PARAM_END};
+
+static SCOSSL_STATUS p_scossl_dh_set_ctx_params(ossl_unused void *ctx, const ossl_unused OSSL_PARAM params[]);
+
+static SCOSSL_DH_CTX *p_scossl_dh_newctx(ossl_unused void *provctx)
+{
+    SCOSSL_DH_CTX *ctx = OPENSSL_malloc(sizeof(SCOSSL_DH_CTX));
+    if (ctx != NULL)
+    {
+
+    }
+
+    return ctx;
+}
+
+static void p_scossl_dh_freectx(_In_ SCOSSL_DH_CTX *ctx)
+{
+    OPENSSL_free(ctx);
+}
+
+static SCOSSL_DH_CTX *p_scossl_dh_dupctx(_In_ SCOSSL_DH_CTX *ctx)
+{
+    SCOSSL_DH_CTX *copyCtx = OPENSSL_malloc(sizeof(SCOSSL_DH_CTX));
+    if (copyCtx != NULL)
+    {
+        copyCtx->libctx = ctx->libctx;
+        copyCtx->keyCtx = ctx->keyCtx;
+        copyCtx->peerKeyCtx = ctx->peerKeyCtx;
+    }
+
+    return copyCtx;
+}
+
+static SCOSSL_STATUS p_scossl_dh_init(_In_ SCOSSL_DH_CTX *ctx, _In_ SCOSSL_ECC_KEY_CTX *keyCtx,
+                                      ossl_unused const OSSL_PARAM params[])
+{
+    return SCOSSL_FAILURE;
+}
+
+static SCOSSL_STATUS p_scossl_dh_set_peer(_Inout_ SCOSSL_DH_CTX *ctx, _In_ SCOSSL_ECC_KEY_CTX *peerKeyCtx)
+{
+    return SCOSSL_FAILURE;
+}
+
+static SCOSSL_STATUS p_scossl_dh_derive(_In_ SCOSSL_DH_CTX *ctx,
+                                        _Out_writes_bytes_opt_(*secretlen) unsigned char *secret, _Out_ size_t *secretlen,
+                                        size_t outlen)
+{
+    return SCOSSL_FAILURE;
+}
+
+static SCOSSL_STATUS p_scossl_dh_set_ctx_params(ossl_unused void *ctx, ossl_unused const OSSL_PARAM params[])
+{
+    return SCOSSL_SUCCESS;
+}
+
+static SCOSSL_STATUS p_scossl_dh_get_ctx_params(ossl_unused void *ctx, ossl_unused OSSL_PARAM params[])
+{
+    return SCOSSL_SUCCESS;
+}
+
+static const OSSL_PARAM *p_scossl_dh_ctx_params(ossl_unused void *ctx, ossl_unused void *provctx)
+{
+    return p_scossl_dh_ctx_param_types;
+}
+
+const OSSL_DISPATCH p_scossl_dh_functions[] = {
+    {OSSL_FUNC_KEYEXCH_NEWCTX, (void (*)(void))p_scossl_dh_newctx},
+    {OSSL_FUNC_KEYEXCH_FREECTX, (void (*)(void))p_scossl_dh_freectx},
+    {OSSL_FUNC_KEYEXCH_DUPCTX, (void (*)(void))p_scossl_dh_dupctx},
+    {OSSL_FUNC_KEYEXCH_INIT, (void (*)(void))p_scossl_dh_init},
+    {OSSL_FUNC_KEYEXCH_SET_PEER, (void (*)(void))p_scossl_dh_set_peer},
+    {OSSL_FUNC_KEYEXCH_DERIVE, (void (*)(void))p_scossl_dh_derive},
+    {OSSL_FUNC_KEYEXCH_SET_CTX_PARAMS, (void (*)(void))p_scossl_dh_set_ctx_params},
+    {OSSL_FUNC_KEYEXCH_SETTABLE_CTX_PARAMS, (void (*)(void))p_scossl_dh_ctx_params},
+    {OSSL_FUNC_KEYEXCH_GET_CTX_PARAMS, (void (*)(void))p_scossl_dh_get_ctx_params},
+    {OSSL_FUNC_KEYEXCH_GETTABLE_CTX_PARAMS, (void (*)(void))p_scossl_dh_ctx_params},
+    {0, NULL}};
+
+#ifdef __cplusplus
+}
+#endif

--- a/SymCryptProvider/src/keyexch/p_scossl_dh.c
+++ b/SymCryptProvider/src/keyexch/p_scossl_dh.c
@@ -2,34 +2,75 @@
 // Copyright (c) Microsoft Corporation. Licensed under the MIT license.
 //
 
-#include "scossl_helpers.h"
 #include "p_scossl_dh.h"
 
-#include <openssl/core_names.h>
+#include <openssl/kdf.h>
 #include <openssl/proverr.h>
 
 #ifdef __cplusplus
 extern "C" {
 #endif
 
+// Normally, if the output of this key exchange will be fed into
+// a KDF, the caller should not set OSSL_EXCHANGE_PARAM_KDF_TYPE,
+// create a KDF themselves, and pass the output of this operation
+// into the KDF. Due to the way X9.42 was historically implemented,
+// the SymCrypt provider needs to do this step for the caller if
+// OSSL_EXCHANGE_PARAM_KDF_TYPE is set to OSSL_KDF_NAME_X942KDF_ASN1.
+enum scossl_kdf_type {
+    SCOSSL_KDF_TYPE_NONE = 0,
+    SCOSSL_KDF_TYPE_X9_42};
+
 typedef struct
 {
+    OSSL_LIB_CTX *libCtx;
+
     SCOSSL_PROV_DH_KEY_CTX *provKey;
     SCOSSL_PROV_DH_KEY_CTX *peerProvKey;
 
-    unsigned int pad;
+    UINT pad;
+
+    // X9.42 parameters
+    enum scossl_kdf_type kdfType;
+    char *kdfMdName;
+    char *kdfMdProps;
+    char *kdfCekAlg;
+    unsigned char *kdfUkm;
+    SIZE_T kdfUkmlen;
+    SIZE_T kdfOutlen;
 } SCOSSL_DH_CTX;
 
-static const OSSL_PARAM p_scossl_dh_ctx_param_types[] = {
+static const OSSL_PARAM p_scossl_dh_ctx_settable_param_types[] = {
     OSSL_PARAM_int(OSSL_EXCHANGE_PARAM_PAD, NULL),
     OSSL_PARAM_utf8_string(OSSL_EXCHANGE_PARAM_KDF_TYPE, NULL, 0),
+    OSSL_PARAM_utf8_string(OSSL_EXCHANGE_PARAM_KDF_DIGEST, NULL, 0),
+    OSSL_PARAM_utf8_string(OSSL_EXCHANGE_PARAM_KDF_DIGEST_PROPS, NULL, 0),
+    OSSL_PARAM_utf8_string(OSSL_KDF_PARAM_CEK_ALG, NULL, 0),
+    OSSL_PARAM_octet_string(OSSL_EXCHANGE_PARAM_KDF_UKM, NULL, 0),
+    OSSL_PARAM_size_t(OSSL_EXCHANGE_PARAM_KDF_OUTLEN, NULL),
+    OSSL_PARAM_END};
+
+static const OSSL_PARAM p_scossl_dh_ctx_gettable_param_types[] = {
+    OSSL_PARAM_int(OSSL_EXCHANGE_PARAM_PAD, NULL),
+    OSSL_PARAM_utf8_string(OSSL_EXCHANGE_PARAM_KDF_TYPE, NULL, 0),
+    OSSL_PARAM_utf8_string(OSSL_EXCHANGE_PARAM_KDF_DIGEST, NULL, 0),
+    OSSL_PARAM_utf8_string(OSSL_KDF_PARAM_CEK_ALG, NULL, 0),
+    OSSL_PARAM_octet_ptr(OSSL_EXCHANGE_PARAM_KDF_UKM, NULL, 0),
+    OSSL_PARAM_size_t(OSSL_EXCHANGE_PARAM_KDF_OUTLEN, NULL),
     OSSL_PARAM_END};
 
 static SCOSSL_STATUS p_scossl_dh_set_ctx_params(_Inout_ SCOSSL_DH_CTX *ctx, _In_ const OSSL_PARAM params[]);
 
-static SCOSSL_DH_CTX *p_scossl_dh_newctx(ossl_unused void *provctx)
+static SCOSSL_DH_CTX *p_scossl_dh_newctx(_In_ SCOSSL_PROVCTX *provctx)
 {
-    return OPENSSL_zalloc(sizeof(SCOSSL_DH_CTX));
+    SCOSSL_DH_CTX *ctx = OPENSSL_zalloc(sizeof(SCOSSL_DH_CTX));
+
+    if (ctx != NULL)
+    {
+        ctx->libCtx = provctx->libctx;
+    }
+
+    return ctx;
 }
 
 static void p_scossl_dh_freectx(_In_ SCOSSL_DH_CTX *ctx)
@@ -42,9 +83,17 @@ static SCOSSL_DH_CTX *p_scossl_dh_dupctx(_In_ SCOSSL_DH_CTX *ctx)
     SCOSSL_DH_CTX *copyCtx = OPENSSL_malloc(sizeof(SCOSSL_DH_CTX));
     if (copyCtx != NULL)
     {
+        copyCtx->libCtx = ctx->libCtx;
         copyCtx->provKey = ctx->provKey;
         copyCtx->peerProvKey = ctx->peerProvKey;
         copyCtx->pad = ctx->pad;
+        copyCtx->kdfType = ctx->kdfType;
+        copyCtx->kdfMdName = ctx->kdfMdName == NULL ? NULL : OPENSSL_strdup(ctx->kdfMdName);
+        copyCtx->kdfMdProps = ctx->kdfMdProps == NULL ? NULL : OPENSSL_strdup(ctx->kdfMdProps);
+        copyCtx->kdfCekAlg = ctx->kdfCekAlg == NULL ? NULL : OPENSSL_strdup(ctx->kdfCekAlg);
+        copyCtx->kdfUkm = ctx->kdfUkm == NULL ? NULL : OPENSSL_memdup(ctx->kdfUkm, ctx->kdfUkmlen);
+        copyCtx->kdfUkmlen = ctx->kdfUkmlen;
+        copyCtx->kdfOutlen = ctx->kdfOutlen;
     }
 
     return copyCtx;
@@ -77,27 +126,90 @@ static SCOSSL_STATUS p_scossl_dh_set_peer(_Inout_ SCOSSL_DH_CTX *ctx, _In_ SCOSS
     return SCOSSL_SUCCESS;
 }
 
-static SCOSSL_STATUS p_scossl_dh_derive(_In_ SCOSSL_DH_CTX *ctx,
-                                        _Out_writes_bytes_opt_(*secretlen) unsigned char *secret, _Out_ size_t *secretlen,
-                                        size_t outlen)
+static SCOSSL_STATUS p_scossl_dh_X9_42_derive(_In_ SCOSSL_DH_CTX *ctx,
+                                              _Out_writes_bytes_(*secretlen) unsigned char *secret, _Out_ size_t *secretlen,
+                                              size_t outlen)
 {
-    int cbAgreedSecret;
-    size_t npad = 0;
-    size_t mask = 1;
+    PBYTE pbAgreedSecret = NULL;
+    SIZE_T cbAgreedSecret = 0;
+    EVP_KDF *kdf = NULL;
+    EVP_KDF_CTX *kdfCtx = NULL;
+    OSSL_PARAM params[6];
 
     SYMCRYPT_ERROR scError = SYMCRYPT_NO_ERROR;
+    SCOSSL_STATUS ret = SCOSSL_FAILURE;
 
-    if (ctx == NULL || secretlen == NULL)
+    // Perform derivation, and pass result to X9_42 implementation
+    if (secret != NULL)
     {
-        ERR_raise(ERR_LIB_PROV, ERR_R_PASSED_NULL_PARAMETER);
-        return SCOSSL_FAILURE;
+        cbAgreedSecret = SymCryptDlkeySizeofPublicKey(ctx->provKey->keyCtx->dlkey);
+
+        if ((pbAgreedSecret = OPENSSL_secure_malloc(cbAgreedSecret)) == NULL)
+        {
+            ERR_raise(ERR_LIB_PROV, ERR_R_MALLOC_FAILURE);
+            goto cleanup;
+        }
+
+        scError = SymCryptDhSecretAgreement(
+            ctx->provKey->keyCtx->dlkey,
+            ctx->peerProvKey->keyCtx->dlkey,
+            SYMCRYPT_NUMBER_FORMAT_MSB_FIRST,
+            0,
+            pbAgreedSecret,
+            cbAgreedSecret);
+        if (scError != SYMCRYPT_NO_ERROR)
+        {
+            ERR_raise(ERR_LIB_PROV, ERR_R_INTERNAL_ERROR);
+            goto cleanup;
+        }
+
+        if ((kdf = EVP_KDF_fetch(ctx->libCtx, OSSL_KDF_NAME_X942KDF_ASN1, NULL)) == NULL ||
+            (kdfCtx = EVP_KDF_CTX_new(kdf)) == NULL)
+        {
+            ERR_raise(ERR_LIB_PROV, ERR_R_INTERNAL_ERROR);
+            goto cleanup;
+        }
+
+        params[0] = OSSL_PARAM_construct_utf8_string(OSSL_KDF_PARAM_DIGEST, ctx->kdfMdName, 0);
+        params[1] = OSSL_PARAM_construct_utf8_string(OSSL_KDF_PARAM_PROPERTIES, ctx->kdfMdProps, 0);
+        params[2] = OSSL_PARAM_construct_utf8_string(OSSL_KDF_PARAM_CEK_ALG, ctx->kdfCekAlg, 0);
+        params[3] = OSSL_PARAM_construct_octet_string(OSSL_KDF_PARAM_KEY, pbAgreedSecret, cbAgreedSecret);
+
+        if (ctx->kdfUkm != NULL)
+        {
+            params[4] = OSSL_PARAM_construct_octet_string(OSSL_KDF_PARAM_UKM, ctx->kdfUkm, ctx->kdfUkmlen);
+        }
+
+        params[5] = OSSL_PARAM_construct_end();
+
+        if (!EVP_KDF_derive(kdfCtx, secret, outlen, params))
+        {
+            goto cleanup;
+        }
     }
 
-    if (ctx->provKey == NULL || ctx->peerProvKey == NULL)
+    *secretlen = ctx->kdfOutlen;
+    ret = SCOSSL_SUCCESS;
+cleanup:
+    if (pbAgreedSecret != NULL)
     {
-        ERR_raise(ERR_LIB_PROV, PROV_R_MISSING_KEY);
-        return SCOSSL_FAILURE;
+        OPENSSL_clear_free(pbAgreedSecret, cbAgreedSecret);
     }
+
+    EVP_KDF_CTX_free(kdfCtx);
+    EVP_KDF_free(kdf);
+
+    return ret;
+}
+
+static SCOSSL_STATUS p_scossl_dh_plain_derive(_In_ SCOSSL_DH_CTX *ctx,
+                                              _Out_writes_bytes_opt_(*secretlen) unsigned char *secret, _Out_ size_t *secretlen,
+                                              size_t outlen)
+{
+    SIZE_T cbAgreedSecret;
+    SIZE_T npad = 0;
+    SIZE_T mask = 1;
+    SYMCRYPT_ERROR scError = SYMCRYPT_NO_ERROR;
 
     cbAgreedSecret = SymCryptDlkeySizeofPublicKey(ctx->provKey->keyCtx->dlkey);
 
@@ -122,7 +234,7 @@ static SCOSSL_STATUS p_scossl_dh_derive(_In_ SCOSSL_DH_CTX *ctx,
         // padding style that strips leading zero bytes.
         if (!ctx->pad)
         {
-            for (int i = 0; i < cbAgreedSecret; i++)
+            for (SIZE_T i = 0; i < cbAgreedSecret; i++)
             {
                 mask &= !secret[i];
                 npad += mask;
@@ -142,27 +254,34 @@ static SCOSSL_STATUS p_scossl_dh_derive(_In_ SCOSSL_DH_CTX *ctx,
     return SCOSSL_SUCCESS;
 }
 
+
+static SCOSSL_STATUS p_scossl_dh_derive(_In_ SCOSSL_DH_CTX *ctx,
+                                        _Out_writes_bytes_opt_(*secretlen) unsigned char *secret, _Out_ size_t *secretlen,
+                                        size_t outlen)
+{
+    if (ctx == NULL || secretlen == NULL)
+    {
+        ERR_raise(ERR_LIB_PROV, ERR_R_PASSED_NULL_PARAMETER);
+        return SCOSSL_FAILURE;
+    }
+
+    if (ctx->provKey == NULL || ctx->peerProvKey == NULL)
+    {
+        ERR_raise(ERR_LIB_PROV, PROV_R_MISSING_KEY);
+        return SCOSSL_FAILURE;
+    }
+
+    if (ctx->kdfType == SCOSSL_KDF_TYPE_X9_42)
+    {
+        return p_scossl_dh_X9_42_derive(ctx, secret, secretlen, outlen);
+    }
+
+    return p_scossl_dh_plain_derive(ctx, secret, secretlen, outlen);
+}
+
 static SCOSSL_STATUS p_scossl_dh_set_ctx_params(_Inout_ SCOSSL_DH_CTX *ctx, _In_ const OSSL_PARAM params[])
 {
     const OSSL_PARAM *p = NULL;
-
-    if ((p = OSSL_PARAM_locate_const(params, OSSL_EXCHANGE_PARAM_KDF_TYPE)) != NULL)
-    {
-        const char *kdfType;
-        if (!OSSL_PARAM_get_utf8_string_ptr(p, &kdfType))
-        {
-            ERR_raise(ERR_LIB_PROV, PROV_R_FAILED_TO_GET_PARAMETER);
-            return SCOSSL_FAILURE;
-        }
-
-        // We don't support other types such as x9.42 for now
-        if (kdfType == NULL ||
-            kdfType[0] !=-'\0')
-        {
-            ERR_raise(ERR_LIB_PROV, PROV_R_NOT_SUPPORTED);
-            return SCOSSL_FAILURE;
-        }
-    }
 
     if ((p = OSSL_PARAM_locate_const(params, OSSL_EXCHANGE_PARAM_PAD)) != NULL)
     {
@@ -176,19 +295,100 @@ static SCOSSL_STATUS p_scossl_dh_set_ctx_params(_Inout_ SCOSSL_DH_CTX *ctx, _In_
         ctx->pad = pad ? 1 : 0;
     }
 
+    if ((p = OSSL_PARAM_locate_const(params, OSSL_EXCHANGE_PARAM_KDF_TYPE)) != NULL)
+    {
+        const char *kdfType;
+        if (!OSSL_PARAM_get_utf8_string_ptr(p, &kdfType) ||
+            kdfType == NULL)
+        {
+            ERR_raise(ERR_LIB_PROV, PROV_R_FAILED_TO_GET_PARAMETER);
+            return SCOSSL_FAILURE;
+        }
+
+        if (kdfType[0] =='\0')
+        {
+            ctx->kdfType = SCOSSL_KDF_TYPE_NONE;
+        }
+        else if (strcmp(kdfType, OSSL_KDF_NAME_X942KDF_ASN1) == 0)
+        {
+            ctx->kdfType = SCOSSL_KDF_TYPE_X9_42;
+        }
+        else
+        {
+            ERR_raise(ERR_LIB_PROV, PROV_R_NOT_SUPPORTED);
+            return SCOSSL_FAILURE;
+        }
+    }
+
+    if ((p = OSSL_PARAM_locate_const(params, OSSL_EXCHANGE_PARAM_KDF_DIGEST)) != NULL)
+    {
+        OPENSSL_free(ctx->kdfMdName);
+        ctx->kdfMdName = NULL;
+
+        if (!OSSL_PARAM_get_utf8_string(p, &ctx->kdfMdName, 0))
+        {
+            ERR_raise(ERR_LIB_PROV, PROV_R_FAILED_TO_GET_PARAMETER);
+            return SCOSSL_FAILURE;
+        }
+    }
+
+    if ((p = OSSL_PARAM_locate_const(params, OSSL_EXCHANGE_PARAM_KDF_DIGEST_PROPS)) != NULL)
+    {
+        OPENSSL_free(ctx->kdfMdProps);
+        ctx->kdfMdProps = NULL;
+
+        if (!OSSL_PARAM_get_utf8_string(p, &ctx->kdfMdProps, 0))
+        {
+            ERR_raise(ERR_LIB_PROV, PROV_R_FAILED_TO_GET_PARAMETER);
+            return SCOSSL_FAILURE;
+        }
+    }
+
+    if ((p = OSSL_PARAM_locate_const(params, OSSL_KDF_PARAM_CEK_ALG)) != NULL)
+    {
+        OPENSSL_free(ctx->kdfCekAlg);
+        ctx->kdfCekAlg = NULL;
+
+        if (!OSSL_PARAM_get_utf8_string(p, &ctx->kdfCekAlg, 0))
+        {
+            ERR_raise(ERR_LIB_PROV, PROV_R_FAILED_TO_GET_PARAMETER);
+            return SCOSSL_FAILURE;
+        }
+    }
+
+    if ((p = OSSL_PARAM_locate_const(params, OSSL_EXCHANGE_PARAM_KDF_UKM)) != NULL)
+    {
+        OPENSSL_free(ctx->kdfUkm);
+        ctx->kdfUkm = NULL;
+        ctx->kdfUkmlen = 0;
+
+        if (p->data != 0 &&
+            p->data_size != 0 &&
+            !OSSL_PARAM_get_octet_string(p, (void **)(&ctx->kdfUkm), 0, &ctx->kdfUkmlen))
+        {
+            ERR_raise(ERR_LIB_PROV, PROV_R_FAILED_TO_GET_PARAMETER);
+            return SCOSSL_FAILURE;
+        }
+    }
+
+    if ((p = OSSL_PARAM_locate_const(params, OSSL_EXCHANGE_PARAM_KDF_OUTLEN)) != NULL &&
+        !OSSL_PARAM_get_size_t(p, &ctx->kdfOutlen))
+    {
+        ERR_raise(ERR_LIB_PROV, PROV_R_FAILED_TO_GET_PARAMETER);
+        return SCOSSL_FAILURE;
+    }
+
     return SCOSSL_SUCCESS;
+}
+
+static const OSSL_PARAM *p_scossl_dh_ctx_settable_params(ossl_unused void *ctx, ossl_unused void *provctx)
+{
+    return p_scossl_dh_ctx_settable_param_types;
 }
 
 static SCOSSL_STATUS p_scossl_dh_get_ctx_params(_In_ SCOSSL_DH_CTX *ctx, _Inout_ OSSL_PARAM params[])
 {
     OSSL_PARAM *p = NULL;
-
-    if ((p = OSSL_PARAM_locate(params, OSSL_EXCHANGE_PARAM_KDF_TYPE)) != NULL &&
-        !OSSL_PARAM_set_utf8_string(p, ""))
-    {
-        ERR_raise(ERR_LIB_PROV, PROV_R_FAILED_TO_SET_PARAMETER);
-        return SCOSSL_FAILURE;
-    }
 
     if ((p = OSSL_PARAM_locate(params, OSSL_EXCHANGE_PARAM_PAD)) != NULL &&
         !OSSL_PARAM_set_uint(p, ctx->pad))
@@ -197,12 +397,55 @@ static SCOSSL_STATUS p_scossl_dh_get_ctx_params(_In_ SCOSSL_DH_CTX *ctx, _Inout_
         return SCOSSL_FAILURE;
     }
 
+    if ((p = OSSL_PARAM_locate(params, OSSL_EXCHANGE_PARAM_KDF_TYPE)) != NULL)
+    {
+        const char *kdfType = "";
+        if (ctx->kdfType == SCOSSL_KDF_TYPE_X9_42)
+        {
+            kdfType = OSSL_KDF_NAME_X942KDF_ASN1;
+        }
+
+        if (!OSSL_PARAM_set_utf8_string(p, kdfType))
+        {
+            ERR_raise(ERR_LIB_PROV, PROV_R_FAILED_TO_SET_PARAMETER);
+            return SCOSSL_FAILURE;
+        }
+    }
+
+    if ((p = OSSL_PARAM_locate(params, OSSL_EXCHANGE_PARAM_KDF_DIGEST)) != NULL &&
+        !OSSL_PARAM_set_utf8_string(p, ctx->kdfMdName == NULL ? "" : ctx->kdfMdName))
+    {
+        ERR_raise(ERR_LIB_PROV, PROV_R_FAILED_TO_SET_PARAMETER);
+        return SCOSSL_FAILURE;
+    }
+
+    if ((p = OSSL_PARAM_locate(params, OSSL_KDF_PARAM_CEK_ALG)) != NULL &&
+        !OSSL_PARAM_set_utf8_string(p, ctx->kdfCekAlg == NULL ? "" : ctx->kdfCekAlg))
+    {
+        ERR_raise(ERR_LIB_PROV, PROV_R_FAILED_TO_SET_PARAMETER);
+        return SCOSSL_FAILURE;
+    }
+
+    if ((p = OSSL_PARAM_locate(params, OSSL_EXCHANGE_PARAM_KDF_UKM)) != NULL &&
+        !OSSL_PARAM_set_octet_ptr(p, ctx->kdfUkm, ctx->kdfUkmlen))
+    {
+        ERR_raise(ERR_LIB_PROV, PROV_R_FAILED_TO_SET_PARAMETER);
+        return SCOSSL_FAILURE;
+    }
+
+    if ((p = OSSL_PARAM_locate(params, OSSL_EXCHANGE_PARAM_KDF_OUTLEN)) != NULL &&
+        !OSSL_PARAM_set_size_t(p, ctx->kdfOutlen))
+    {
+        ERR_raise(ERR_LIB_PROV, PROV_R_FAILED_TO_SET_PARAMETER);
+        return SCOSSL_FAILURE;
+    }
+
     return SCOSSL_SUCCESS;
 }
 
-static const OSSL_PARAM *p_scossl_dh_ctx_params(ossl_unused void *ctx, ossl_unused void *provctx)
+static const OSSL_PARAM *p_scossl_dh_ctx_gettable_params(ossl_unused void *ctx, ossl_unused void *provctx)
 {
-    return p_scossl_dh_ctx_param_types;
+    return p_scossl_dh_ctx_gettable_param_types;
 }
 
 const OSSL_DISPATCH p_scossl_dh_functions[] = {
@@ -213,9 +456,9 @@ const OSSL_DISPATCH p_scossl_dh_functions[] = {
     {OSSL_FUNC_KEYEXCH_SET_PEER, (void (*)(void))p_scossl_dh_set_peer},
     {OSSL_FUNC_KEYEXCH_DERIVE, (void (*)(void))p_scossl_dh_derive},
     {OSSL_FUNC_KEYEXCH_SET_CTX_PARAMS, (void (*)(void))p_scossl_dh_set_ctx_params},
-    {OSSL_FUNC_KEYEXCH_SETTABLE_CTX_PARAMS, (void (*)(void))p_scossl_dh_ctx_params},
+    {OSSL_FUNC_KEYEXCH_SETTABLE_CTX_PARAMS, (void (*)(void))p_scossl_dh_ctx_settable_params},
     {OSSL_FUNC_KEYEXCH_GET_CTX_PARAMS, (void (*)(void))p_scossl_dh_get_ctx_params},
-    {OSSL_FUNC_KEYEXCH_GETTABLE_CTX_PARAMS, (void (*)(void))p_scossl_dh_ctx_params},
+    {OSSL_FUNC_KEYEXCH_GETTABLE_CTX_PARAMS, (void (*)(void))p_scossl_dh_ctx_gettable_params},
     {0, NULL}};
 
 #ifdef __cplusplus

--- a/SymCryptProvider/src/keyexch/p_scossl_dh.h
+++ b/SymCryptProvider/src/keyexch/p_scossl_dh.h
@@ -1,0 +1,24 @@
+//
+// Copyright (c) Microsoft Corporation. Licensed under the MIT license.
+//
+
+#include "scossl_dh.h"
+#include "p_scossl_base.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+typedef struct
+{
+    // Provider needs to support importing group by parameters.
+    // This is only set if the group has been imported by parameters
+    // and needs to be freed.
+    PSYMCRYPT_DLGROUP pDlGroup;
+    SCOSSL_DH_KEY_CTX *keyCtx;
+    OSSL_LIB_CTX *libCtx;
+} SCOSSL_PROV_DH_KEY_CTX;
+
+#ifdef __cplusplus
+}
+#endif

--- a/SymCryptProvider/src/keymgmt/p_scossl_dh_keymgmt.c
+++ b/SymCryptProvider/src/keymgmt/p_scossl_dh_keymgmt.c
@@ -1040,15 +1040,15 @@ static SCOSSL_STATUS p_scossl_dh_keymgmt_export(_In_ SCOSSL_PROV_DH_KEY_CTX *ctx
     BOOL includePrivate = (selection & OSSL_KEYMGMT_SELECT_PRIVATE_KEY) != 0;
     int dlGroupNid;
     const char *dlGroup;
-    PBYTE  pbData;
-    SIZE_T cbData;
+    PBYTE  pbData = NULL;
+    SIZE_T cbData = 0;
 
     PBYTE  pbPrivateKey;
     PBYTE  pbPublicKey;
     SIZE_T cbPrivateKey;
     SIZE_T cbPublicKey;
-    BIGNUM *bnPrivKey;
-    BIGNUM *bnPubKey;
+    BIGNUM *bnPrivKey = NULL;
+    BIGNUM *bnPubKey = NULL;
 
     BIGNUM *bnP = NULL;
     BIGNUM *bnQ = NULL;

--- a/SymCryptProvider/src/keymgmt/p_scossl_dh_keymgmt.c
+++ b/SymCryptProvider/src/keymgmt/p_scossl_dh_keymgmt.c
@@ -130,7 +130,7 @@ static SCOSSL_PROV_DH_KEY_CTX *p_scossl_dh_keymgmt_dup_key_ctx(_In_ const SCOSSL
         if (copyCtx->keyCtx->initialized &&
             ctx->pDlGroup != NULL)
         {
-            copyCtx->pDlGroup = (PSYMCRYPT_DLGROUP) SymCryptDlkeyGetGroup(ctx->keyCtx->dlkey);
+            copyCtx->pDlGroup = (PSYMCRYPT_DLGROUP) SymCryptDlkeyGetGroup(copyCtx->keyCtx->dlkey);
         }
 
         copyCtx->libCtx = ctx->libCtx;

--- a/SymCryptProvider/src/keymgmt/p_scossl_dh_keymgmt.c
+++ b/SymCryptProvider/src/keymgmt/p_scossl_dh_keymgmt.c
@@ -663,8 +663,8 @@ static SCOSSL_STATUS p_scossl_dh_keymgmt_get_key_params(_In_ SCOSSL_DH_KEY_CTX *
     PBYTE pbPrivateKey;
     PBYTE pbPublicKey;
     PBYTE pbData = NULL;
-    SIZE_T cbPrivateKey;
-    SIZE_T cbPublicKey;
+    SIZE_T cbPrivateKey = 0;
+    SIZE_T cbPublicKey = 0;
     SIZE_T cbData = 0;
     BIGNUM *bnPrivKey = NULL;
     BIGNUM *bnPubKey = NULL;

--- a/SymCryptProvider/src/keymgmt/p_scossl_dh_keymgmt.c
+++ b/SymCryptProvider/src/keymgmt/p_scossl_dh_keymgmt.c
@@ -1,0 +1,162 @@
+//
+// Copyright (c) Microsoft Corporation. Licensed under the MIT license.
+//
+
+#include "scossl_helpers.h"
+
+#include <openssl/proverr.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+typedef struct
+{
+
+} SCOSSL_DH_KEYGEN_CTX;
+
+typedef struct
+{
+
+} SCOSSL_DH_KEY_CTX;
+
+static const OSSL_PARAM p_scossl_dh_keygen_settable_param_types[] = {
+    OSSL_PARAM_END};
+
+static const OSSL_PARAM p_scossl_dh_keymgmt_gettable_param_types[] = {
+    OSSL_PARAM_END};
+
+static const OSSL_PARAM p_scossl_dh_keymgmt_impexp_param_types[] = {
+    OSSL_PARAM_END};
+
+static SCOSSL_DH_KEY_CTX *p_scossl_dh_keymgmt_new_ctx(ossl_unused void *provctx)
+{
+    SCOSSL_DH_KEY_CTX *keyCtx = OPENSSL_zalloc(sizeof(SCOSSL_DH_KEY_CTX));
+    if (keyCtx == NULL)
+    {
+        ERR_raise(ERR_LIB_PROV, ERR_R_MALLOC_FAILURE);
+        return NULL;
+    }
+
+    return keyCtx;
+}
+
+static SCOSSL_DH_KEY_CTX *p_scossl_dh_keymgmt_dup_ctx(_In_ const SCOSSL_DH_KEY_CTX *keyCtx)
+{
+    SCOSSL_DH_KEY_CTX *copyCtx = OPENSSL_malloc(sizeof(SCOSSL_DH_KEY_CTX));
+    if (copyCtx == NULL)
+    {
+        return NULL;
+    }
+
+    return copyCtx;
+}
+
+static void p_scossl_dh_keymgmt_free_ctx(_In_ SCOSSL_DH_KEY_CTX *keyCtx)
+{
+    if (keyCtx == NULL)
+        return;
+
+    OPENSSL_free(keyCtx);
+}
+
+//
+// Key Generation
+//
+static SCOSSL_STATUS p_scossl_dh_keygen_set_params(_Inout_ SCOSSL_DH_KEYGEN_CTX *genCtx, const _In_ OSSL_PARAM params[])
+{
+   return SCOSSL_FAILURE;
+}
+
+static const OSSL_PARAM *p_scossl_dh_keygen_settable_params(ossl_unused void *genCtx, ossl_unused void *provctx)
+{
+    return p_scossl_dh_keygen_settable_param_types;
+}
+
+static void p_scossl_dh_keygen_cleanup(_Inout_ SCOSSL_DH_KEYGEN_CTX *genCtx)
+{
+    if (genCtx == NULL)
+        return;
+
+    OPENSSL_free(genCtx);
+}
+
+static SCOSSL_DH_KEYGEN_CTX *p_scossl_dh_keygen_init(_In_ SCOSSL_PROVCTX *provctx, ossl_unused int selection,
+                                                       const _In_ OSSL_PARAM params[])
+{
+    return NULL;
+}
+
+static SCOSSL_DH_KEY_CTX *p_scossl_dh_keygen(_In_ SCOSSL_DH_KEYGEN_CTX *genCtx, ossl_unused OSSL_CALLBACK *cb, ossl_unused void *cbarg)
+{
+    return NULL;
+}
+
+static SCOSSL_STATUS p_scossl_dh_keymgmt_get_params(_In_ SCOSSL_DH_KEY_CTX *keyCtx, _Inout_ OSSL_PARAM params[])
+{
+    return SCOSSL_FAILURE;
+}
+
+static const OSSL_PARAM *p_scossl_dh_keymgmt_gettable_params(ossl_unused void *provctx)
+{
+    return p_scossl_dh_keymgmt_gettable_param_types;
+}
+
+static BOOL p_scossl_dh_keymgmt_has(_In_ SCOSSL_DH_KEY_CTX *keyCtx, int selection)
+{
+    return FALSE;
+}
+
+static BOOL p_scossl_dh_keymgmt_match(_In_ SCOSSL_DH_KEY_CTX *keyCtx1, _In_ SCOSSL_DH_KEY_CTX *keyCtx2,
+                                       int selection)
+{
+    return SCOSSL_FAILURE;
+}
+
+//
+// Key import/export
+//
+static const OSSL_PARAM *p_scossl_dh_keymgmt_impexp_types(int selection)
+{
+    return p_scossl_dh_keymgmt_impexp_param_types;
+}
+
+static SCOSSL_STATUS p_scossl_dh_keymgmt_import(_Inout_ SCOSSL_DH_KEY_CTX *keyCtx, int selection, const _In_ OSSL_PARAM params[])
+{
+    return SCOSSL_FAILURE;
+}
+
+static SCOSSL_STATUS p_scossl_dh_keymgmt_export(_In_ SCOSSL_DH_KEY_CTX *keyCtx, int selection,
+                                                 _In_ OSSL_CALLBACK *param_cb, _In_ void *cbarg)
+{
+    return SCOSSL_FAILURE;
+}
+
+static const char *p_scossl_dh_keymgmt_query_operation_name(int operation_id)
+{
+    return NULL;
+}
+
+const OSSL_DISPATCH p_scossl_dh_keymgmt_functions[] = {
+    {OSSL_FUNC_KEYMGMT_NEW, (void (*)(void))p_scossl_dh_keymgmt_new_ctx},
+    {OSSL_FUNC_KEYMGMT_DUP, (void (*)(void))p_scossl_dh_keymgmt_dup_ctx},
+    {OSSL_FUNC_KEYMGMT_FREE, (void (*)(void))p_scossl_dh_keymgmt_free_ctx},
+    {OSSL_FUNC_KEYMGMT_GEN_SET_PARAMS, (void (*)(void))p_scossl_dh_keygen_set_params},
+    {OSSL_FUNC_KEYMGMT_GEN_SETTABLE_PARAMS, (void (*)(void))p_scossl_dh_keygen_settable_params},
+    {OSSL_FUNC_KEYMGMT_GEN_CLEANUP, (void (*)(void))p_scossl_dh_keygen_cleanup},
+    {OSSL_FUNC_KEYMGMT_GEN_INIT, (void (*)(void))p_scossl_dh_keygen_init},
+    {OSSL_FUNC_KEYMGMT_GEN, (void (*)(void))p_scossl_dh_keygen},
+    {OSSL_FUNC_KEYMGMT_GET_PARAMS, (void (*)(void))p_scossl_dh_keymgmt_get_params},
+    {OSSL_FUNC_KEYMGMT_GETTABLE_PARAMS, (void (*)(void))p_scossl_dh_keymgmt_gettable_params},
+    {OSSL_FUNC_KEYMGMT_HAS, (void (*)(void))p_scossl_dh_keymgmt_has},
+    {OSSL_FUNC_KEYMGMT_MATCH, (void (*)(void))p_scossl_dh_keymgmt_match},
+    {OSSL_FUNC_KEYMGMT_IMPORT_TYPES, (void (*)(void))p_scossl_dh_keymgmt_impexp_types},
+    {OSSL_FUNC_KEYMGMT_EXPORT_TYPES, (void (*)(void))p_scossl_dh_keymgmt_impexp_types},
+    {OSSL_FUNC_KEYMGMT_IMPORT, (void (*)(void))p_scossl_dh_keymgmt_import},
+    {OSSL_FUNC_KEYMGMT_EXPORT, (void (*)(void))p_scossl_dh_keymgmt_export},
+    {OSSL_FUNC_KEYMGMT_QUERY_OPERATION_NAME, (void (*)(void))p_scossl_dh_keymgmt_query_operation_name},
+    {0, NULL}};
+
+#ifdef __cplusplus
+}
+#endif

--- a/SymCryptProvider/src/keymgmt/p_scossl_dh_keymgmt.c
+++ b/SymCryptProvider/src/keymgmt/p_scossl_dh_keymgmt.c
@@ -12,27 +12,27 @@
 extern "C" {
 #endif
 
+#define SCOSSL_DH_KEYHEN_POSSIBLE_SELECTIONS (OSSL_KEYMGMT_SELECT_KEYPAIR | OSSL_KEYMGMT_SELECT_DOMAIN_PARAMETERS)
+
+#define SCOSSL_DH_PBITS_DEFAULT 2048
+
+#define SCOSSL_DH_FFC_TYPE_DEFAULT "default"
+#define SCOSSL_DH_FFC_TYPE_GROUP   "group"
+
+// Constant values for unused parameters that may be requested by caller
+#define SCOSSL_DH_GINDEX -1
+#define SCOSSL_DH_PCOUNTER -1
+#define SCOSSL_DH_H 0
+
 typedef struct
 {
     SCOSSL_PROVCTX *provCtx;
     PCSYMCRYPT_DLGROUP pDlGroup;
     SIZE_T pbits;
     UINT32 nBitsPriv;
-    int selection;
 } SCOSSL_DH_KEYGEN_CTX;
 
-#define P_SCOSSL_DH_PBITS_DEFAULT 2048
-
-#define P_SCOSSL_DH_FFC_TYPE_DEFAULT "default"
-#define P_SCOSSL_DH_FFC_TYPE_GROUP   "group"
-
-// Constant values for parameters not used but may
-// be expected by caller
-#define P_SCOSSL_DH_GINDEX -1
-#define P_SCOSSL_DH_PCOUNTER -1
-#define P_SCOSSL_DH_H 0
-
-#define P_SCOSSL_DH_PARAMETER_TYPES                                    \
+#define SCOSSL_DH_PARAMETER_TYPES                                      \
     OSSL_PARAM_int(OSSL_PKEY_PARAM_DH_PRIV_LEN, NULL),                 \
     OSSL_PARAM_BN(OSSL_PKEY_PARAM_FFC_P, NULL, 0),                     \
     OSSL_PARAM_BN(OSSL_PKEY_PARAM_FFC_Q, NULL, 0),                     \
@@ -42,7 +42,7 @@ typedef struct
     OSSL_PARAM_utf8_string(OSSL_PKEY_PARAM_FFC_DIGEST_PROPS, NULL, 0), \
     OSSL_PARAM_utf8_string(OSSL_PKEY_PARAM_GROUP_NAME, NULL, 0)
 
-#define P_SCOSSL_DH_PKEY_PARAMETER_TYPES             \
+#define SCOSSL_DH_PKEY_PARAMETER_TYPES             \
     OSSL_PARAM_BN(OSSL_PKEY_PARAM_PUB_KEY, NULL, 0), \
     OSSL_PARAM_BN(OSSL_PKEY_PARAM_PRIV_KEY, NULL, 0)
 
@@ -56,16 +56,16 @@ static const OSSL_PARAM p_scossl_dh_keygen_param_types[] = {
 
 // Import/export types
 static const OSSL_PARAM p_scossl_dh_param_types[] = {
-    P_SCOSSL_DH_PARAMETER_TYPES,
+    SCOSSL_DH_PARAMETER_TYPES,
     OSSL_PARAM_END};
 
 static const OSSL_PARAM p_scossl_dh_pkey_types[] = {
-    P_SCOSSL_DH_PKEY_PARAMETER_TYPES,
+    SCOSSL_DH_PKEY_PARAMETER_TYPES,
     OSSL_PARAM_END};
 
 static const OSSL_PARAM p_scossl_dh_all_types[] = {
-    P_SCOSSL_DH_PARAMETER_TYPES,
-    P_SCOSSL_DH_PKEY_PARAMETER_TYPES,
+    SCOSSL_DH_PARAMETER_TYPES,
+    SCOSSL_DH_PKEY_PARAMETER_TYPES,
     OSSL_PARAM_END};
 
 static const OSSL_PARAM *p_scossl_dh_impexp_types[] = {
@@ -84,13 +84,12 @@ static const OSSL_PARAM p_scossl_dh_keymgmt_gettable_param_types[] = {
     OSSL_PARAM_BN(OSSL_PKEY_PARAM_FFC_P, NULL, 0),
     OSSL_PARAM_BN(OSSL_PKEY_PARAM_FFC_Q, NULL, 0),
     OSSL_PARAM_BN(OSSL_PKEY_PARAM_FFC_G, NULL, 0),
-    OSSL_PARAM_BN(OSSL_PKEY_PARAM_FFC_COFACTOR, NULL, 0),
     OSSL_PARAM_int(OSSL_PKEY_PARAM_FFC_GINDEX, NULL),
     OSSL_PARAM_int(OSSL_PKEY_PARAM_FFC_PCOUNTER, NULL),
     OSSL_PARAM_int(OSSL_PKEY_PARAM_FFC_H, NULL),
     OSSL_PARAM_octet_string(OSSL_PKEY_PARAM_FFC_SEED, NULL, 0),
-    P_SCOSSL_DH_PARAMETER_TYPES,
-    P_SCOSSL_DH_PKEY_PARAMETER_TYPES,
+    SCOSSL_DH_PARAMETER_TYPES,
+    SCOSSL_DH_PKEY_PARAMETER_TYPES,
     OSSL_PARAM_END};
 
 static SCOSSL_PROV_DH_KEY_CTX *p_scossl_dh_keymgmt_new_ctx(_In_ SCOSSL_PROVCTX *provCtx)
@@ -125,10 +124,14 @@ static SCOSSL_PROV_DH_KEY_CTX *p_scossl_dh_keymgmt_dup_key_ctx(_In_ const SCOSSL
             return NULL;
         }
 
-        if (copyCtx->keyCtx->initialized)
+        // If we also copied a custom group make sure it gets
+        // set in the caller so it can be properly freed.
+        if (copyCtx->keyCtx->initialized &&
+            ctx->pDlGroup != NULL)
         {
-            copyCtx->pDlGroup = (PSYMCRYPT_DLGROUP) (ctx->keyCtx->dlkey);
+            copyCtx->pDlGroup = (PSYMCRYPT_DLGROUP) SymCryptDlkeyGetGroup(ctx->keyCtx->dlkey);
         }
+
         copyCtx->libCtx = ctx->libCtx;
     }
 
@@ -148,15 +151,204 @@ static void p_scossl_dh_keymgmt_free_key_ctx(_In_ SCOSSL_PROV_DH_KEY_CTX *ctx)
     }
 }
 
+// Returns true if this is a known group. If this returns false, then the caller
+// is responsible for freeing the group. On error *ppDlGroup is set to NULL.
+static SCOSSL_STATUS p_scossl_dh_params_to_group(_In_ OSSL_LIB_CTX *libCtx, _In_ const OSSL_PARAM params[],
+                                                 _Out_ PSYMCRYPT_DLGROUP *ppDlGroup, _Out_ BOOL *pGroupSetByParams)
+{
+    const OSSL_PARAM *p;
+    BIGNUM *bnP = NULL;
+    BIGNUM *bnQ = NULL;
+    BIGNUM *bnG = NULL;
+    PBYTE pbData = NULL;
+    SIZE_T cbData = 0;
+    SCOSSL_STATUS ret = SCOSSL_FAILURE;
+    SYMCRYPT_ERROR scError =  SYMCRYPT_NO_ERROR;
+    PSYMCRYPT_DLGROUP pDlGroupTmp = NULL;
+
+    *pGroupSetByParams = FALSE;
+
+    if ((p = OSSL_PARAM_locate_const(params, OSSL_PKEY_PARAM_GROUP_NAME)) != NULL)
+    {
+        const char *groupName;
+
+        if (!OSSL_PARAM_get_utf8_string_ptr(p, &groupName))
+        {
+            ERR_raise(ERR_LIB_PROV, PROV_R_FAILED_TO_GET_PARAMETER);
+            goto cleanup;
+        }
+
+        pDlGroupTmp = (PSYMCRYPT_DLGROUP)scossl_dh_get_group_by_nid(OBJ_sn2nid(groupName), NULL);
+    }
+    else if ((p = OSSL_PARAM_locate_const(params, OSSL_PKEY_PARAM_FFC_P)) != NULL)
+    {
+        const OSSL_PARAM *paramQ;
+        const OSSL_PARAM *paramG;
+        PBYTE pbPrimeP;
+        PBYTE pbPrimeQ;
+        PBYTE pbGenG;
+        PBYTE pbSeed = NULL;
+        SIZE_T cbPrimeP;
+        SIZE_T cbPrimeQ;
+        SIZE_T cbGenG;
+        SIZE_T cbSeed = 0;
+        int genCounter = 0;
+        PCSYMCRYPT_DLGROUP pKnownDlGroup;
+        PCSYMCRYPT_HASH pHashAlgorithm = NULL;
+
+        // Q or G are required for import
+        paramQ = OSSL_PARAM_locate_const(params, OSSL_PKEY_PARAM_FFC_Q);
+        paramG = OSSL_PARAM_locate_const(params, OSSL_PKEY_PARAM_FFC_G);
+
+        if (paramQ == NULL && paramG == NULL)
+        {
+            ERR_raise(ERR_LIB_PROV, PROV_R_INVALID_DATA);
+            goto cleanup;
+        }
+
+        if (!OSSL_PARAM_get_BN(p, &bnP) ||
+            (paramQ != NULL && !OSSL_PARAM_get_BN(paramQ, &bnQ)) ||
+            (paramG != NULL && !OSSL_PARAM_get_BN(paramG, &bnG)))
+        {
+            ERR_raise(ERR_LIB_PROV, PROV_R_FAILED_TO_GET_PARAMETER);
+            goto cleanup;
+        }
+
+        cbPrimeP = BN_num_bytes(bnP);
+        cbPrimeQ = bnQ == NULL ? 0 : BN_num_bytes(bnQ);
+        cbGenG = bnG == NULL ? 0 : BN_num_bytes(bnG);
+        cbData = cbPrimeP + cbPrimeQ + cbGenG;
+
+        if ((pbData = OPENSSL_malloc(cbData)) == NULL)
+        {
+            ERR_raise(ERR_LIB_PROV, ERR_R_MALLOC_FAILURE);
+            goto cleanup;
+        }
+
+        pbPrimeP = pbData;
+        pbPrimeQ = bnQ == NULL ? NULL : pbData + cbPrimeP;
+        pbGenG = bnG == NULL ? NULL : pbData + cbPrimeP + cbPrimeQ;
+
+        if (!BN_bn2bin(bnP, pbPrimeP) ||
+            (bnQ != NULL && !BN_bn2bin(bnQ, pbPrimeQ)) ||
+            (bnG != NULL && !BN_bn2bin(bnG, pbGenG)))
+        {
+            ERR_raise(ERR_LIB_PROV, PROV_R_FAILED_TO_GET_PARAMETER);
+            goto cleanup;
+        }
+
+        if ((pDlGroupTmp = SymCryptDlgroupAllocate(cbPrimeP * 8, cbPrimeQ * 8)) == NULL)
+        {
+            ERR_raise(ERR_LIB_PROV, ERR_R_MALLOC_FAILURE);
+            goto cleanup;
+        }
+
+        if ((p = OSSL_PARAM_locate_const(params, OSSL_PKEY_PARAM_FFC_SEED)) != NULL)
+        {
+            if (!OSSL_PARAM_get_octet_string_ptr(p, (const void **)&pbSeed, &cbSeed))
+            {
+                ERR_raise(ERR_LIB_PROV, PROV_R_FAILED_TO_GET_PARAMETER);
+                goto cleanup;
+            }
+        }
+
+        if ((p = OSSL_PARAM_locate_const(params, OSSL_PKEY_PARAM_FFC_DIGEST)) != NULL)
+        {
+            EVP_MD *md;
+            const char *mdName;
+            const char *mdProps = NULL;
+
+            if (!OSSL_PARAM_get_utf8_string_ptr(p, &mdName))
+            {
+                ERR_raise(ERR_LIB_PROV, PROV_R_FAILED_TO_GET_PARAMETER);
+                goto cleanup;
+            }
+
+            mdProps = NULL;
+            if ((p = OSSL_PARAM_locate_const(params, OSSL_PKEY_PARAM_FFC_DIGEST_PROPS)) != NULL &&
+                !OSSL_PARAM_get_utf8_string_ptr(p, &mdProps))
+            {
+                ERR_raise(ERR_LIB_PROV, PROV_R_FAILED_TO_GET_PARAMETER);
+                goto cleanup;
+            }
+
+            if ((md = EVP_MD_fetch(libCtx, mdName, mdProps)) != NULL)
+            {
+                pHashAlgorithm  = scossl_get_symcrypt_hash_algorithm(EVP_MD_type(md));
+            }
+
+            EVP_MD_free(md);
+
+            if (pHashAlgorithm == NULL)
+            {
+                ERR_raise(ERR_LIB_PROV, PROV_R_FAILED_TO_GET_PARAMETER);
+                goto cleanup;
+            }
+        }
+
+        if ((p = OSSL_PARAM_locate_const(params, OSSL_PKEY_PARAM_FFC_PCOUNTER)) != NULL &&
+            !OSSL_PARAM_get_int(p, &genCounter))
+        {
+            ERR_raise(ERR_LIB_PROV, PROV_R_FAILED_TO_GET_PARAMETER);
+            goto cleanup;
+        }
+
+        scError = SymCryptDlgroupSetValue(
+            pbPrimeP, cbPrimeP,
+            pbPrimeQ, cbPrimeQ,
+            pbGenG, cbGenG,
+            SYMCRYPT_NUMBER_FORMAT_MSB_FIRST,
+            pHashAlgorithm,
+            pbSeed, cbSeed,
+            genCounter,
+            SYMCRYPT_DLGROUP_FIPS_NONE,
+            pDlGroupTmp);
+        if (scError != SYMCRYPT_NO_ERROR)
+        {
+            ERR_raise(ERR_LIB_PROV, ERR_R_INTERNAL_ERROR);
+            goto cleanup;
+        }
+
+        // Check whether this is actually a known group set by params.
+        if ((pKnownDlGroup = scossl_dh_get_known_group(pDlGroupTmp)) != NULL)
+        {
+            SymCryptDlgroupFree(pDlGroupTmp);
+            pDlGroupTmp = (PSYMCRYPT_DLGROUP)pKnownDlGroup;
+        }
+        else
+        {
+            *pGroupSetByParams = TRUE;
+        }
+    }
+
+    ret = SCOSSL_SUCCESS;
+
+cleanup:
+    OPENSSL_free(pbData);
+    BN_free(bnP);
+    BN_free(bnQ);
+    BN_free(bnG);
+
+    if (!ret && pDlGroupTmp != NULL)
+    {
+        SymCryptDlgroupFree(pDlGroupTmp);
+        pDlGroupTmp = NULL;
+    }
+
+    *ppDlGroup = pDlGroupTmp;
+
+    return ret;
+}
+
 //
 // Key Generation
 //
 static SCOSSL_STATUS p_scossl_dh_keygen_set_params(_Inout_ SCOSSL_DH_KEYGEN_CTX *genCtx, _In_ const OSSL_PARAM params[])
 {
+    PSYMCRYPT_DLGROUP pDlGroup;
+    BOOL groupSetByParams;
     const OSSL_PARAM *p;
 
-    // SymCrypt provider only supports named groups. We don't set anything here,
-    // instead notifying the caller that the operation is unsupported.
     if ((p = OSSL_PARAM_locate_const(params, OSSL_PKEY_PARAM_FFC_TYPE)) != NULL)
     {
         const char *ffcTypeName;
@@ -166,31 +358,33 @@ static SCOSSL_STATUS p_scossl_dh_keygen_set_params(_Inout_ SCOSSL_DH_KEYGEN_CTX 
             return SCOSSL_FAILURE;
         }
 
-        if (OPENSSL_strcasecmp(ffcTypeName, P_SCOSSL_DH_FFC_TYPE_DEFAULT) != 0 &&
-            OPENSSL_strcasecmp(ffcTypeName, P_SCOSSL_DH_FFC_TYPE_GROUP) != 0)
+        if (OPENSSL_strcasecmp(ffcTypeName, SCOSSL_DH_FFC_TYPE_DEFAULT) != 0 &&
+            OPENSSL_strcasecmp(ffcTypeName, SCOSSL_DH_FFC_TYPE_GROUP) != 0)
         {
             ERR_raise(ERR_LIB_PROV, PROV_R_NOT_SUPPORTED);
             return SCOSSL_FAILURE;
         }
     }
 
-    if ((p = OSSL_PARAM_locate_const(params, OSSL_PKEY_PARAM_GROUP_NAME)) != NULL)
+    // We advertize only supporting named groups for keygen, but callers may still try to
+    // import the group by parameters. This should only be done with the DHX key type,
+    // which we defer to the default openssl implementation.
+    if (!p_scossl_dh_params_to_group(genCtx->provCtx->libctx,
+                                     params,
+                                     &pDlGroup,
+                                     &groupSetByParams))
     {
-        const char *groupName;
-        PCSYMCRYPT_DLGROUP pDlGroup;
-        if (!OSSL_PARAM_get_utf8_string_ptr(p, &groupName))
-        {
-            ERR_raise(ERR_LIB_PROV, PROV_R_FAILED_TO_GET_PARAMETER);
-            return SCOSSL_FAILURE;
-        }
-
-        if ((pDlGroup = scossl_dh_get_group_by_nid(OBJ_sn2nid(groupName), NULL)) == NULL)
-        {
-            return SCOSSL_FAILURE;
-        }
-
-        genCtx->pDlGroup = pDlGroup;
+        return SCOSSL_FAILURE;
     }
+
+    if (groupSetByParams)
+    {
+        SymCryptDlgroupFree(pDlGroup);
+        ERR_raise(ERR_LIB_PROV, ERR_R_UNSUPPORTED);
+        return SCOSSL_FAILURE;
+    }
+
+    genCtx->pDlGroup = (PCSYMCRYPT_DLGROUP) pDlGroup;
 
     if ((p = OSSL_PARAM_locate_const(params, OSSL_PKEY_PARAM_FFC_PBITS)) != NULL &&
         !OSSL_PARAM_get_size_t(p, &genCtx->pbits))
@@ -238,13 +432,14 @@ static void p_scossl_dh_keygen_cleanup(_Inout_ SCOSSL_DH_KEYGEN_CTX *genCtx)
 static SCOSSL_DH_KEYGEN_CTX *p_scossl_dh_keygen_init(_In_ SCOSSL_PROVCTX *provCtx, int selection,
                                                      _In_ const OSSL_PARAM params[])
 {
-    SCOSSL_DH_KEYGEN_CTX *genCtx = OPENSSL_malloc(sizeof(SCOSSL_DH_KEYGEN_CTX));
-    if (genCtx != NULL)
+    SCOSSL_DH_KEYGEN_CTX *genCtx = NULL;
+
+    if ((selection & SCOSSL_DH_KEYHEN_POSSIBLE_SELECTIONS) != 0 &&
+        (genCtx = OPENSSL_malloc(sizeof(SCOSSL_DH_KEYGEN_CTX))) != NULL)
     {
         genCtx->pDlGroup = NULL;
         genCtx->nBitsPriv = 0;
-        genCtx->pbits = P_SCOSSL_DH_PBITS_DEFAULT;
-        genCtx->selection = selection;
+        genCtx->pbits = SCOSSL_DH_PBITS_DEFAULT;
         genCtx->provCtx = provCtx;
 
         if (!p_scossl_dh_keygen_set_params(genCtx, params))
@@ -260,14 +455,13 @@ static SCOSSL_DH_KEYGEN_CTX *p_scossl_dh_keygen_init(_In_ SCOSSL_PROVCTX *provCt
 static SCOSSL_PROV_DH_KEY_CTX *p_scossl_dh_keygen(_In_ SCOSSL_DH_KEYGEN_CTX *genCtx, ossl_unused OSSL_CALLBACK *cb, ossl_unused void *cbarg)
 {
     SCOSSL_PROV_DH_KEY_CTX *ctx;
-    BOOL generateKeyPair;
 
-    // Select named group based on pbits if one was not supplied by
-    // the caller
+    // Select named group based on pbits if named group was not explicitly set.
+    // Note that the ffdhe group, not the modp group is used to match the behavior
+    // of the default openssl implementation.
     if (genCtx->pDlGroup == NULL)
     {
         int dlGroupNid = 0;
-        PCSYMCRYPT_DLGROUP pDlGroup = NULL;
         switch(genCtx->pbits)
         {
             case 2048:
@@ -281,13 +475,11 @@ static SCOSSL_PROV_DH_KEY_CTX *p_scossl_dh_keygen(_In_ SCOSSL_DH_KEYGEN_CTX *gen
                 break;
         }
 
-        if ((pDlGroup = scossl_dh_get_group_by_nid(dlGroupNid, NULL)) == NULL)
+        if ((genCtx->pDlGroup = scossl_dh_get_group_by_nid(dlGroupNid, NULL)) == NULL)
         {
             ERR_raise(ERR_LIB_PROV, ERR_R_INIT_FAIL);
             return NULL;
         }
-
-        genCtx->pDlGroup = pDlGroup;
     }
 
     if ((ctx = p_scossl_dh_keymgmt_new_ctx(genCtx->provCtx)) == NULL)
@@ -296,9 +488,7 @@ static SCOSSL_PROV_DH_KEY_CTX *p_scossl_dh_keygen(_In_ SCOSSL_DH_KEYGEN_CTX *gen
         return NULL;
     }
 
-    generateKeyPair = (genCtx->selection & OSSL_KEYMGMT_SELECT_KEYPAIR) != 0;
-
-    if (!scossl_dh_create_key(ctx->keyCtx, genCtx->pDlGroup, genCtx->nBitsPriv, generateKeyPair))
+    if (!scossl_dh_generate_keypair(ctx->keyCtx, genCtx->nBitsPriv, genCtx->pDlGroup))
     {
         OPENSSL_free(ctx);
         return NULL;
@@ -314,39 +504,34 @@ static const OSSL_PARAM *p_scossl_dh_keymgmt_gettable_params(ossl_unused void *p
 
 static SCOSSL_STATUS p_scossl_dh_keymgmt_get_ffc_params(_In_ SCOSSL_DH_KEY_CTX *keyCtx, _Inout_ OSSL_PARAM params[])
 {
+    SCOSSL_STATUS ret = SCOSSL_FAILURE;
+    PBYTE  pbPrimeP;
+    PBYTE  pbPrimeQ;
+    PBYTE  pbGenG;
+    PBYTE  pbSeed;
     PBYTE  pbCur;
     PBYTE  pbData = NULL;
-    SIZE_T cbData = 0;
-    PBYTE  pbPrimeP;
     SIZE_T cbPrimeP;
-    PBYTE  pbPrimeQ;
     SIZE_T cbPrimeQ;
-    PBYTE  pbGenG;
     SIZE_T cbGenG;
-    PBYTE  pbSeed;
     SIZE_T cbSeed;
-    OSSL_PARAM *p;
-    OSSL_PARAM *paramPrimeP;
-    OSSL_PARAM *paramPrimeQ;
-    OSSL_PARAM *paramGenG;
-    OSSL_PARAM *paramSeed;
+    SIZE_T cbData = 0;
     BIGNUM *bnPrimeP = NULL;
     BIGNUM *bnPrimeQ = NULL;
     BIGNUM *bnGenG = NULL;
-
-    SCOSSL_STATUS ret = SCOSSL_FAILURE;
+    PCSYMCRYPT_DLGROUP pDlGroup = SymCryptDlkeyGetGroup(keyCtx->dlkey);
+    OSSL_PARAM *p;
+    OSSL_PARAM *paramPrimeP = OSSL_PARAM_locate(params, OSSL_PKEY_PARAM_FFC_P);
+    OSSL_PARAM *paramPrimeQ = OSSL_PARAM_locate(params, OSSL_PKEY_PARAM_FFC_Q);
+    OSSL_PARAM *paramGenG = OSSL_PARAM_locate(params, OSSL_PKEY_PARAM_FFC_G);
+    OSSL_PARAM *paramSeed = OSSL_PARAM_locate(params, OSSL_PKEY_PARAM_FFC_SEED);
 
     SymCryptDlgroupGetSizes(
-        keyCtx->dlkey->pDlgroup,
+        pDlGroup,
         &cbPrimeP,
         &cbPrimeQ,
         &cbGenG,
         &cbSeed);
-
-    paramPrimeP = OSSL_PARAM_locate(params, OSSL_PKEY_PARAM_FFC_P);
-    paramPrimeQ = OSSL_PARAM_locate(params, OSSL_PKEY_PARAM_FFC_Q);
-    paramGenG = OSSL_PARAM_locate(params, OSSL_PKEY_PARAM_FFC_G);
-    paramSeed = OSSL_PARAM_locate(params, OSSL_PKEY_PARAM_FFC_SEED);
 
     cbPrimeP = paramPrimeP == NULL ? 0 : cbPrimeP;
     cbPrimeQ = paramPrimeQ == NULL ? 0 : cbPrimeQ;
@@ -362,30 +547,28 @@ static SCOSSL_STATUS p_scossl_dh_keymgmt_get_ffc_params(_In_ SCOSSL_DH_KEY_CTX *
     if (cbData != 0)
     {
         if ((pbData = OPENSSL_malloc(cbData)) == NULL ||
-            ((bnPrimeP = BN_new()) == NULL) ||
-            ((bnPrimeQ = BN_new()) == NULL) ||
-            ((bnGenG = BN_new()) == NULL))
+            (cbPrimeP != 0 && (bnPrimeP = BN_new()) == NULL) ||
+            (cbPrimeQ != 0 && (bnPrimeQ = BN_new()) == NULL) ||
+            (cbGenG != 0 && (bnGenG = BN_new()) == NULL))
         {
             ERR_raise(ERR_LIB_PROV, ERR_R_MALLOC_FAILURE);
             goto cleanup;
         }
 
         pbCur = pbData;
-
         pbPrimeP = cbPrimeP == 0 ? NULL : pbCur;
+
         pbCur += cbPrimeP;
-
         pbPrimeQ = cbPrimeQ == 0 ? NULL : pbCur;
+
         pbCur += cbPrimeQ;
-
         pbGenG = cbGenG == 0 ? NULL : pbCur;
-        pbCur += cbGenG;
 
+        pbCur += cbGenG;
         pbSeed = cbSeed == 0 ? NULL : pbCur;
-        pbCur += cbSeed;
 
         if (SymCryptDlgroupGetValue(
-                keyCtx->dlkey->pDlgroup,
+                pDlGroup,
                 pbPrimeP, cbPrimeP,
                 pbPrimeQ, cbPrimeQ,
                 pbGenG, cbGenG,
@@ -399,7 +582,7 @@ static SCOSSL_STATUS p_scossl_dh_keymgmt_get_ffc_params(_In_ SCOSSL_DH_KEY_CTX *
         }
 
         if (pbPrimeP != NULL &&
-            (BN_bin2bn(pbPrimeP, cbPrimeP, bnPrimeP) == NULL ||
+                (BN_bin2bn(pbPrimeP, cbPrimeP, bnPrimeP) == NULL ||
                 !OSSL_PARAM_set_BN(paramPrimeP, bnPrimeP)))
         {
             ERR_raise(ERR_LIB_PROV, PROV_R_FAILED_TO_SET_PARAMETER);
@@ -407,7 +590,7 @@ static SCOSSL_STATUS p_scossl_dh_keymgmt_get_ffc_params(_In_ SCOSSL_DH_KEY_CTX *
         }
 
         if (pbPrimeQ != NULL &&
-            (BN_bin2bn(pbPrimeQ, cbPrimeQ, bnPrimeQ) == NULL ||
+                (BN_bin2bn(pbPrimeQ, cbPrimeQ, bnPrimeQ) == NULL ||
                 !OSSL_PARAM_set_BN(paramPrimeQ, bnPrimeQ)))
         {
             ERR_raise(ERR_LIB_PROV, PROV_R_FAILED_TO_SET_PARAMETER);
@@ -415,7 +598,7 @@ static SCOSSL_STATUS p_scossl_dh_keymgmt_get_ffc_params(_In_ SCOSSL_DH_KEY_CTX *
         }
 
         if (pbGenG != NULL &&
-            (BN_bin2bn(pbGenG, cbGenG, bnGenG) == NULL ||
+                (BN_bin2bn(pbGenG, cbGenG, bnGenG) == NULL ||
                 !OSSL_PARAM_set_BN(paramGenG, bnGenG)))
         {
             ERR_raise(ERR_LIB_PROV, PROV_R_FAILED_TO_SET_PARAMETER);
@@ -431,21 +614,21 @@ static SCOSSL_STATUS p_scossl_dh_keymgmt_get_ffc_params(_In_ SCOSSL_DH_KEY_CTX *
     }
 
     if ((p = OSSL_PARAM_locate(params, OSSL_PKEY_PARAM_FFC_GINDEX)) != NULL &&
-        !OSSL_PARAM_set_int(p, P_SCOSSL_DH_GINDEX))
+        !OSSL_PARAM_set_int(p, SCOSSL_DH_GINDEX))
     {
         ERR_raise(ERR_LIB_PROV, PROV_R_FAILED_TO_SET_PARAMETER);
         goto cleanup;
     }
 
     if ((p = OSSL_PARAM_locate(params, OSSL_PKEY_PARAM_FFC_PCOUNTER)) != NULL &&
-        !OSSL_PARAM_set_int(p, P_SCOSSL_DH_PCOUNTER))
+        !OSSL_PARAM_set_int(p, SCOSSL_DH_PCOUNTER))
     {
         ERR_raise(ERR_LIB_PROV, PROV_R_FAILED_TO_SET_PARAMETER);
         goto cleanup;
     }
 
     if ((p = OSSL_PARAM_locate(params, OSSL_PKEY_PARAM_FFC_H)) != NULL &&
-        !OSSL_PARAM_set_int(p, P_SCOSSL_DH_H))
+        !OSSL_PARAM_set_int(p, SCOSSL_DH_H))
     {
         ERR_raise(ERR_LIB_PROV, PROV_R_FAILED_TO_SET_PARAMETER);
         goto cleanup;
@@ -468,22 +651,18 @@ cleanup:
 
 static SCOSSL_STATUS p_scossl_dh_keymgmt_get_key_params(_In_ SCOSSL_DH_KEY_CTX *keyCtx, _Inout_ OSSL_PARAM params[])
 {
-    PBYTE  pbData;
-    SIZE_T cbData;
-    PBYTE  pbPrivateKey = NULL;
-    SIZE_T cbPrivateKey = 0;
-    PBYTE  pbPublicKey = NULL;
-    SIZE_T cbPublicKey = 0;
+    PBYTE pbPrivateKey;
+    PBYTE pbPublicKey;
+    PBYTE pbData = NULL;
+    SIZE_T cbPrivateKey;
+    SIZE_T cbPublicKey;
+    SIZE_T cbData = 0;
     BIGNUM *bnPrivKey = NULL;
     BIGNUM *bnPubKey = NULL;
-    OSSL_PARAM *paramEncodedKey;
-    OSSL_PARAM *paramPrivKey;
-    OSSL_PARAM *paramPubKey;
     SCOSSL_STATUS ret = SCOSSL_FAILURE;
-
-    paramEncodedKey = OSSL_PARAM_locate(params, OSSL_PKEY_PARAM_ENCODED_PUBLIC_KEY);
-    paramPrivKey = OSSL_PARAM_locate(params, OSSL_PKEY_PARAM_PRIV_KEY);
-    paramPubKey = OSSL_PARAM_locate(params, OSSL_PKEY_PARAM_PUB_KEY);
+    OSSL_PARAM *paramEncodedKey = OSSL_PARAM_locate(params, OSSL_PKEY_PARAM_ENCODED_PUBLIC_KEY);
+    OSSL_PARAM *paramPrivKey = OSSL_PARAM_locate(params, OSSL_PKEY_PARAM_PRIV_KEY);
+    OSSL_PARAM *paramPubKey = OSSL_PARAM_locate(params, OSSL_PKEY_PARAM_PUB_KEY);
 
     if (paramPrivKey != NULL)
     {
@@ -573,7 +752,6 @@ cleanup:
 
 static SCOSSL_STATUS p_scossl_dh_keymgmt_get_params(_In_ SCOSSL_PROV_DH_KEY_CTX *ctx, _Inout_ OSSL_PARAM params[])
 {
-
     OSSL_PARAM *p;
 
     if ((p = OSSL_PARAM_locate(params, OSSL_PKEY_PARAM_BITS)) != NULL &&
@@ -611,7 +789,7 @@ static SCOSSL_STATUS p_scossl_dh_keymgmt_get_params(_In_ SCOSSL_PROV_DH_KEY_CTX 
 
     if ((p = OSSL_PARAM_locate(params, OSSL_PKEY_PARAM_GROUP_NAME)) != NULL)
     {
-        int dlGroupNid = scossl_dh_get_group_nid(ctx->keyCtx->dlkey->pDlgroup);
+        int dlGroupNid = scossl_dh_get_group_nid(SymCryptDlkeyGetGroup(ctx->keyCtx->dlkey));
         if (dlGroupNid == 0)
         {
             ERR_raise(ERR_LIB_PROV, ERR_R_INTERNAL_ERROR);
@@ -640,7 +818,7 @@ static BOOL p_scossl_dh_keymgmt_has(_In_ SCOSSL_PROV_DH_KEY_CTX *ctx, int select
     }
     if ((selection & OSSL_KEYMGMT_SELECT_DOMAIN_PARAMETERS) != 0)
     {
-        ret = ret && (ctx->keyCtx->dlkey->pDlgroup != NULL);
+        ret = ret && SymCryptDlkeyGetGroup(ctx->keyCtx->dlkey) != NULL;
     }
     if ((selection & OSSL_KEYMGMT_SELECT_PUBLIC_KEY) != 0)
     {
@@ -726,13 +904,12 @@ static BOOL p_scossl_dh_keymgmt_match(_In_ SCOSSL_PROV_DH_KEY_CTX *ctx1, _In_ SC
 
     if ((selection & OSSL_KEYMGMT_SELECT_DOMAIN_PARAMETERS) != 0)
     {
-        BOOL isGroup1Set = ctx1->keyCtx->dlkey != NULL && ctx1->keyCtx->dlkey->pDlgroup != NULL;
-        BOOL isGroup2Set = ctx2->keyCtx->dlkey != NULL && ctx2->keyCtx->dlkey->pDlgroup != NULL;
+        PCSYMCRYPT_DLGROUP pDlGroup1 = ctx1->keyCtx->dlkey != NULL ? SymCryptDlkeyGetGroup(ctx1->keyCtx->dlkey) : NULL;
+        PCSYMCRYPT_DLGROUP pDlGroup2 = ctx2->keyCtx->dlkey != NULL ? SymCryptDlkeyGetGroup(ctx2->keyCtx->dlkey) : NULL;
 
         // Both groups must be either NULL or equal
-        if (isGroup1Set != isGroup2Set ||
-            (isGroup1Set && isGroup2Set &&
-             !SymCryptDlgroupIsSame(ctx1->keyCtx->dlkey->pDlgroup, ctx2->keyCtx->dlkey->pDlgroup)))
+        if (pDlGroup1 != pDlGroup2 ||
+            !SymCryptDlgroupIsSame(pDlGroup1, pDlGroup2))
         {
             goto cleanup;
         }
@@ -770,25 +947,11 @@ static const OSSL_PARAM *p_scossl_dh_keymgmt_impexp_types(int selection)
 static SCOSSL_STATUS p_scossl_dh_keymgmt_import(_Inout_ SCOSSL_PROV_DH_KEY_CTX *ctx, int selection, _In_ const OSSL_PARAM params[])
 {
     const OSSL_PARAM *p;
-    const OSSL_PARAM *paramP;
-    const OSSL_PARAM *paramQ;
-    const OSSL_PARAM *paramG;
-    BIGNUM *bnP = NULL;
-    BIGNUM *bnQ = NULL;
-    BIGNUM *bnG = NULL;
-    PBYTE pbPrimeP = NULL;
-    PBYTE pbPrimeQ = NULL;
-    PBYTE pbGenG = NULL;
-    SIZE_T cbPrimeP = 0;
-    SIZE_T cbPrimeQ = 0;
-    SIZE_T cbGenG = 0;
-    const char *groupName;
     BOOL groupSetByParams = FALSE;
     PSYMCRYPT_DLGROUP pDlGroup = NULL;
     BIGNUM *bnPrivateKey = NULL;
     BIGNUM *bnPublicKey = NULL;
     int nBitsPriv = 0;
-    SYMCRYPT_ERROR scError =  SYMCRYPT_NO_ERROR;
     SCOSSL_STATUS ret = SCOSSL_FAILURE;
 
     // Group required for import
@@ -797,147 +960,19 @@ static SCOSSL_STATUS p_scossl_dh_keymgmt_import(_Inout_ SCOSSL_PROV_DH_KEY_CTX *
         return SCOSSL_FAILURE;
     }
 
-    if ((p = OSSL_PARAM_locate_const(params, OSSL_PKEY_PARAM_GROUP_NAME)) != NULL)
+    if (ctx->pDlGroup != NULL)
     {
-        if (!OSSL_PARAM_get_utf8_string_ptr(p, &groupName))
-        {
-            ERR_raise(ERR_LIB_PROV, PROV_R_FAILED_TO_GET_PARAMETER);
-            goto cleanup;
-        }
-
-        if ((pDlGroup = (PSYMCRYPT_DLGROUP)scossl_dh_get_group_by_nid(OBJ_sn2nid(groupName), NULL)) == NULL)
-        {
-            goto cleanup;
-        }
+        SymCryptDlgroupFree(ctx->pDlGroup);
+        ctx->pDlGroup = NULL;
     }
-    else
+
+    if (!p_scossl_dh_params_to_group(ctx->libCtx,
+                                     params,
+                                     &pDlGroup,
+                                     &groupSetByParams) ||
+        pDlGroup == NULL)
     {
-        PCSYMCRYPT_DLGROUP pKnownDlGroup = NULL;
-        PCSYMCRYPT_HASH pHashAlgorithm = NULL;
-        PBYTE pbSeed = NULL;
-        SIZE_T cbSeed = 0;
-        int genCounter = 0;
-
-        groupSetByParams = TRUE;
-        // P and either Q or G are required for import
-        paramP = OSSL_PARAM_locate_const(params, OSSL_PKEY_PARAM_FFC_P);
-        paramQ = OSSL_PARAM_locate_const(params, OSSL_PKEY_PARAM_FFC_Q);
-        paramG = OSSL_PARAM_locate_const(params, OSSL_PKEY_PARAM_FFC_G);
-
-        if (paramP == NULL || (paramQ == NULL && paramG == NULL))
-        {
-            ERR_raise(ERR_LIB_PROV, PROV_R_INVALID_DATA);
-            goto cleanup;
-        }
-
-        if (!OSSL_PARAM_get_BN(paramP, &bnP) ||
-            (paramQ != NULL && !OSSL_PARAM_get_BN(paramQ, &bnQ)) ||
-            (paramG != NULL && !OSSL_PARAM_get_BN(paramG, &bnG)))
-        {
-            ERR_raise(ERR_LIB_PROV, PROV_R_FAILED_TO_GET_PARAMETER);
-            goto cleanup;
-        }
-
-        cbPrimeP = BN_num_bytes(bnP);
-        cbPrimeQ = bnQ != NULL ? BN_num_bytes(bnQ) : 0;
-        cbGenG = bnG != NULL ? BN_num_bytes(bnG) : 0;
-
-        if ((pbPrimeP = OPENSSL_malloc(cbPrimeP)) == NULL ||
-            (bnQ != NULL && (pbPrimeQ = OPENSSL_malloc(cbPrimeQ)) == NULL) ||
-            (bnG != NULL && (pbGenG = OPENSSL_malloc(cbGenG)) == NULL))
-        {
-            ERR_raise(ERR_LIB_PROV, ERR_R_MALLOC_FAILURE);
-            goto cleanup;
-        }
-
-        if (!BN_bn2bin(bnP, pbPrimeP) ||
-            (bnQ != NULL && !BN_bn2bin(bnQ, pbPrimeQ)) ||
-            (bnG != NULL && !BN_bn2bin(bnG, pbGenG)))
-        {
-            ERR_raise(ERR_LIB_PROV, PROV_R_FAILED_TO_GET_PARAMETER);
-            goto cleanup;
-        }
-
-        if ((pDlGroup = SymCryptDlgroupAllocate(BN_num_bits(bnP), bnQ == NULL ? 0 : BN_num_bits(bnQ))) == NULL)
-        {
-            ERR_raise(ERR_LIB_PROV, ERR_R_MALLOC_FAILURE);
-            goto cleanup;
-        }
-
-        if ((p = OSSL_PARAM_locate_const(params, OSSL_PKEY_PARAM_FFC_SEED)) != NULL)
-        {
-            if (!OSSL_PARAM_get_octet_string_ptr(p, (const void **)&pbSeed, &cbSeed))
-            {
-                ERR_raise(ERR_LIB_PROV, PROV_R_FAILED_TO_GET_PARAMETER);
-                goto cleanup;
-            }
-        }
-
-        if ((p = OSSL_PARAM_locate_const(params, OSSL_PKEY_PARAM_FFC_DIGEST)) != NULL)
-        {
-            EVP_MD *md;
-            const char *mdName;
-            const char *mdProps = NULL;
-
-            if (!OSSL_PARAM_get_utf8_string_ptr(p, &mdName))
-            {
-                ERR_raise(ERR_LIB_PROV, PROV_R_FAILED_TO_GET_PARAMETER);
-                goto cleanup;
-            }
-
-            mdProps = NULL;
-            if ((p = OSSL_PARAM_locate_const(params, OSSL_PKEY_PARAM_FFC_DIGEST_PROPS)) != NULL &&
-                !OSSL_PARAM_get_utf8_string_ptr(p, &mdProps))
-            {
-                ERR_raise(ERR_LIB_PROV, PROV_R_FAILED_TO_GET_PARAMETER);
-                goto cleanup;
-            }
-
-            md = EVP_MD_fetch(ctx->libCtx, mdName, mdProps);
-            if (md != NULL)
-            {
-                pHashAlgorithm  = scossl_get_symcrypt_hash_algorithm(EVP_MD_type(md));
-            }
-
-            EVP_MD_free(md);
-
-            if (pHashAlgorithm == NULL)
-            {
-                ERR_raise(ERR_LIB_PROV, PROV_R_FAILED_TO_GET_PARAMETER);
-                goto cleanup;
-            }
-        }
-
-        if ((p = OSSL_PARAM_locate_const(params, OSSL_PKEY_PARAM_FFC_PCOUNTER)) != NULL &&
-            !OSSL_PARAM_get_int(p, &genCounter))
-        {
-            ERR_raise(ERR_LIB_PROV, PROV_R_FAILED_TO_GET_PARAMETER);
-            goto cleanup;
-        }
-
-        scError = SymCryptDlgroupSetValue(
-            pbPrimeP, cbPrimeP,
-            pbPrimeQ, cbPrimeQ,
-            pbGenG, cbGenG,
-            SYMCRYPT_NUMBER_FORMAT_MSB_FIRST,
-            pHashAlgorithm,
-            pbSeed, cbSeed,
-            genCounter,
-            SYMCRYPT_DLGROUP_FIPS_NONE,
-            pDlGroup);
-        if (scError != SYMCRYPT_NO_ERROR)
-        {
-            ERR_raise(ERR_LIB_PROV, ERR_R_INTERNAL_ERROR);
-            goto cleanup;
-        }
-
-        // Check whether this is actually a known group set by params.
-        if ((pKnownDlGroup = scossl_dh_get_known_group(pDlGroup)) != NULL)
-        {
-            SymCryptDlgroupFree(pDlGroup);
-            pDlGroup = (PSYMCRYPT_DLGROUP)pKnownDlGroup;
-            groupSetByParams = FALSE;
-        }
+        return SCOSSL_FAILURE;
     }
 
     if ((p = OSSL_PARAM_locate_const(params, OSSL_PKEY_PARAM_DH_PRIV_LEN)) != NULL)
@@ -994,8 +1029,7 @@ static SCOSSL_STATUS p_scossl_dh_keymgmt_import(_Inout_ SCOSSL_PROV_DH_KEY_CTX *
             }
         }
 
-        if ((bnPrivateKey == NULL && bnPublicKey == NULL)||
-            !scossl_dh_import_keypair(ctx->keyCtx, nBitsPriv, pDlGroup, groupSetByParams, bnPrivateKey, bnPublicKey))
+        if (!scossl_dh_import_keypair(ctx->keyCtx, nBitsPriv, pDlGroup, groupSetByParams, bnPrivateKey, bnPublicKey))
         {
             goto cleanup;
         }
@@ -1007,14 +1041,8 @@ static SCOSSL_STATUS p_scossl_dh_keymgmt_import(_Inout_ SCOSSL_PROV_DH_KEY_CTX *
     }
 
     ret = SCOSSL_SUCCESS;
-cleanup:
-    OPENSSL_free(pbPrimeP);
-    OPENSSL_free(pbPrimeQ);
-    OPENSSL_free(pbGenG);
-    BN_free(bnP);
-    BN_free(bnQ);
-    BN_free(bnG);
 
+cleanup:
     if (!ret)
     {
         if (ctx->keyCtx->dlkey != NULL)
@@ -1024,8 +1052,7 @@ cleanup:
             ctx->keyCtx->initialized = FALSE;
         }
 
-        if (groupSetByParams &&
-            pDlGroup != NULL)
+        if (groupSetByParams && pDlGroup != NULL)
         {
             SymCryptDlgroupFree(pDlGroup);
             ctx->pDlGroup = NULL;
@@ -1045,31 +1072,31 @@ static SCOSSL_STATUS p_scossl_dh_keymgmt_export(_In_ SCOSSL_PROV_DH_KEY_CTX *ctx
     OSSL_PARAM *params = NULL;
     BOOL includePublic = (selection & OSSL_KEYMGMT_SELECT_PUBLIC_KEY) != 0;
     BOOL includePrivate = (selection & OSSL_KEYMGMT_SELECT_PRIVATE_KEY) != 0;
-    int dlGroupNid;
-    const char *dlGroup;
-    PBYTE  pbData = NULL;
-    SIZE_T cbData = 0;
-
-    PBYTE  pbPrivateKey;
-    PBYTE  pbPublicKey;
-    SIZE_T cbPrivateKey;
-    SIZE_T cbPublicKey;
-    BIGNUM *bnPrivKey = NULL;
-    BIGNUM *bnPubKey = NULL;
-
-    BIGNUM *bnP = NULL;
-    BIGNUM *bnQ = NULL;
-    BIGNUM *bnG = NULL;
     PBYTE pbPrimeP = NULL;
     PBYTE pbPrimeQ = NULL;
     PBYTE pbGenG = NULL;
     PBYTE pbSeed = NULL;
-    SIZE_T cbPrimeP = 0;
-    SIZE_T cbPrimeQ = 0;
-    SIZE_T cbGenG = 0;
-    SIZE_T cbSeed = 0;
+    PBYTE  pbPrivateKey;
+    PBYTE  pbPublicKey;
+    PBYTE  pbCur;
+    PBYTE  pbData = NULL;
+    SIZE_T cbPrimeP;
+    SIZE_T cbPrimeQ;
+    SIZE_T cbGenG;
+    SIZE_T cbSeed;
+    SIZE_T cbPrivateKey;
+    SIZE_T cbPublicKey;
+    SIZE_T cbData = 0;
+    BIGNUM *bnPrimeP = NULL;
+    BIGNUM *bnPrimeQ = NULL;
+    BIGNUM *bnGenG = NULL;
+    BIGNUM *bnPrivKey = NULL;
+    BIGNUM *bnPubKey = NULL;
+    int mdNid;
+    int dlGroupNid;
+    const char *dlGroupName;
+    PCSYMCRYPT_DLGROUP pDlGroup;
     PCSYMCRYPT_HASH pHashAlgorithm;
-    int mdnid;
     UINT32 genCounter;
 
     SYMCRYPT_ERROR scError =  SYMCRYPT_NO_ERROR;
@@ -1077,12 +1104,13 @@ static SCOSSL_STATUS p_scossl_dh_keymgmt_export(_In_ SCOSSL_PROV_DH_KEY_CTX *ctx
 
     if (ctx->keyCtx == NULL ||
         ctx->keyCtx->dlkey == NULL ||
-        ctx->keyCtx->dlkey->pDlgroup == NULL ||
         (selection & OSSL_KEYMGMT_SELECT_DOMAIN_PARAMETERS) == 0 ||
         ((selection & OSSL_KEYMGMT_SELECT_KEYPAIR) != 0 && !ctx->keyCtx->initialized))
     {
         return SCOSSL_FAILURE;
     }
+
+    pDlGroup = SymCryptDlkeyGetGroup(ctx->keyCtx->dlkey);
 
     if ((bld = OSSL_PARAM_BLD_new()) == NULL)
     {
@@ -1091,24 +1119,47 @@ static SCOSSL_STATUS p_scossl_dh_keymgmt_export(_In_ SCOSSL_PROV_DH_KEY_CTX *ctx
     }
 
     SymCryptDlgroupGetSizes(
-        ctx->keyCtx->dlkey->pDlgroup,
+        pDlGroup,
         &cbPrimeP,
         &cbPrimeQ,
         &cbGenG,
         &cbSeed);
 
-    if ((pbPrimeP = OPENSSL_malloc(cbPrimeP)) == NULL ||
-        (cbPrimeQ != 0 && (pbPrimeQ = OPENSSL_malloc(cbPrimeQ)) == NULL) ||
-        (cbGenG != 0 && (pbGenG = OPENSSL_malloc(cbGenG)) == NULL) ||
-        (cbSeed != 0 && (pbSeed = OPENSSL_malloc(cbSeed)) == NULL))
+    if (cbPrimeP == 0)
+    {
+        ERR_raise(ERR_LIB_PROV, ERR_R_INTERNAL_ERROR);
+        goto cleanup;
+    }
+
+    cbData =
+        cbPrimeP +
+        cbPrimeQ +
+        cbGenG +
+        cbSeed;
+
+    if ((pbData = OPENSSL_malloc(cbData)) == NULL ||
+        (cbPrimeP != 0 && (bnPrimeP = BN_new()) == NULL) ||
+        (cbPrimeQ != 0 && (bnPrimeQ = BN_new()) == NULL) ||
+        (cbGenG != 0 && (bnGenG = BN_new()) == NULL))
     {
         ERR_raise(ERR_LIB_PROV, ERR_R_MALLOC_FAILURE);
         goto cleanup;
     }
 
+    pbPrimeP = pbData;
+
+    pbCur = pbData + cbPrimeP;
+    pbPrimeQ = cbPrimeQ == 0 ? NULL : pbCur;
+
+    pbCur += cbPrimeQ;
+    pbGenG = cbGenG == 0 ? NULL : pbCur;
+
+    pbCur += cbGenG;
+    pbSeed = cbSeed == 0 ? NULL : pbCur;
+
     // Always export group parameters
     scError = SymCryptDlgroupGetValue(
-        ctx->keyCtx->dlkey->pDlgroup,
+        pDlGroup,
         pbPrimeP, cbPrimeP,
         pbPrimeQ, cbPrimeQ,
         pbGenG, cbGenG,
@@ -1122,49 +1173,28 @@ static SCOSSL_STATUS p_scossl_dh_keymgmt_export(_In_ SCOSSL_PROV_DH_KEY_CTX *ctx
         goto cleanup;
     }
 
-    if ((bnP = BN_new()) == NULL)
-    {
-        ERR_raise(ERR_LIB_PROV, ERR_R_MALLOC_FAILURE);
-        goto cleanup;
-    }
-
-    if (BN_lebin2bn(pbPrimeP, cbPrimeP, bnP) == NULL ||
-        !OSSL_PARAM_BLD_push_BN(bld, OSSL_PKEY_PARAM_FFC_P, bnP))
+    if (pbPrimeP != NULL &&
+            (BN_bin2bn(pbPrimeP, cbPrimeP, bnPrimeP) == NULL ||
+            !OSSL_PARAM_BLD_push_BN(bld, OSSL_PKEY_PARAM_FFC_P, bnPrimeP)))
     {
         ERR_raise(ERR_LIB_PROV, PROV_R_FAILED_TO_SET_PARAMETER);
         goto cleanup;
     }
 
-    if (pbPrimeQ != NULL)
+    if (pbPrimeQ != NULL &&
+            (BN_bin2bn(pbPrimeQ, cbPrimeQ, bnPrimeQ) == NULL ||
+            !OSSL_PARAM_BLD_push_BN(bld, OSSL_PKEY_PARAM_FFC_Q, bnPrimeQ)))
     {
-        if ((bnQ = BN_new()) == NULL)
-        {
-            ERR_raise(ERR_LIB_PROV, ERR_R_MALLOC_FAILURE);
-            goto cleanup;
-        }
-
-        if (BN_lebin2bn(pbPrimeQ, cbPrimeQ, bnQ) == NULL ||
-            !OSSL_PARAM_BLD_push_BN(bld, OSSL_PKEY_PARAM_FFC_Q, bnQ))
-        {
-            ERR_raise(ERR_LIB_PROV, PROV_R_FAILED_TO_SET_PARAMETER);
-            goto cleanup;
-        }
+        ERR_raise(ERR_LIB_PROV, PROV_R_FAILED_TO_SET_PARAMETER);
+        goto cleanup;
     }
 
-    if (pbGenG != NULL)
+    if (pbGenG != NULL &&
+            (BN_bin2bn(pbGenG, cbGenG, bnGenG) == NULL ||
+            !OSSL_PARAM_BLD_push_BN(bld, OSSL_PKEY_PARAM_FFC_G, bnGenG)))
     {
-        if ((bnG = BN_new()) == NULL)
-        {
-            ERR_raise(ERR_LIB_PROV, ERR_R_MALLOC_FAILURE);
-            goto cleanup;
-        }
-
-        if (BN_lebin2bn(pbGenG, cbGenG, bnG) == NULL ||
-            !OSSL_PARAM_BLD_push_BN(bld, OSSL_PKEY_PARAM_FFC_G, bnG))
-        {
-            ERR_raise(ERR_LIB_PROV, PROV_R_FAILED_TO_SET_PARAMETER);
-            goto cleanup;
-        }
+        ERR_raise(ERR_LIB_PROV, PROV_R_FAILED_TO_SET_PARAMETER);
+        goto cleanup;
     }
 
     if (pbSeed != NULL &&
@@ -1174,9 +1204,9 @@ static SCOSSL_STATUS p_scossl_dh_keymgmt_export(_In_ SCOSSL_PROV_DH_KEY_CTX *ctx
         goto cleanup;
     }
 
-    if ((mdnid = scossl_get_mdnid_from_symcrypt_hash_algorithm(pHashAlgorithm)) != NID_undef)
+    if ((mdNid = scossl_get_mdnid_from_symcrypt_hash_algorithm(pHashAlgorithm)) != NID_undef)
     {
-        const char *mdName = OBJ_nid2sn(mdnid);
+        const char *mdName = OBJ_nid2sn(mdNid);
 
         if (!OSSL_PARAM_BLD_push_utf8_string(bld, OSSL_PKEY_PARAM_FFC_DIGEST, mdName, strlen(mdName)))
         {
@@ -1186,10 +1216,10 @@ static SCOSSL_STATUS p_scossl_dh_keymgmt_export(_In_ SCOSSL_PROV_DH_KEY_CTX *ctx
     }
 
     // Group name may not be available if the group was imported by params
-    if ((dlGroupNid = scossl_dh_get_group_nid(ctx->keyCtx->dlkey->pDlgroup)) != 0)
+    if ((dlGroupNid = scossl_dh_get_group_nid(pDlGroup)) != 0)
     {
-        if ((dlGroup = OBJ_nid2sn(dlGroupNid)) == NULL ||
-            !OSSL_PARAM_BLD_push_utf8_string(bld, OSSL_PKEY_PARAM_GROUP_NAME, dlGroup, strlen(dlGroup)))
+        if ((dlGroupName = OBJ_nid2sn(dlGroupNid)) == NULL ||
+            !OSSL_PARAM_BLD_push_utf8_string(bld, OSSL_PKEY_PARAM_GROUP_NAME, dlGroupName, strlen(dlGroupName)))
         {
             ERR_raise(ERR_LIB_PROV, PROV_R_FAILED_TO_SET_PARAMETER);
             goto cleanup;
@@ -1201,6 +1231,7 @@ static SCOSSL_STATUS p_scossl_dh_keymgmt_export(_In_ SCOSSL_PROV_DH_KEY_CTX *ctx
         cbPrivateKey = includePrivate ? SymCryptDlkeySizeofPrivateKey(ctx->keyCtx->dlkey) : 0;
         cbPublicKey = includePublic ? SymCryptDlkeySizeofPublicKey(ctx->keyCtx->dlkey) : 0;
 
+        OPENSSL_free(pbData);
         cbData = cbPrivateKey + cbPublicKey;
         if ((pbData = OPENSSL_zalloc(cbData)) == NULL)
         {
@@ -1269,25 +1300,13 @@ cleanup:
     {
         OPENSSL_clear_free(pbData, cbData);
     }
-
-    OPENSSL_free(pbPrimeP);
-    OPENSSL_free(pbPrimeQ);
-    OPENSSL_free(pbGenG);
-    OPENSSL_free(pbSeed);
-
-    BN_free(bnP);
-    BN_free(bnQ);
-    BN_free(bnG);
-
-    BN_clear_free(bnPrivKey);
+    BN_free(bnPrimeP);
+    BN_free(bnPrimeQ);
+    BN_free(bnGenG);
     BN_free(bnPubKey);
+    BN_clear_free(bnPrivKey);
     OSSL_PARAM_BLD_free(bld);
     return ret;
-}
-
-static const char *p_scossl_dh_keymgmt_query_operation_name(ossl_unused int operation_id)
-{
-    return "DH";
 }
 
 const OSSL_DISPATCH p_scossl_dh_keymgmt_functions[] = {
@@ -1307,7 +1326,6 @@ const OSSL_DISPATCH p_scossl_dh_keymgmt_functions[] = {
     {OSSL_FUNC_KEYMGMT_EXPORT_TYPES, (void (*)(void))p_scossl_dh_keymgmt_impexp_types},
     {OSSL_FUNC_KEYMGMT_IMPORT, (void (*)(void))p_scossl_dh_keymgmt_import},
     {OSSL_FUNC_KEYMGMT_EXPORT, (void (*)(void))p_scossl_dh_keymgmt_export},
-    {OSSL_FUNC_KEYMGMT_QUERY_OPERATION_NAME, (void (*)(void))p_scossl_dh_keymgmt_query_operation_name},
     {0, NULL}};
 
 #ifdef __cplusplus

--- a/SymCryptProvider/src/p_scossl_base.c
+++ b/SymCryptProvider/src/p_scossl_base.c
@@ -5,6 +5,7 @@
 #include <openssl/core_dispatch.h>
 #include <openssl/proverr.h>
 
+#include "scossl_dh.h"
 #include "scossl_ecc.h"
 #include "p_scossl_base.h"
 
@@ -124,7 +125,7 @@ extern const OSSL_DISPATCH p_scossl_rsa_keymgmt_functions[];
 extern const OSSL_DISPATCH p_scossl_ecc_keymgmt_functions[];
 
 static const OSSL_ALGORITHM p_scossl_keymgmt[] = {
-    // ALG("DH:dhKeyAgreement:1.2.840.113549.1.3.1", p_scossl_dh_keymgmt_functions),
+    ALG("DH:dhKeyAgreement:1.2.840.113549.1.3.1", p_scossl_dh_keymgmt_functions),
     ALG("RSA:rsaEncryption:1.2.840.113549.1.1.1:", p_scossl_rsa_keymgmt_functions),
     ALG("EC:id-ecPublicKey:1.2.840.10045.2.1", p_scossl_ecc_keymgmt_functions),
     ALG_TABLE_END};
@@ -167,6 +168,7 @@ static int p_scossl_get_status()
 
 static void p_scossl_teardown(_Inout_ SCOSSL_PROVCTX *provctx)
 {
+    // scossl_destroy_safeprime_dlgroups();
     scossl_ecc_destroy_ecc_curves();
     OPENSSL_free(provctx);
 }
@@ -255,7 +257,8 @@ SCOSSL_STATUS OSSL_provider_init(_In_ const OSSL_CORE_HANDLE *handle,
     if (!scossl_prov_initialized)
     {
         SYMCRYPT_MODULE_INIT();
-        if(!scossl_ecc_init_static())
+        if (!scossl_dh_init_static() ||
+            !scossl_ecc_init_static())
         {
             ERR_raise(ERR_LIB_PROV, ERR_R_INIT_FAIL);
             return SCOSSL_FAILURE;

--- a/SymCryptProvider/src/p_scossl_base.c
+++ b/SymCryptProvider/src/p_scossl_base.c
@@ -138,7 +138,7 @@ extern const OSSL_DISPATCH p_scossl_hkdf_keyexch_functions[];
 extern const OSSL_DISPATCH p_scossl_tls1prf_keyexch_functions[];
 
 static const OSSL_ALGORITHM p_scossl_keyexch[] = {
-    // ALG("DH:dhKeyAgreement:1.2.840.113549.1.3.1", p_scossl_dh_functions),
+    ALG("DH:dhKeyAgreement:1.2.840.113549.1.3.1", p_scossl_dh_functions),
     ALG("ECDH", p_scossl_ecdh_functions),
     // ALG("X25519:1.3.101.110", p_scossl_x25519_functions),
     // ALG("HKDF", p_scossl_hkdf_keyexch_functions),

--- a/SymCryptProvider/src/p_scossl_base.c
+++ b/SymCryptProvider/src/p_scossl_base.c
@@ -168,7 +168,7 @@ static int p_scossl_get_status()
 
 static void p_scossl_teardown(_Inout_ SCOSSL_PROVCTX *provctx)
 {
-    // scossl_destroy_safeprime_dlgroups();
+    scossl_destroy_safeprime_dlgroups();
     scossl_ecc_destroy_ecc_curves();
     OPENSSL_free(provctx);
 }


### PR DESCRIPTION
- Add Diffie-Hellman key exchange to the provider
    - Added DH key management interface
        - Supports import by group parameters for app compat, but a warning is logged
    - Added DH key exchange interface
        - Supports X9.42 for app compat. This follows the default provider model of creating a new EVP_KDF and feeding it the result of the derivation. Import of X9.42 formatted keys is offloaded to the default provider
- Refactored common code from engine to share with provider
    - Derive function remains separate due to differences in the requirements between the provider and engine
    - Added support for added NID_modp_* in OpenSSL 3
    - Added support for import by group parameters due to requirement in the provider