### PR TITLE
Various provider bugfixes

### DIFF
--- a/SymCryptProvider/src/ciphers/p_scossl_aes.c
+++ b/SymCryptProvider/src/ciphers/p_scossl_aes.c
@@ -283,6 +283,7 @@ static SCOSSL_STATUS p_scossl_aes_generic_update(_Inout_ SCOSSL_AES_CTX *ctx,
             // Return SCOSSL_FAILURE for any code that isn't SYMCRYPT_NO_ERROR
             SYMCRYPT_UINT32_MAP scErrorMap[1] = {
                 {SYMCRYPT_NO_ERROR, SCOSSL_SUCCESS}};
+            SIZE_T outlPadded;
 
             switch (ctx->tlsVersion)
             {
@@ -296,7 +297,7 @@ static SCOSSL_STATUS p_scossl_aes_generic_update(_Inout_ SCOSSL_AES_CTX *ctx,
                 *outl -= SYMCRYPT_AES_BLOCK_SIZE;
                 __attribute__ ((fallthrough));
             case TLS1_VERSION:
-                SIZE_T outlPadded = *outl;
+                outlPadded = *outl;
 
                 if (ctx->tlsMacSize > *outl)
                 {

--- a/SymCryptProvider/src/p_scossl_base.c
+++ b/SymCryptProvider/src/p_scossl_base.c
@@ -381,6 +381,9 @@ static void p_scossl_start_keysinuse(_In_ const OSSL_CORE_HANDLE *handle)
         OSSL_PARAM_utf8_ptr(CONF_KEYSINUSE_LOGGING_DELAY, &confLoggingDelay, 0),
         OSSL_PARAM_END};
 
+    // Config related errors shouldn't surface to caller
+    ERR_set_mark();
+
     if (core_get_params(handle, keysinuseParams) &&
         confEnabled != NULL)
     {
@@ -458,6 +461,8 @@ static void p_scossl_start_keysinuse(_In_ const OSSL_CORE_HANDLE *handle)
 
         p_scossl_keysinuse_init();
     }
+
+    ERR_pop_to_mark();
 }
 #endif
 


### PR DESCRIPTION
- Declare variable outside of case statement for compiler compatibility.
- Properly export 64-bit RSA public exponents.
- Move `keysinuseLock` initialization in copy context functions.
- Initialize `keysinuseLock` for context created in keygen functions.
- Suppress errors from the config API when loading keysinuse. These errors can be safely ignored by callers, but can cause failures at the SSL layer if they're left on the error stack.