### PR TITLE
Properly support restricted PSS keys

### DIFF
--- a/ScosslCommon/inc/scossl_rsa.h
+++ b/ScosslCommon/inc/scossl_rsa.h
@@ -10,12 +10,6 @@ extern "C" {
 
 typedef struct
 {
-    int initialized;
-    PSYMCRYPT_RSAKEY key;
-} SCOSSL_RSA_KEY_CTX;
-
-typedef struct
-{
     BIGNUM *p;
     BIGNUM *q;
     BIGNUM *d;
@@ -31,29 +25,26 @@ typedef struct
     SCOSSL_RSA_PRIVATE_EXPORT_PARAMS *privateParams;
 } SCOSSL_RSA_EXPORT_PARAMS;
 
-SCOSSL_RSA_KEY_CTX *scossl_rsa_new_key_ctx();
-void scossl_rsa_free_key_ctx(_In_ SCOSSL_RSA_KEY_CTX *keyCtx);
-
-SCOSSL_STATUS scossl_rsa_pkcs1_sign(_In_ SCOSSL_RSA_KEY_CTX *keyCtx, int mdnid,
+SCOSSL_STATUS scossl_rsa_pkcs1_sign(_In_ PSYMCRYPT_RSAKEY key, int mdnid,
                                     _In_reads_bytes_(cbHashValue) PCBYTE pbHashValue, SIZE_T cbHashValue,
                                     _Out_writes_bytes_(*pcbSignature) PBYTE pbSignature, _Out_ SIZE_T* pcbSignature);
-SCOSSL_STATUS scossl_rsa_pkcs1_verify(_In_ SCOSSL_RSA_KEY_CTX *keyCtx, int mdnid,
+SCOSSL_STATUS scossl_rsa_pkcs1_verify(_In_ PSYMCRYPT_RSAKEY key, int mdnid,
                                       _In_reads_bytes_(cbHashValue) PCBYTE pbHashValue, SIZE_T cbHashValue,
                                       _In_reads_bytes_(pcbSignature) PCBYTE pbSignature, SIZE_T pcbSignature);
 
-SCOSSL_STATUS scossl_rsapss_sign(_In_ SCOSSL_RSA_KEY_CTX *keyCtx, int mdnid, int cbSalt,
+SCOSSL_STATUS scossl_rsapss_sign(_In_ PSYMCRYPT_RSAKEY key, int mdnid, int cbSalt,
                                  _In_reads_bytes_(cbHashValue) PCBYTE pbHashValue, SIZE_T cbHashValue,
                                  _Out_writes_bytes_(*pcbSignature) PBYTE pbSignature, _Out_ SIZE_T* pcbSignature);
-SCOSSL_STATUS scossl_rsapss_verify(_In_ SCOSSL_RSA_KEY_CTX *keyCtx, _In_ int mdnid, int cbSalt,
+SCOSSL_STATUS scossl_rsapss_verify(_In_ PSYMCRYPT_RSAKEY key, int mdnid, int cbSalt,
                                    _In_reads_bytes_(cbHashValue) PCBYTE pbHashValue, SIZE_T cbHashValue,
                                    _In_reads_bytes_(pcbSignature) PCBYTE pbSignature, SIZE_T pcbSignature);
 
-SCOSSL_STATUS scossl_rsa_encrypt(_In_ SCOSSL_RSA_KEY_CTX *keyCtx, UINT padding,
+SCOSSL_STATUS scossl_rsa_encrypt(_In_ PSYMCRYPT_RSAKEY key, UINT padding,
                                  int mdnid, _In_reads_bytes_opt_(cbLabel) PCBYTE pbLabel, SIZE_T cbLabel,
                                  _In_reads_bytes_(cbSrc) PCBYTE pbSrc, SIZE_T cbSrc,
                                  _Out_writes_bytes_(*pcbDst) PBYTE pbDst, _Out_ INT32 *pcbDst, SIZE_T cbDst);
 
-SCOSSL_STATUS scossl_rsa_decrypt(_In_ SCOSSL_RSA_KEY_CTX *keyCtx, UINT padding,
+SCOSSL_STATUS scossl_rsa_decrypt(_In_ PSYMCRYPT_RSAKEY key, UINT padding,
                                  int mdnid, _In_reads_bytes_opt_(cbLabel) PCBYTE pbLabel, SIZE_T cbLabel,
                                  _In_reads_bytes_(cbSrc) PCBYTE pbSrc, SIZE_T cbSrc,
                                  _Out_writes_bytes_(*pcbDst) PBYTE pbDst, _Out_ INT32 *pcbDst, SIZE_T cbDst);

--- a/SymCryptEngine/src/e_scossl_rsa.h
+++ b/SymCryptEngine/src/e_scossl_rsa.h
@@ -89,12 +89,17 @@ SCOSSL_STATUS e_scossl_rsa_init(_Inout_ RSA *rsa);
 // Returns SCOSSL_SUCCESS on success, or SCOSSL_FAILURE on error
 SCOSSL_STATUS e_scossl_rsa_finish(_Inout_ RSA *rsa);
 
+typedef struct _SCOSSL_RSA_KEY_CONTEXT {
+    int initialized;
+    PSYMCRYPT_RSAKEY key;
+} SCOSSL_RSA_KEY_CONTEXT;
+
 // Initializes keyCtx from key rsa.
 // Returns SCOSSL_SUCCESS on success, or SCOSSL_FAILURE on error
-SCOSSL_STATUS e_scossl_initialize_rsa_key(_In_ const RSA* rsa, _Out_ SCOSSL_RSA_KEY_CTX *keyCtx);
+SCOSSL_STATUS e_scossl_initialize_rsa_key(_In_ const RSA* rsa, _Out_ SCOSSL_RSA_KEY_CONTEXT *keyCtx);
 
 // Frees data and key of keyCtx
-void e_scossl_rsa_free_key_context(_In_ SCOSSL_RSA_KEY_CTX *keyCtx);
+void e_scossl_rsa_free_key_context(_In_ SCOSSL_RSA_KEY_CONTEXT *keyCtx);
 
 #ifdef __cplusplus
 }

--- a/SymCryptEngine/src/e_scossl_rsapss.c
+++ b/SymCryptEngine/src/e_scossl_rsapss.c
@@ -15,7 +15,7 @@ SCOSSL_STATUS e_scossl_rsapss_sign(_Inout_ EVP_PKEY_CTX *ctx, _Out_writes_opt_(*
 {
     EVP_PKEY* pkey = NULL;
     const RSA* rsa = NULL;
-    SCOSSL_RSA_KEY_CTX *keyCtx = NULL;
+    SCOSSL_RSA_KEY_CONTEXT *keyCtx = NULL;
     const EVP_MD *messageDigest;
     const EVP_MD *mgf1Digest;
     int type = 0;
@@ -72,7 +72,7 @@ SCOSSL_STATUS e_scossl_rsapss_sign(_Inout_ EVP_PKEY_CTX *ctx, _Out_writes_opt_(*
         }
     }
 
-    return scossl_rsapss_sign(keyCtx, type, cbSalt, tbs, tbslen, sig, (SIZE_T*)siglen);
+    return scossl_rsapss_sign(keyCtx->key, type, cbSalt, tbs, tbslen, sig, (SIZE_T*)siglen);
 }
 
 SCOSSL_STATUS e_scossl_rsapss_verify(_Inout_ EVP_PKEY_CTX *ctx, _In_reads_bytes_(siglen) const unsigned char *sig, size_t siglen,
@@ -80,7 +80,7 @@ SCOSSL_STATUS e_scossl_rsapss_verify(_Inout_ EVP_PKEY_CTX *ctx, _In_reads_bytes_
 {
     EVP_PKEY* pkey = NULL;
     const RSA* rsa = NULL;
-    SCOSSL_RSA_KEY_CTX *keyCtx = NULL;
+    SCOSSL_RSA_KEY_CONTEXT *keyCtx = NULL;
     const EVP_MD *messageDigest;
     const EVP_MD *mgf1Digest;
     int type = 0;
@@ -142,7 +142,7 @@ SCOSSL_STATUS e_scossl_rsapss_verify(_Inout_ EVP_PKEY_CTX *ctx, _In_reads_bytes_
         return SCOSSL_FAILURE;
     }
 
-    return scossl_rsapss_verify(keyCtx, type, cbSalt, tbs, tbslen, sig, siglen);
+    return scossl_rsapss_verify(keyCtx->key, type, cbSalt, tbs, tbslen, sig, siglen);
 }
 
 

--- a/SymCryptProvider/src/p_scossl_base.c
+++ b/SymCryptProvider/src/p_scossl_base.c
@@ -216,12 +216,14 @@ static const OSSL_ALGORITHM p_scossl_rand[] = {
 // Key management
 extern const OSSL_DISPATCH p_scossl_dh_keymgmt_functions[];
 extern const OSSL_DISPATCH p_scossl_rsa_keymgmt_functions[];
+extern const OSSL_DISPATCH p_scossl_rsapss_keymgmt_functions[];
 extern const OSSL_DISPATCH p_scossl_ecc_keymgmt_functions[];
 extern const OSSL_DISPATCH p_scossl_x25519_keymgmt_functions[];
 
 static const OSSL_ALGORITHM p_scossl_keymgmt[] = {
     ALG("DH:dhKeyAgreement:1.2.840.113549.1.3.1", p_scossl_dh_keymgmt_functions),
     ALG("RSA:rsaEncryption:1.2.840.113549.1.1.1:", p_scossl_rsa_keymgmt_functions),
+    ALG("RSA-PSS:RSASSA-PSS:1.2.840.113549.1.1.10", p_scossl_rsapss_keymgmt_functions),
     ALG("EC:id-ecPublicKey:1.2.840.10045.2.1", p_scossl_ecc_keymgmt_functions),
     ALG("X25519:1.3.101.110", p_scossl_x25519_keymgmt_functions),
     ALG_TABLE_END};
@@ -230,15 +232,11 @@ static const OSSL_ALGORITHM p_scossl_keymgmt[] = {
 extern const OSSL_DISPATCH p_scossl_dh_functions[];
 extern const OSSL_DISPATCH p_scossl_ecdh_functions[];
 extern const OSSL_DISPATCH p_scossl_x25519_functions[];
-extern const OSSL_DISPATCH p_scossl_hkdf_keyexch_functions[];
-extern const OSSL_DISPATCH p_scossl_tls1prf_keyexch_functions[];
 
 static const OSSL_ALGORITHM p_scossl_keyexch[] = {
     ALG("DH:dhKeyAgreement:1.2.840.113549.1.3.1", p_scossl_dh_functions),
     ALG("ECDH", p_scossl_ecdh_functions),
     ALG("X25519:1.3.101.110", p_scossl_ecdh_functions),
-    // ALG("HKDF", p_scossl_hkdf_keyexch_functions),
-    // ALG("TLS1-PRF", p_scossl_tls1prf_keyexch_functions),
     ALG_TABLE_END};
 
 // Signature
@@ -388,21 +386,21 @@ SCOSSL_STATUS OSSL_provider_init(_In_ const OSSL_CORE_HANDLE *handle,
     {
         switch(in->function_id)
         {
-            case OSSL_FUNC_CRYPTO_MALLOC:
-                c_CRYPTO_malloc = OSSL_FUNC_CRYPTO_malloc(in);
-                break;
-            case OSSL_FUNC_CRYPTO_ZALLOC:
-                c_CRYPTO_zalloc = OSSL_FUNC_CRYPTO_zalloc(in);
-                break;
-            case OSSL_FUNC_CRYPTO_FREE:
-                c_CRYPTO_free = OSSL_FUNC_CRYPTO_free(in);
-                break;
-            case OSSL_FUNC_CRYPTO_CLEAR_FREE:
-                c_CRYPTO_clear_free = OSSL_FUNC_CRYPTO_clear_free(in);
-                break;
-            case OSSL_FUNC_CORE_GET_LIBCTX:
-                core_get_libctx = OSSL_FUNC_core_get_libctx(in);
-                break;
+        case OSSL_FUNC_CRYPTO_MALLOC:
+            c_CRYPTO_malloc = OSSL_FUNC_CRYPTO_malloc(in);
+            break;
+        case OSSL_FUNC_CRYPTO_ZALLOC:
+            c_CRYPTO_zalloc = OSSL_FUNC_CRYPTO_zalloc(in);
+            break;
+        case OSSL_FUNC_CRYPTO_FREE:
+            c_CRYPTO_free = OSSL_FUNC_CRYPTO_free(in);
+            break;
+        case OSSL_FUNC_CRYPTO_CLEAR_FREE:
+            c_CRYPTO_clear_free = OSSL_FUNC_CRYPTO_clear_free(in);
+            break;
+        case OSSL_FUNC_CORE_GET_LIBCTX:
+            core_get_libctx = OSSL_FUNC_core_get_libctx(in);
+            break;
         }
     }
 

--- a/SymCryptProvider/src/p_scossl_rsa.c
+++ b/SymCryptProvider/src/p_scossl_rsa.c
@@ -15,8 +15,8 @@
 extern "C" {
 #endif
 
-#define SCOSSL_PROV_RSA_PSS_DEFAULT_MD 0
-#define SCOSSL_PROV_RSA_PSS_DEFAULT_SATLLEN_MIN 20
+#define SCOSSL_PROV_RSA_PSS_DEFAULT_MD (0) // Index of the default MD in p_scossl_rsa_supported_mds (SHA1)
+#define SCOSSL_PROV_RSA_PSS_DEFAULT_SALTLEN_MIN (20)
 
 static const OSSL_ITEM p_scossl_rsa_supported_mds[] = {
     {NID_sha1,     OSSL_DIGEST_NAME_SHA1}, // Default
@@ -113,7 +113,7 @@ SCOSSL_STATUS p_scossl_rsa_pss_restrictions_from_params(OSSL_LIB_CTX *libctx, co
         // as the default provider.
         pssRestrictions->mdInfo = &p_scossl_rsa_supported_mds[SCOSSL_PROV_RSA_PSS_DEFAULT_MD];
         pssRestrictions->mgf1MdInfo = &p_scossl_rsa_supported_mds[SCOSSL_PROV_RSA_PSS_DEFAULT_MD];
-        pssRestrictions->cbSaltMin = SCOSSL_PROV_RSA_PSS_DEFAULT_SATLLEN_MIN;
+        pssRestrictions->cbSaltMin = SCOSSL_PROV_RSA_PSS_DEFAULT_SALTLEN_MIN;
 
         *pPssRestrictions = pssRestrictions;
     }

--- a/SymCryptProvider/src/p_scossl_rsa.c
+++ b/SymCryptProvider/src/p_scossl_rsa.c
@@ -8,10 +8,15 @@
 
 #include <openssl/core_names.h>
 #include <openssl/evp.h>
+#include <openssl/param_build.h>
+#include <openssl/proverr.h>
 
 #ifdef __cplusplus
 extern "C" {
 #endif
+
+#define SCOSSL_PROV_RSA_PSS_DEFAULT_MD 0
+#define SCOSSL_PROV_RSA_PSS_DEFAULT_SATLLEN_MIN 20
 
 static const OSSL_ITEM p_scossl_rsa_supported_mds[] = {
     {NID_sha1,     OSSL_DIGEST_NAME_SHA1}, // Default
@@ -51,6 +56,117 @@ const OSSL_ITEM *p_scossl_rsa_get_supported_md(OSSL_LIB_CTX *libctx,
     }
 
     return mdInfo;
+}
+
+static const OSSL_ITEM *p_scossl_rsa_pss_param_to_mdinfo(_In_ OSSL_LIB_CTX *libctx,
+                                                         _In_ const OSSL_PARAM *p, _In_ const char *mdProps)
+{
+    const OSSL_ITEM *mdInfo;
+    const char *mdName;
+
+    if (!OSSL_PARAM_get_utf8_string_ptr(p, &mdName))
+    {
+        ERR_raise(ERR_LIB_PROV, PROV_R_FAILED_TO_GET_PARAMETER);
+        return NULL;
+    }
+
+    mdInfo = p_scossl_rsa_get_supported_md(libctx, mdName, mdProps, NULL);
+    if (mdInfo == NULL)
+    {
+        ERR_raise(ERR_LIB_PROV, PROV_R_INVALID_DIGEST);
+        return NULL;
+    }
+
+    return mdInfo;
+}
+
+_Use_decl_annotations_
+SCOSSL_STATUS p_scossl_rsa_pss_restrictions_from_params(OSSL_LIB_CTX *libctx, const OSSL_PARAM params[],
+                                                        SCOSSL_RSA_PSS_RESTRICTIONS **pPssRestrictions)
+{
+    const char *mdProps = NULL;
+    SCOSSL_RSA_PSS_RESTRICTIONS *pssRestrictions;
+    SCOSSL_STATUS ret = SCOSSL_FAILURE;
+
+    const OSSL_PARAM *paramSaltlenMin = OSSL_PARAM_locate_const(params, OSSL_PKEY_PARAM_RSA_PSS_SALTLEN);
+    const OSSL_PARAM *paramPropq = OSSL_PARAM_locate_const(params, OSSL_PKEY_PARAM_RSA_DIGEST_PROPS);
+    const OSSL_PARAM *paramMd = OSSL_PARAM_locate_const(params, OSSL_PKEY_PARAM_RSA_DIGEST);
+    const OSSL_PARAM *paramMgf1md = OSSL_PARAM_locate_const(params, OSSL_PKEY_PARAM_RSA_MGF1_DIGEST);
+
+    if (paramSaltlenMin == NULL &&
+        paramPropq == NULL &&
+        paramMd == NULL &&
+        paramMgf1md == NULL)
+    {
+        return SCOSSL_SUCCESS;
+    }
+
+    if (*pPssRestrictions == NULL)
+    {
+        if ((pssRestrictions = OPENSSL_malloc(sizeof(SCOSSL_RSA_PSS_RESTRICTIONS))) == NULL)
+        {
+            ERR_raise(ERR_LIB_PROV, ERR_R_MALLOC_FAILURE);
+            goto cleanup;
+        }
+
+        // Set defaults based on RFC 8017, A.2.3. This is the same behavior
+        // as the default provider.
+        pssRestrictions->mdInfo = &p_scossl_rsa_supported_mds[SCOSSL_PROV_RSA_PSS_DEFAULT_MD];
+        pssRestrictions->mgf1MdInfo = &p_scossl_rsa_supported_mds[SCOSSL_PROV_RSA_PSS_DEFAULT_MD];
+        pssRestrictions->cbSaltMin = SCOSSL_PROV_RSA_PSS_DEFAULT_SATLLEN_MIN;
+
+        *pPssRestrictions = pssRestrictions;
+    }
+    else
+    {
+        pssRestrictions = *pPssRestrictions;
+    }
+
+    if (paramSaltlenMin != NULL &&
+        !OSSL_PARAM_get_int(paramSaltlenMin, &pssRestrictions->cbSaltMin))
+    {
+        ERR_raise(ERR_LIB_PROV, PROV_R_INVALID_SALT_LENGTH);
+        goto cleanup;
+    }
+
+    if (paramPropq != NULL &&
+        !OSSL_PARAM_get_utf8_string_ptr(paramPropq, &mdProps))
+    {
+        ERR_raise(ERR_LIB_PROV, PROV_R_FAILED_TO_GET_PARAMETER);
+        goto cleanup;
+    }
+
+    if (paramMd != NULL &&
+        (pssRestrictions->mdInfo = p_scossl_rsa_pss_param_to_mdinfo(libctx, paramMd, mdProps)) == NULL)
+    {
+        goto cleanup;
+    }
+
+    if (paramMgf1md != NULL &&
+        (pssRestrictions->mgf1MdInfo = p_scossl_rsa_pss_param_to_mdinfo(libctx, paramMgf1md, mdProps)) == NULL)
+    {
+        goto cleanup;
+    }
+
+    ret = SCOSSL_SUCCESS;
+
+cleanup:
+    if (!ret)
+    {
+        OPENSSL_free(pssRestrictions);
+        *pPssRestrictions = NULL;
+    }
+
+    return ret;
+}
+
+_Use_decl_annotations_
+SCOSSL_STATUS p_scossl_rsa_pss_restrictions_to_params(const SCOSSL_RSA_PSS_RESTRICTIONS *pssRestrictions,
+                                              OSSL_PARAM_BLD *bld)
+{
+    return OSSL_PARAM_BLD_push_utf8_string(bld, OSSL_PKEY_PARAM_RSA_DIGEST, pssRestrictions->mdInfo->ptr, 0) &&
+           OSSL_PARAM_BLD_push_utf8_string(bld, OSSL_PKEY_PARAM_RSA_MGF1_DIGEST, pssRestrictions->mgf1MdInfo->ptr, 0) &&
+           OSSL_PARAM_BLD_push_int(bld, OSSL_PKEY_PARAM_RSA_PSS_SALTLEN, pssRestrictions->cbSaltMin);
 }
 
 #ifdef __cplusplus

--- a/SymCryptProvider/src/p_scossl_rsa.h
+++ b/SymCryptProvider/src/p_scossl_rsa.h
@@ -8,9 +8,31 @@
 extern "C" {
 #endif
 
+typedef struct
+{
+    const OSSL_ITEM *mdInfo;
+    const OSSL_ITEM *mgf1MdInfo;
+    int cbSaltMin;
+} SCOSSL_RSA_PSS_RESTRICTIONS;
+
+typedef struct
+{
+    OSSL_LIB_CTX *libctx;
+    BOOL initialized;
+    PSYMCRYPT_RSAKEY key;
+    UINT padding;
+    SCOSSL_RSA_PSS_RESTRICTIONS *pssRestrictions;
+} SCOSSL_PROV_RSA_KEY_CTX;
+
 const OSSL_ITEM *p_scossl_rsa_get_supported_md(_In_ OSSL_LIB_CTX *libctx,
                                                _In_ const char *mdname, _In_ const char *propq,
                                                _Out_opt_ EVP_MD **md);
+
+SCOSSL_STATUS p_scossl_rsa_pss_restrictions_from_params(_In_ OSSL_LIB_CTX *libctx, _In_ const OSSL_PARAM params[],
+                                                        _Out_ SCOSSL_RSA_PSS_RESTRICTIONS **pPssRestrictions);
+
+SCOSSL_STATUS p_scossl_rsa_pss_restrictions_to_params(_In_ const SCOSSL_RSA_PSS_RESTRICTIONS *pssRestrictions,
+                                                      _Inout_ OSSL_PARAM_BLD *bld);
 
 #ifdef __cplusplus
 }

--- a/SymCryptProvider/src/signature/p_scossl_rsa_signature.c
+++ b/SymCryptProvider/src/signature/p_scossl_rsa_signature.c
@@ -426,6 +426,7 @@ static SCOSSL_STATUS p_scossl_rsa_set_ctx_params(_Inout_ SCOSSL_RSA_SIGN_CTX *ct
         }
         else
         {
+            EVP_MD_free(ctx->md);
             ctx->md = md;
             ctx->mdInfo = mdInfo;
         }


### PR DESCRIPTION
The SymCrypt provider only supported PSS padded RSA if the key was imported through the RSA key management interface. RSASSA-PSS keys were not routed to the SymCrypt provider, and the keys' restrictions would not be properly handled. 

This PR addresses the gap by adding the RSASSA-PSS key management interface and updating the RSA signature interface to enforce the restrictions associated with RSASSA-PSS keys.