### PR TITLE
Fix 3.0 compatability issues

### DIFF
--- a/SymCryptProvider/inc/p_scossl_base.h.in
+++ b/SymCryptProvider/inc/p_scossl_base.h.in
@@ -29,7 +29,7 @@ static const OSSL_PARAM p_scossl_param_types[] = {
 
 // EVP_MD_CTX_dup is a helpful function for the provider, but was not added until OpenSSL 3.1
 // This function is copied from 3.1 to allow its use when the provider is built against 3.0
-#if OPENSSL_VERSION_MINOR == 0
+#if OPENSSL_VERSION_MAJOR == 3 && OPENSSL_VERSION_MINOR == 0
 EVP_MD_CTX *EVP_MD_CTX_dup(const EVP_MD_CTX *in);
 #endif
 

--- a/SymCryptProvider/inc/p_scossl_base.h.in
+++ b/SymCryptProvider/inc/p_scossl_base.h.in
@@ -27,6 +27,12 @@ static const OSSL_PARAM p_scossl_param_types[] = {
     OSSL_PARAM_int(OSSL_PROV_PARAM_STATUS, NULL),
     OSSL_PARAM_END};
 
+// EVP_MD_CTX_dup is a helpful function for the provider, but was not added until OpenSSL 3.1
+// This function is copied from 3.1 to allow its use when the provider is built against 3.0
+#if OPENSSL_VERSION_MINOR == 0
+EVP_MD_CTX *EVP_MD_CTX_dup(const EVP_MD_CTX *in);
+#endif
+
 #ifdef __cplusplus
 }
 #endif

--- a/SymCryptProvider/src/p_scossl_base.c
+++ b/SymCryptProvider/src/p_scossl_base.c
@@ -451,6 +451,19 @@ void CRYPTO_clear_free(void *ptr, size_t num, const char *file, int line)
     return c_CRYPTO_clear_free(ptr, num, file, line);
 }
 
+#if OPENSSL_VERSION_MINOR == 0
+EVP_MD_CTX *EVP_MD_CTX_dup(const EVP_MD_CTX *in)
+{
+    EVP_MD_CTX *out = EVP_MD_CTX_new();
+
+    if (out != NULL && !EVP_MD_CTX_copy_ex(out, in)) {
+        EVP_MD_CTX_free(out);
+        out = NULL;
+    }
+    return out;
+}
+#endif
+
 #ifdef __cplusplus
 }
 #endif

--- a/SymCryptProvider/src/signature/p_scossl_rsa_signature.c
+++ b/SymCryptProvider/src/signature/p_scossl_rsa_signature.c
@@ -628,7 +628,7 @@ static SCOSSL_STATUS p_scossl_rsa_get_ctx_params(_In_ SCOSSL_RSA_SIGN_CTX *ctx, 
                     len = BIO_snprintf(p->data, p->data_size, "%d",
                                            ctx->cbSalt);
                     if (len <= 0)
-                        return 0;
+                        return SCOSSL_FAILURE;
                     p->return_size = len;
             }
 

--- a/SymCryptProvider/src/signature/p_scossl_rsa_signature.c
+++ b/SymCryptProvider/src/signature/p_scossl_rsa_signature.c
@@ -145,7 +145,11 @@ static SCOSSL_STATUS p_scossl_rsa_signverify_init(_Inout_ SCOSSL_RSA_SIGN_CTX *c
         return SCOSSL_FAILURE;
     }
 
+#ifdef RSA_PSS_SALTLEN_AUTO_DIGEST_MAX
     ctx->cbSalt = RSA_PSS_SALTLEN_AUTO_DIGEST_MAX;
+#else
+    ctx->cbSalt = RSA_PSS_SALTLEN_AUTO;
+#endif
     ctx->operation = operation;
     if (keyCtx != NULL)
     {
@@ -455,12 +459,14 @@ static SCOSSL_STATUS p_scossl_rsa_set_ctx_params(_Inout_ SCOSSL_RSA_SIGN_CTX *ct
             {
                 saltlen = RSA_PSS_SALTLEN_MAX;
             }
+#ifdef RSA_PSS_SALTLEN_AUTO_DIGEST_MAX
             else if (strcmp(p->data, OSSL_PKEY_RSA_PSS_SALT_LEN_AUTO_DIGEST_MAX) == 0)
             {
                 // Sign: Smaller of digest length or maximized salt length
                 // Verify: Autorecovered salt length
                 saltlen = RSA_PSS_SALTLEN_AUTO_DIGEST_MAX;
             }
+#endif
             else
             {
                 saltlen = atoi(p->data);
@@ -470,8 +476,11 @@ static SCOSSL_STATUS p_scossl_rsa_set_ctx_params(_Inout_ SCOSSL_RSA_SIGN_CTX *ct
             ERR_raise(ERR_LIB_PROV, PROV_R_FAILED_TO_GET_PARAMETER);
             return SCOSSL_FAILURE;
         }
-
+#ifdef RSA_PSS_SALTLEN_AUTO_DIGEST_MAX
         if (saltlen < RSA_PSS_SALTLEN_AUTO_DIGEST_MAX)
+#else
+        if (saltlen < RSA_PSS_SALTLEN_MAX)
+#endif
         {
             ERR_raise(ERR_LIB_PROV, PROV_R_INVALID_SALT_LENGTH);
             return SCOSSL_FAILURE;
@@ -610,9 +619,11 @@ static SCOSSL_STATUS p_scossl_rsa_get_ctx_params(_In_ SCOSSL_RSA_SIGN_CTX *ctx, 
                 case RSA_PSS_SALTLEN_MAX:
                     saltLenText = OSSL_PKEY_RSA_PSS_SALT_LEN_MAX;
                     break;
+#ifdef RSA_PSS_SALTLEN_AUTO_DIGEST_MAX
                 case RSA_PSS_SALTLEN_AUTO_DIGEST_MAX:
                     saltLenText = OSSL_PKEY_RSA_PSS_SALT_LEN_AUTO_DIGEST_MAX;
                     break;
+#endif
                 default:
                     len = BIO_snprintf(p->data, p->data_size, "%d",
                                            ctx->cbSalt);


### PR DESCRIPTION
RSA_PSS_SALTLEN_AUTO_DIGEST_MAX and EVP_MD_CTX_dup weren't added until OpenSSL 3.1. This PR fixes builds for 3.0 by:
- Wrapping RSA_PSS_SALTLEN_AUTO_DIGEST_MAX with #ifdef (same thing as in ScosslCommon)
- Define EVP_MD_CTX_dup using the official 3.1 implementation if building on 3.0