### PR TITLE
Fix CMake file to avoid installing libraries incorrect path

### DIFF
--- a/SymCryptEngine/dynamic/CMakeLists.txt
+++ b/SymCryptEngine/dynamic/CMakeLists.txt
@@ -57,7 +57,9 @@ target_link_libraries(scossl_dynamic PRIVATE scossl_common)
 target_link_libraries(scossl_dynamic PUBLIC ${SYMCRYPT_LIBRARY})
 target_link_libraries(scossl_dynamic PUBLIC ${OPENSSL_CRYPTO_LIBRARY})
 
-set(OPENSSL_ENGINES CACHE PATH "Path to OpenSSL engines" "${CMAKE_INSTALL_LIBDIR}/engines-1.1")
+if (NOT DEFINED OPENSSL_ENGINES)
+    set(OPENSSL_ENGINES "${CMAKE_INSTALL_LIBDIR}/engines-1.1" CACHE PATH "Path to OpenSSL engines")
+endif()
 
 # Install the engine to the OpenSSL engines directory
 # NB: this won't work if the distro has a custom engines directory that doesn't match


### PR DESCRIPTION
Avoids incorrectly parsing cmake file resulting in installing the shared libraries in: `/usr/CACHE;PATH;Path to OpenSSL engines;lib/engines-1.1/symcryptengine.so`

Thanks to Alejandro Hernandez Samaniego for making this change (I'm just copying it from an internal patch).