### PR TITLE
Provider KBKDF (SP800-108)

### DIFF
--- a/SymCryptProvider/CMakeLists.txt
+++ b/SymCryptProvider/CMakeLists.txt
@@ -22,6 +22,7 @@ set(SCOSSL_SOURCES
     ./src/ciphers/p_scossl_aes_aead.c
     ./src/ciphers/p_scossl_aes_xts.c
     ./src/kdf/p_scossl_hkdf.c
+    ./src/kdf/p_scossl_kbkdf.c
     ./src/kdf/p_scossl_sshkdf.c
     ./src/kdf/p_scossl_tls1prf.c
     ./src/keyexch/p_scossl_dh.c

--- a/SymCryptProvider/src/kdf/p_scossl_kbkdf.c
+++ b/SymCryptProvider/src/kdf/p_scossl_kbkdf.c
@@ -4,67 +4,425 @@
 
 #include "p_scossl_base.h"
 
+#include <openssl/proverr.h>
+
 #ifdef __cplusplus
 extern "C" {
 #endif
 
+// MAC algorithm and additional data needed to determine correct PCSYMCRYPT_MAC
+// (digest type for HMAC, cipher for CMAC) may be set in multiple calls to p_scossl_kbkdf_set_ctx_params.
+// MAC type, digest, and cipher need to be tracked independently. ctx->pMac is only set when MAC type
+// and required additional parameters have been set.
+#define SCOSSL_MAC_TYPE_HMAC 0
+#define SCOSSL_MAC_TYPE_CMAC 1
+#define SCOSSL_MAC_TYPE_KMAC 2
+
 typedef struct
 {
-    OSSL_LIB_CTX *libctx;
+    OSSL_LIB_CTX *libCtx;
 
+    PBYTE pbKey;
+    SIZE_T cbKey;
+    PBYTE pbLabel;
+    SIZE_T cbLabel;
+    PBYTE pbContext;
+    SIZE_T cbContext;
+    PCSYMCRYPT_MAC pMac;
+
+    UINT macType;
+    SIZE_T cbCmacKey;
 } SCOSSL_PROV_KBKDF_CTX;
 
 static const OSSL_PARAM p_scossl_kbkdf_gettable_ctx_param_types[] = {
+    OSSL_PARAM_size_t(OSSL_KDF_PARAM_SIZE, NULL),
     OSSL_PARAM_END};
 
 static const OSSL_PARAM p_scossl_kbkdf_settable_ctx_param_types[] = {
+    OSSL_PARAM_octet_string(OSSL_KDF_PARAM_KEY, NULL, 0),
+    OSSL_PARAM_octet_string(OSSL_KDF_PARAM_SALT, NULL, 0), // Label
+    OSSL_PARAM_octet_string(OSSL_KDF_PARAM_INFO, NULL, 0), // Context
+    OSSL_PARAM_utf8_string(OSSL_KDF_PARAM_MAC, NULL, 0),
+    OSSL_PARAM_utf8_string(OSSL_KDF_PARAM_DIGEST, NULL, 0),
+    OSSL_PARAM_utf8_string(OSSL_KDF_PARAM_CIPHER, NULL, 0),
+    OSSL_PARAM_utf8_string(OSSL_KDF_PARAM_PROPERTIES, NULL, 0),
+    OSSL_PARAM_utf8_string(OSSL_KDF_PARAM_MODE, NULL, 0),
+    // Below parameters aren't configurable. The provider will reject anything that
+    // does not match the fixed behavior of SymCrypt.
+    OSSL_PARAM_int(OSSL_KDF_PARAM_KBKDF_USE_L, NULL),
+    OSSL_PARAM_int(OSSL_KDF_PARAM_KBKDF_USE_SEPARATOR, NULL),
+    OSSL_PARAM_int(OSSL_KDF_PARAM_KBKDF_R, NULL),
     OSSL_PARAM_END};
+
+static SCOSSL_STATUS p_scossl_kbkdf_set_ctx_params(_Inout_ SCOSSL_PROV_KBKDF_CTX *ctx, const _In_ OSSL_PARAM params[]);
 
 static SCOSSL_PROV_KBKDF_CTX *p_scossl_kbkdf_newctx(_In_ SCOSSL_PROVCTX *provctx)
 {
+    SCOSSL_PROV_KBKDF_CTX *ctx = OPENSSL_zalloc(sizeof(SCOSSL_PROV_KBKDF_CTX));
+    if (ctx != NULL)
+    {
+        ctx->libCtx = provctx->libctx;
+    }
 
+    return ctx;
 }
 
 static void p_scossl_kbkdf_freectx(_Inout_ SCOSSL_PROV_KBKDF_CTX *ctx)
 {
+    if (ctx == NULL)
+        return;
 
+    OPENSSL_clear_free(ctx->pbKey, ctx->cbKey);
+    OPENSSL_clear_free(ctx->pbLabel, ctx->cbLabel);
+    OPENSSL_clear_free(ctx->pbContext, ctx->cbContext);
+    OPENSSL_free(ctx);
 }
 
 static SCOSSL_PROV_KBKDF_CTX *p_scossl_kbkdf_dupctx(_In_ SCOSSL_PROV_KBKDF_CTX *ctx)
 {
+    SCOSSL_PROV_KBKDF_CTX *copyCtx = OPENSSL_zalloc(sizeof(SCOSSL_PROV_KBKDF_CTX));
+    if (copyCtx != NULL)
+    {
+        *copyCtx = *ctx;
 
+        if ((ctx->pbKey != NULL     && (copyCtx->pbKey = OPENSSL_memdup(ctx->pbKey, ctx->cbKey)) == NULL) ||
+            (ctx->pbLabel != NULL   && (copyCtx->pbLabel = OPENSSL_memdup(ctx->pbLabel, ctx->cbLabel)) == NULL) ||
+            (ctx->pbContext != NULL && (copyCtx->pbContext = OPENSSL_memdup(ctx->pbContext, ctx->cbContext)) == NULL))
+        {
+            p_scossl_kbkdf_freectx(copyCtx);
+            ERR_raise(ERR_LIB_PROV, ERR_R_MALLOC_FAILURE);
+            return NULL;
+        }
+    }
+
+    return copyCtx;
 }
 
 static SCOSSL_STATUS p_scossl_kbkdf_reset(_Inout_ SCOSSL_PROV_KBKDF_CTX *ctx)
 {
+    OSSL_LIB_CTX *libCtx = ctx->libCtx;
 
+    OPENSSL_clear_free(ctx->pbKey, ctx->cbKey);
+    OPENSSL_clear_free(ctx->pbLabel, ctx->cbLabel);
+    OPENSSL_clear_free(ctx->pbContext, ctx->cbContext);
+    OPENSSL_cleanse(ctx, sizeof(SCOSSL_PROV_KBKDF_CTX));
+
+    ctx->libCtx = libCtx;
+
+    return SCOSSL_SUCCESS;
 }
 
 static SCOSSL_STATUS p_scossl_kbkdf_derive(_In_ SCOSSL_PROV_KBKDF_CTX *ctx,
-                                          _Out_writes_bytes_(keylen) unsigned char *key, size_t keylen,
-                                          _In_ const OSSL_PARAM params[])
+                                           _Out_writes_bytes_(keylen) unsigned char *key, size_t keylen,
+                                           _In_ const OSSL_PARAM params[])
 {
+    SYMCRYPT_ERROR scError = SYMCRYPT_NO_ERROR;
 
+    if (!p_scossl_kbkdf_set_ctx_params(ctx, params))
+    {
+        return SCOSSL_FAILURE;
+    }
+
+    if (ctx->pMac == NULL)
+    {
+        ERR_raise(ERR_LIB_PROV, PROV_R_MISSING_MAC);
+        return SCOSSL_FAILURE;
+    }
+
+    if (ctx->pbKey == NULL)
+    {
+        ERR_raise(ERR_LIB_PROV, PROV_R_MISSING_KEY);
+        return SCOSSL_FAILURE;
+    }
+
+    scError = SymCryptSp800_108(
+        ctx->pMac,
+        ctx->pbKey, ctx->cbKey,
+        ctx->pbLabel, ctx->cbLabel,
+        ctx->pbContext, ctx->cbContext,
+        key, keylen);
+
+    if (scError != SYMCRYPT_NO_ERROR)
+    {
+        ERR_raise(ERR_LIB_PROV, ERR_R_INTERNAL_ERROR);
+        return SCOSSL_FAILURE;
+    }
+
+    return SCOSSL_SUCCESS;
 }
 
 static const OSSL_PARAM *p_scossl_kbkdf_gettable_ctx_params(ossl_unused void *ctx, ossl_unused void *provctx)
 {
-
+    return p_scossl_kbkdf_gettable_ctx_param_types;
 }
 
 static const OSSL_PARAM *p_scossl_kbkdf_settable_ctx_params(ossl_unused void *ctx, ossl_unused void *provctx)
 {
-
+    return p_scossl_kbkdf_settable_ctx_param_types;
 }
 
-static SCOSSL_STATUS p_scossl_kbkdf_get_ctx_params(_In_ SCOSSL_PROV_KBKDF_CTX *ctx, _Inout_ OSSL_PARAM params[])
+static SCOSSL_STATUS p_scossl_kbkdf_get_ctx_params(ossl_unused void *ctx, _Inout_ OSSL_PARAM params[])
 {
+    OSSL_PARAM *p;
 
+    if ((p = OSSL_PARAM_locate(params, OSSL_KDF_PARAM_SIZE)) != NULL &&
+        !OSSL_PARAM_set_size_t(p, SIZE_MAX))
+    {
+        ERR_raise(ERR_LIB_PROV, PROV_R_FAILED_TO_SET_PARAMETER);
+        return SCOSSL_FAILURE;
+    }
+
+    return SCOSSL_SUCCESS;
 }
 
 static SCOSSL_STATUS p_scossl_kbkdf_set_ctx_params(_Inout_ SCOSSL_PROV_KBKDF_CTX *ctx, const _In_ OSSL_PARAM params[])
 {
+    char *propq = NULL;
+    EVP_MD *md = NULL;
+    EVP_CIPHER *cipher = NULL;
+    EVP_MAC *mac = NULL;
+    SCOSSL_STATUS ret = SCOSSL_FAILURE;
+    const OSSL_PARAM *p;
 
+    if ((p = OSSL_PARAM_locate_const(params, OSSL_KDF_PARAM_KEY)) != NULL)
+    {
+        OPENSSL_clear_free(ctx->pbKey, ctx->cbKey);
+
+        if (!OSSL_PARAM_get_octet_string(p, (void **) &ctx->pbKey, 0, &ctx->cbKey))
+        {
+            ERR_raise(ERR_LIB_PROV, PROV_R_FAILED_TO_GET_PARAMETER);
+            goto cleanup;
+        }
+
+        // Check that key size matches expected if cmac is intitialized
+        if (ctx->pMac == SymCryptAesCmacAlgorithm &&
+            ctx->cbKey != ctx->cbCmacKey)
+        {
+            ERR_raise(ERR_LIB_PROV, PROV_R_FAILED_TO_GET_PARAMETER);
+            goto cleanup;
+        }
+    }
+
+    if ((p = OSSL_PARAM_locate_const(params, OSSL_KDF_PARAM_SALT)) != NULL)
+    {
+        OPENSSL_clear_free(ctx->pbLabel, ctx->cbLabel);
+
+        if (!OSSL_PARAM_get_octet_string(p, (void **) &ctx->pbLabel, 0, &ctx->cbLabel))
+        {
+            ERR_raise(ERR_LIB_PROV, PROV_R_FAILED_TO_GET_PARAMETER);
+            goto cleanup;
+        }
+    }
+
+    if ((p = OSSL_PARAM_locate_const(params, OSSL_KDF_PARAM_INFO)) != NULL)
+    {
+        OPENSSL_clear_free(ctx->pbContext, ctx->cbContext);
+
+        if (!OSSL_PARAM_get_octet_string(p, (void **) &ctx->pbContext, 0, &ctx->cbContext))
+        {
+            ERR_raise(ERR_LIB_PROV, PROV_R_FAILED_TO_GET_PARAMETER);
+            goto cleanup;
+        }
+    }
+
+    if ((p = OSSL_PARAM_locate_const(params, OSSL_KDF_PARAM_PROPERTIES)) != NULL &&
+        !OSSL_PARAM_get_utf8_string(p, &propq, 0))
+    {
+        ERR_raise(ERR_LIB_PROV, PROV_R_FAILED_TO_GET_PARAMETER);
+        goto cleanup;
+    }
+
+    if ((p = OSSL_PARAM_locate_const(params, OSSL_KDF_PARAM_MAC)) != NULL)
+    {
+        const char *macName;
+        if (!OSSL_PARAM_get_utf8_string_ptr(p, &macName) ||
+            macName == NULL)
+        {
+            ERR_raise(ERR_LIB_PROV, PROV_R_FAILED_TO_GET_PARAMETER);
+            goto cleanup;
+        }
+
+        if ((mac = EVP_MAC_fetch(ctx->libCtx, macName, propq)) == NULL)
+        {
+            ERR_raise(ERR_LIB_PROV, PROV_R_INVALID_MAC);
+            goto cleanup;
+        }
+
+        if (EVP_MAC_is_a(mac, SN_hmac))
+        {
+            ctx->macType = SCOSSL_MAC_TYPE_HMAC;
+            ctx->pMac = NULL;
+        }
+        else if (EVP_MAC_is_a(mac, SN_cmac))
+        {
+            ctx->macType = SCOSSL_MAC_TYPE_CMAC;
+            ctx->pMac = SymCryptAesCmacAlgorithm;
+        }
+        else if (EVP_MAC_is_a(mac, SN_kmac128))
+        {
+            ctx->macType = SCOSSL_MAC_TYPE_KMAC;
+            ctx->pMac = SymCryptKmac128Algorithm;
+        }
+        else if (EVP_MAC_is_a(mac, SN_kmac256))
+        {
+            ctx->macType = SCOSSL_MAC_TYPE_KMAC;
+            ctx->pMac = SymCryptKmac256Algorithm;
+        }
+        else
+        {
+            ERR_raise(ERR_LIB_PROV, PROV_R_INVALID_MAC);
+            goto cleanup;
+        }
+
+        // New MAC
+        ctx->pMac = NULL;
+    }
+
+    if ((p = OSSL_PARAM_locate_const(params, OSSL_KDF_PARAM_MODE)) != NULL)
+    {
+        const char *mode;
+        if (!OSSL_PARAM_get_utf8_string_ptr(p, &mode) ||
+            mode == NULL)
+        {
+            ERR_raise(ERR_LIB_PROV, PROV_R_FAILED_TO_GET_PARAMETER);
+            goto cleanup;
+        }
+
+        // SymCrypt only supports counter mode.
+        if (OPENSSL_strcasecmp(mode, "counter") != 0)
+        {
+            ERR_raise(ERR_LIB_PROV, PROV_R_INVALID_MODE);
+            goto cleanup;
+        }
+    }
+
+    if ((p = OSSL_PARAM_locate_const(params, OSSL_KDF_PARAM_DIGEST)) != NULL)
+    {
+        const char *mdName;
+        if (!OSSL_PARAM_get_utf8_string_ptr(p, &mdName) ||
+            mdName == NULL)
+        {
+            ERR_raise(ERR_LIB_PROV, PROV_R_FAILED_TO_GET_PARAMETER);
+            goto cleanup;
+        }
+
+        if ((md = EVP_MD_fetch(ctx->libCtx, mdName, propq)) == NULL)
+        {
+            ERR_raise(ERR_LIB_PROV, PROV_R_INVALID_DIGEST);
+            goto cleanup;
+        }
+
+        if (ctx->macType == SCOSSL_MAC_TYPE_HMAC &&
+            (ctx->pMac = scossl_get_symcrypt_hmac_algorithm(EVP_MD_type(md))) == NULL)
+        {
+            ERR_raise(ERR_LIB_PROV, PROV_R_INVALID_DIGEST);
+            goto cleanup;
+        }
+    }
+
+    if ((p = OSSL_PARAM_locate_const(params, OSSL_KDF_PARAM_CIPHER)) != NULL)
+    {
+        const char *cipherName;
+        if (!OSSL_PARAM_get_utf8_string_ptr(p, &cipherName))
+        {
+            ERR_raise(ERR_LIB_PROV, PROV_R_FAILED_TO_GET_PARAMETER);
+            goto cleanup;
+        }
+
+        if ((cipher = EVP_CIPHER_fetch(ctx->libCtx, cipherName, propq)) == NULL)
+        {
+            ERR_raise(ERR_LIB_PROV, PROV_R_INVALID_DIGEST);
+            goto cleanup;
+        }
+
+        if (ctx->macType == SCOSSL_MAC_TYPE_CMAC)
+        {
+            switch(EVP_CIPHER_type(cipher))
+            {
+            case NID_aes_128_cbc:
+                ctx->cbCmacKey = 16;
+                break;
+            case NID_aes_192_cbc:
+                ctx->cbCmacKey = 24;
+                break;
+            case NID_aes_256_cbc:
+                ctx->cbCmacKey = 32;
+                break;
+            default:
+                ERR_raise(ERR_LIB_PROV, PROV_R_INVALID_MODE);
+                goto cleanup;
+            }
+
+            if (ctx->pbKey != NULL &&
+                ctx->cbKey != ctx->cbCmacKey)
+            {
+                ERR_raise(ERR_LIB_PROV, PROV_R_INVALID_KEY_LENGTH);
+                goto cleanup;
+            }
+        }
+    }
+
+    // SymCrypt does not omit L or separator
+    if ((p = OSSL_PARAM_locate_const(params, OSSL_KDF_PARAM_KBKDF_USE_L)) != NULL)
+    {
+        int useL;
+
+        if (!OSSL_PARAM_get_int(p, &useL))
+        {
+            ERR_raise(ERR_LIB_PROV, PROV_R_FAILED_TO_GET_PARAMETER);
+            goto cleanup;
+        }
+
+        if (useL == 0)
+        {
+            ERR_raise(ERR_LIB_PROV, PROV_R_NOT_SUPPORTED);
+            goto cleanup;
+        }
+    }
+
+    if ((p = OSSL_PARAM_locate_const(params, OSSL_KDF_PARAM_KBKDF_USE_SEPARATOR)) != NULL)
+    {
+        int useSeparator;
+
+        if (!OSSL_PARAM_get_int(p, &useSeparator))
+        {
+            ERR_raise(ERR_LIB_PROV, PROV_R_FAILED_TO_GET_PARAMETER);
+            goto cleanup;
+        }
+
+        if (useSeparator == 0)
+        {
+            ERR_raise(ERR_LIB_PROV, PROV_R_NOT_SUPPORTED);
+            goto cleanup;
+        }
+    }
+
+    // SymCrypt always uses a 32-bit counter size
+    if ((p = OSSL_PARAM_locate_const(params, OSSL_KDF_PARAM_KBKDF_R)) != NULL)
+    {
+        int r;
+
+        if (!OSSL_PARAM_get_int(p, &r))
+        {
+            ERR_raise(ERR_LIB_PROV, PROV_R_FAILED_TO_GET_PARAMETER);
+            goto cleanup;
+        }
+
+        if (r != 32)
+        {
+            ERR_raise(ERR_LIB_PROV, PROV_R_NOT_SUPPORTED);
+            goto cleanup;
+        }
+    }
+
+    ret = SCOSSL_SUCCESS;
+
+cleanup:
+    OPENSSL_free(propq);
+    EVP_MAC_free(mac);
+    EVP_MD_free(md);
+    EVP_CIPHER_free(cipher);
+    return ret;
 }
 
 const OSSL_DISPATCH p_scossl_kbkdf_kdf_functions[] = {

--- a/SymCryptProvider/src/kdf/p_scossl_kbkdf.c
+++ b/SymCryptProvider/src/kdf/p_scossl_kbkdf.c
@@ -1,0 +1,84 @@
+//
+// Copyright (c) Microsoft Corporation. Licensed under the MIT license.
+//
+
+#include "p_scossl_base.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+typedef struct
+{
+    OSSL_LIB_CTX *libctx;
+
+} SCOSSL_PROV_KBKDF_CTX;
+
+static const OSSL_PARAM p_scossl_kbkdf_gettable_ctx_param_types[] = {
+    OSSL_PARAM_END};
+
+static const OSSL_PARAM p_scossl_kbkdf_settable_ctx_param_types[] = {
+    OSSL_PARAM_END};
+
+static SCOSSL_PROV_KBKDF_CTX *p_scossl_kbkdf_newctx(_In_ SCOSSL_PROVCTX *provctx)
+{
+
+}
+
+static void p_scossl_kbkdf_freectx(_Inout_ SCOSSL_PROV_KBKDF_CTX *ctx)
+{
+
+}
+
+static SCOSSL_PROV_KBKDF_CTX *p_scossl_kbkdf_dupctx(_In_ SCOSSL_PROV_KBKDF_CTX *ctx)
+{
+
+}
+
+static SCOSSL_STATUS p_scossl_kbkdf_reset(_Inout_ SCOSSL_PROV_KBKDF_CTX *ctx)
+{
+
+}
+
+static SCOSSL_STATUS p_scossl_kbkdf_derive(_In_ SCOSSL_PROV_KBKDF_CTX *ctx,
+                                          _Out_writes_bytes_(keylen) unsigned char *key, size_t keylen,
+                                          _In_ const OSSL_PARAM params[])
+{
+
+}
+
+static const OSSL_PARAM *p_scossl_kbkdf_gettable_ctx_params(ossl_unused void *ctx, ossl_unused void *provctx)
+{
+
+}
+
+static const OSSL_PARAM *p_scossl_kbkdf_settable_ctx_params(ossl_unused void *ctx, ossl_unused void *provctx)
+{
+
+}
+
+static SCOSSL_STATUS p_scossl_kbkdf_get_ctx_params(_In_ SCOSSL_PROV_KBKDF_CTX *ctx, _Inout_ OSSL_PARAM params[])
+{
+
+}
+
+static SCOSSL_STATUS p_scossl_kbkdf_set_ctx_params(_Inout_ SCOSSL_PROV_KBKDF_CTX *ctx, const _In_ OSSL_PARAM params[])
+{
+
+}
+
+const OSSL_DISPATCH p_scossl_kbkdf_kdf_functions[] = {
+    {OSSL_FUNC_KDF_NEWCTX, (void (*)(void))p_scossl_kbkdf_newctx},
+    {OSSL_FUNC_KDF_FREECTX, (void (*)(void))p_scossl_kbkdf_freectx},
+    {OSSL_FUNC_KDF_DUPCTX, (void (*)(void))p_scossl_kbkdf_dupctx},
+    {OSSL_FUNC_KDF_RESET, (void (*)(void))p_scossl_kbkdf_reset},
+    {OSSL_FUNC_KDF_DERIVE, (void (*)(void))p_scossl_kbkdf_derive},
+    {OSSL_FUNC_KDF_GETTABLE_CTX_PARAMS, (void (*)(void))p_scossl_kbkdf_gettable_ctx_params},
+    {OSSL_FUNC_KDF_SETTABLE_CTX_PARAMS, (void (*)(void))p_scossl_kbkdf_settable_ctx_params},
+    {OSSL_FUNC_KDF_GET_CTX_PARAMS, (void (*)(void))p_scossl_kbkdf_get_ctx_params},
+    {OSSL_FUNC_KDF_SET_CTX_PARAMS, (void (*)(void))p_scossl_kbkdf_set_ctx_params},
+    {0, NULL}};
+
+#ifdef __cplusplus
+}
+#endif

--- a/SymCryptProvider/src/mac/p_scossl_kmac.c
+++ b/SymCryptProvider/src/mac/p_scossl_kmac.c
@@ -2,7 +2,7 @@
 // Copyright (c) Microsoft Corporation. Licensed under the MIT license.
 //
 
-#include "scossl_helpers.h"
+#include "p_scossl_kmac.h"
 
 #include <openssl/core_names.h>
 #include <openssl/proverr.h>
@@ -14,44 +14,13 @@ extern "C" {
 #define KMAC_MAX_OUTPUT_LEN (0xFFFFFF / 8)
 #define KMAC_MAX_CUSTOM 512
 
-typedef union
-{
-    SYMCRYPT_KMAC128_EXPANDED_KEY kmac128Key;
-    SYMCRYPT_KMAC256_EXPANDED_KEY kmac256Key;
-} SCOSSL_KMAC_EXPANDED_KEY;
-
-typedef union
-{
-    SYMCRYPT_KMAC128_STATE kmac128State;
-    SYMCRYPT_KMAC256_STATE kmac256State;
-} SCOSSL_KMAC_STATE;
-
-typedef SYMCRYPT_ERROR (SYMCRYPT_CALL * PSYMCRYPT_KMAC_EXPAND_KEY_EX)
-                                        (SCOSSL_KMAC_EXPANDED_KEY *pExpandedKey, PCBYTE pbKey, SIZE_T cbKey,
-                                         PCBYTE  pbCustomizationString, SIZE_T  cbCustomizationString);
-typedef VOID (SYMCRYPT_CALL * PSYMCRYPT_KMAC_RESULT_EX) (SCOSSL_KMAC_STATE *pState, PVOID pbResult, SIZE_T cbResult);
-typedef VOID (SYMCRYPT_CALL * PSYMCRYPT_KMAC_EXTRACT) (SCOSSL_KMAC_STATE *pState, PVOID pbOutput, SIZE_T cbOutput, BOOLEAN bWipe);
-typedef VOID (SYMCRYPT_CALL * PSYMCRYPT_KMAC_KEY_COPY) (SCOSSL_KMAC_EXPANDED_KEY *pSrc, SCOSSL_KMAC_EXPANDED_KEY *pDst);
-typedef VOID (SYMCRYPT_CALL * PSYMCRYPT_KMAC_STATE_COPY) (SCOSSL_KMAC_STATE *pSrc, SCOSSL_KMAC_STATE *pDst);
-
-typedef struct
-{
-    PSYMCRYPT_KMAC_EXPAND_KEY_EX expandKeyExFunc;
-    PSYMCRYPT_KMAC_RESULT_EX     resultExFunc;
-    PSYMCRYPT_KMAC_EXTRACT       extractFunc;
-    PSYMCRYPT_KMAC_KEY_COPY      keyCopyFunc;
-    PSYMCRYPT_KMAC_STATE_COPY    stateCopyFunc;
-    SIZE_T blockSize;
-} SCOSSL_KMAC_EXTENSIONS;
-
 const SCOSSL_KMAC_EXTENSIONS SymCryptKmac128AlgorithmEx = {
     (PSYMCRYPT_KMAC_EXPAND_KEY_EX) SymCryptKmac128ExpandKeyEx,
     (PSYMCRYPT_KMAC_RESULT_EX)     SymCryptKmac128ResultEx,
     (PSYMCRYPT_KMAC_EXTRACT)       SymCryptKmac128Extract,
     (PSYMCRYPT_KMAC_KEY_COPY)      SymCryptKmac128KeyCopy,
     (PSYMCRYPT_KMAC_STATE_COPY)    SymCryptKmac128StateCopy,
-    SYMCRYPT_KMAC128_INPUT_BLOCK_SIZE
-};
+    SYMCRYPT_KMAC128_INPUT_BLOCK_SIZE};
 
 const SCOSSL_KMAC_EXTENSIONS SymCryptKmac256AlgorithmEx = {
     (PSYMCRYPT_KMAC_EXPAND_KEY_EX) SymCryptKmac256ExpandKeyEx,
@@ -59,8 +28,7 @@ const SCOSSL_KMAC_EXTENSIONS SymCryptKmac256AlgorithmEx = {
     (PSYMCRYPT_KMAC_EXTRACT)       SymCryptKmac256Extract,
     (PSYMCRYPT_KMAC_KEY_COPY)      SymCryptKmac256KeyCopy,
     (PSYMCRYPT_KMAC_STATE_COPY)    SymCryptKmac256StateCopy,
-    SYMCRYPT_KMAC256_INPUT_BLOCK_SIZE
-};
+    SYMCRYPT_KMAC256_INPUT_BLOCK_SIZE};
 
 typedef struct
 {

--- a/SymCryptProvider/src/mac/p_scossl_kmac.h
+++ b/SymCryptProvider/src/mac/p_scossl_kmac.h
@@ -2,16 +2,13 @@
 // Copyright (c) Microsoft Corporation. Licensed under the MIT license.
 //
 
-// Some of the structures defined here are used for KBKDF KMAC.
 #include "scossl_helpers.h"
 
 #ifdef __cplusplus
 extern "C" {
 #endif
 
-#define KMAC_MAX_OUTPUT_LEN (0xFFFFFF / 8)
-#define KMAC_MAX_CUSTOM 512
-
+// These types and constants are used by both KMAC and KBKDF using KMAC
 typedef union
 {
     SYMCRYPT_KMAC128_EXPANDED_KEY kmac128Key;

--- a/SymCryptProvider/src/mac/p_scossl_kmac.h
+++ b/SymCryptProvider/src/mac/p_scossl_kmac.h
@@ -1,0 +1,50 @@
+//
+// Copyright (c) Microsoft Corporation. Licensed under the MIT license.
+//
+
+// Some of the structures defined here are used for KBKDF KMAC.
+#include "scossl_helpers.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#define KMAC_MAX_OUTPUT_LEN (0xFFFFFF / 8)
+#define KMAC_MAX_CUSTOM 512
+
+typedef union
+{
+    SYMCRYPT_KMAC128_EXPANDED_KEY kmac128Key;
+    SYMCRYPT_KMAC256_EXPANDED_KEY kmac256Key;
+} SCOSSL_KMAC_EXPANDED_KEY;
+
+typedef union
+{
+    SYMCRYPT_KMAC128_STATE kmac128State;
+    SYMCRYPT_KMAC256_STATE kmac256State;
+} SCOSSL_KMAC_STATE;
+
+typedef SYMCRYPT_ERROR (SYMCRYPT_CALL * PSYMCRYPT_KMAC_EXPAND_KEY_EX)
+                                        (SCOSSL_KMAC_EXPANDED_KEY *pExpandedKey, PCBYTE pbKey, SIZE_T cbKey,
+                                         PCBYTE  pbCustomizationString, SIZE_T  cbCustomizationString);
+typedef VOID (SYMCRYPT_CALL * PSYMCRYPT_KMAC_RESULT_EX) (SCOSSL_KMAC_STATE *pState, PVOID pbResult, SIZE_T cbResult);
+typedef VOID (SYMCRYPT_CALL * PSYMCRYPT_KMAC_EXTRACT) (SCOSSL_KMAC_STATE *pState, PVOID pbOutput, SIZE_T cbOutput, BOOLEAN bWipe);
+typedef VOID (SYMCRYPT_CALL * PSYMCRYPT_KMAC_KEY_COPY) (SCOSSL_KMAC_EXPANDED_KEY *pSrc, SCOSSL_KMAC_EXPANDED_KEY *pDst);
+typedef VOID (SYMCRYPT_CALL * PSYMCRYPT_KMAC_STATE_COPY) (SCOSSL_KMAC_STATE *pSrc, SCOSSL_KMAC_STATE *pDst);
+
+typedef struct
+{
+    PSYMCRYPT_KMAC_EXPAND_KEY_EX expandKeyExFunc;
+    PSYMCRYPT_KMAC_RESULT_EX     resultExFunc;
+    PSYMCRYPT_KMAC_EXTRACT       extractFunc;
+    PSYMCRYPT_KMAC_KEY_COPY      keyCopyFunc;
+    PSYMCRYPT_KMAC_STATE_COPY    stateCopyFunc;
+    SIZE_T blockSize;
+} SCOSSL_KMAC_EXTENSIONS;
+
+extern const SCOSSL_KMAC_EXTENSIONS SymCryptKmac128AlgorithmEx;
+extern const SCOSSL_KMAC_EXTENSIONS SymCryptKmac256AlgorithmEx;
+
+#ifdef __cplusplus
+}
+#endif

--- a/SymCryptProvider/src/p_scossl_base.c
+++ b/SymCryptProvider/src/p_scossl_base.c
@@ -451,7 +451,7 @@ void CRYPTO_clear_free(void *ptr, size_t num, const char *file, int line)
     return c_CRYPTO_clear_free(ptr, num, file, line);
 }
 
-#if OPENSSL_VERSION_MINOR == 0
+#if OPENSSL_VERSION_MAJOR == 3 && OPENSSL_VERSION_MINOR == 0
 EVP_MD_CTX *EVP_MD_CTX_dup(const EVP_MD_CTX *in)
 {
     EVP_MD_CTX *out = EVP_MD_CTX_new();

--- a/SymCryptProvider/src/p_scossl_base.c
+++ b/SymCryptProvider/src/p_scossl_base.c
@@ -196,13 +196,15 @@ static const OSSL_ALGORITHM p_scossl_mac[] = {
     ALG_TABLE_END};
 
 // KDF
-extern const OSSL_DISPATCH p_scossl_sshkdf_kdf_functions[];
 extern const OSSL_DISPATCH p_scossl_hkdf_kdf_functions[];
+extern const OSSL_DISPATCH p_scossl_kbkdf_kdf_functions[];
+extern const OSSL_DISPATCH p_scossl_sshkdf_kdf_functions[];
 extern const OSSL_DISPATCH p_scossl_tls1prf_kdf_functions[];
 
 static const OSSL_ALGORITHM p_scossl_kdf[] = {
-    ALG("SSHKDF", p_scossl_sshkdf_kdf_functions),
     ALG("HKDF", p_scossl_hkdf_kdf_functions),
+    ALG("SSHKDF", p_scossl_sshkdf_kdf_functions),
+    ALG("KBKDF", p_scossl_kbkdf_kdf_functions),
     ALG("TLS1-PRF", p_scossl_tls1prf_kdf_functions),
     ALG_TABLE_END};
 


### PR DESCRIPTION
This PR adds the KBKDF (SP800-108) interface to the SymCrypt provider. The following are supported:
Counter mode:
- HMAC-SHA1
- HMAC-SHA256
- HMAC-SHA384
- HMAC-SHA512
- HMAC-SHA3-256
- HMAC-SHA3-384
- HMAC-SHA3-512
- CMAC-AES128
- CMAC-AES192
- CMAC-AES256

KMAC:
- KMAC128
- KMAC256