### PR TITLE
Behavior fixes for API compatability

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.13.0)
 
 project(SymCrypt-OpenSSL
-    VERSION 1.5.0
+    VERSION 1.5.1
     DESCRIPTION "The SymCrypt engine for OpenSSL (SCOSSL)"
     HOMEPAGE_URL "https://github.com/microsoft/SymCrypt-OpenSSL")
 

--- a/ScosslCommon/src/scossl_ecc.c
+++ b/ScosslCommon/src/scossl_ecc.c
@@ -515,11 +515,11 @@ cleanup:
 }
 
 // Return the max length of the DER encoded signature
-// 2 * (private key length) + 7 DER encoding header bytes
+// 2 * (private key length) + DER encoding header bytes
 _Use_decl_annotations_
 SIZE_T scossl_ecdsa_size(PCSYMCRYPT_ECURVE curve)
 {
-    return 2*SymCryptEcurveSizeofScalarMultiplier(curve) + 7;
+    return 2*SymCryptEcurveSizeofScalarMultiplier(curve) + 8;
 }
 
 _Use_decl_annotations_

--- a/SymCryptProvider/src/ciphers/p_scossl_aes.c
+++ b/SymCryptProvider/src/ciphers/p_scossl_aes.c
@@ -248,6 +248,7 @@ static SCOSSL_STATUS p_scossl_aes_generic_block_update(_Inout_ SCOSSL_AES_CTX *c
 
     if (inl == 0)
     {
+        *outl = 0;
         return SCOSSL_SUCCESS;
     }
 
@@ -428,6 +429,7 @@ static SCOSSL_STATUS p_scossl_aes_generic_stream_update(_Inout_ SCOSSL_AES_CTX *
 {
     if (inl == 0)
     {
+        *outl = 0;
         return SCOSSL_SUCCESS;
     }
 
@@ -769,10 +771,7 @@ static SCOSSL_STATUS scossl_aes_cbc_cipher(_Inout_ SCOSSL_AES_CTX *ctx,
         return SCOSSL_FAILURE;
     }
 
-    if (outl != NULL)
-    {
-        *outl = inl;
-    }
+    *outl = inl;
 
     if (ctx->encrypt)
     {
@@ -796,10 +795,7 @@ static SCOSSL_STATUS scossl_aes_ecb_cipher(_Inout_ SCOSSL_AES_CTX *ctx,
         return SCOSSL_FAILURE;
     }
 
-    if (outl != NULL)
-    {
-        *outl = inl;
-    }
+    *outl = inl;
 
     if (ctx->encrypt)
     {
@@ -824,10 +820,7 @@ static SCOSSL_STATUS p_scossl_aes_cfb_cipher_internal(_Inout_ SCOSSL_AES_CTX *ct
         return SCOSSL_FAILURE;
     }
 
-    if (outl != NULL)
-    {
-        *outl = inl;
-    }
+    *outl = inl;
 
     if (ctx->encrypt)
     {
@@ -860,10 +853,7 @@ static SCOSSL_STATUS scossl_aes_cfb_cipher(_Inout_ SCOSSL_AES_CTX *ctx,
     SIZE_T cbInFullBlocks;
     SIZE_T cbInRemaining;
 
-    if (outl != NULL)
-    {
-        *outl = inl;
-    }
+    *outl = inl;
 
     if (ctx->cbBuf > 0)
     {

--- a/SymCryptProvider/src/ciphers/p_scossl_aes.c
+++ b/SymCryptProvider/src/ciphers/p_scossl_aes.c
@@ -820,7 +820,10 @@ static SCOSSL_STATUS p_scossl_aes_cfb_cipher_internal(_Inout_ SCOSSL_AES_CTX *ct
         return SCOSSL_FAILURE;
     }
 
-    *outl = inl;
+    if (outl != NULL)
+    {
+        *outl = inl;
+    }
 
     if (ctx->encrypt)
     {

--- a/SymCryptProvider/src/ciphers/p_scossl_aes.c
+++ b/SymCryptProvider/src/ciphers/p_scossl_aes.c
@@ -248,7 +248,6 @@ static SCOSSL_STATUS p_scossl_aes_generic_block_update(_Inout_ SCOSSL_AES_CTX *c
 
     if (inl == 0)
     {
-        *outl = 0;
         return SCOSSL_SUCCESS;
     }
 
@@ -762,7 +761,7 @@ static SCOSSL_STATUS p_scossl_aes_generic_set_ctx_params(_Inout_ SCOSSL_AES_CTX 
 }
 
 static SCOSSL_STATUS scossl_aes_cbc_cipher(_Inout_ SCOSSL_AES_CTX *ctx,
-                                           _Out_writes_bytes_opt_(*outl) unsigned char *out, _Out_ size_t *outl, size_t outsize,
+                                           _Out_writes_bytes_opt_(*outl) unsigned char *out, _Out_opt_ size_t *outl, size_t outsize,
                                            _In_reads_bytes_(inl) const unsigned char *in, size_t inl)
 {
     if (outsize < inl)
@@ -771,7 +770,10 @@ static SCOSSL_STATUS scossl_aes_cbc_cipher(_Inout_ SCOSSL_AES_CTX *ctx,
         return SCOSSL_FAILURE;
     }
 
-    *outl = inl;
+    if (outl != NULL)
+    {
+        *outl = inl;
+    }
 
     if (ctx->encrypt)
     {
@@ -786,7 +788,7 @@ static SCOSSL_STATUS scossl_aes_cbc_cipher(_Inout_ SCOSSL_AES_CTX *ctx,
 }
 
 static SCOSSL_STATUS scossl_aes_ecb_cipher(_Inout_ SCOSSL_AES_CTX *ctx,
-                                           _Out_writes_bytes_opt_(*outl) unsigned char *out, _Out_ size_t *outl, size_t outsize,
+                                           _Out_writes_bytes_opt_(*outl) unsigned char *out, _Out_opt_ size_t *outl, size_t outsize,
                                            _In_reads_bytes_(inl) const unsigned char *in, size_t inl)
 {
     if (outsize < inl)
@@ -795,7 +797,10 @@ static SCOSSL_STATUS scossl_aes_ecb_cipher(_Inout_ SCOSSL_AES_CTX *ctx,
         return SCOSSL_FAILURE;
     }
 
-    *outl = inl;
+    if (outl != NULL)
+    {
+        *outl = inl;
+    }
 
     if (ctx->encrypt)
     {
@@ -847,7 +852,7 @@ static SCOSSL_STATUS p_scossl_aes_cfb_cipher_internal(_Inout_ SCOSSL_AES_CTX *ct
 // previous call, the remaining space in the buffer is filled and
 // encrypted/decrypted with the previous chaining value before continuing.
 static SCOSSL_STATUS scossl_aes_cfb_cipher(_Inout_ SCOSSL_AES_CTX *ctx,
-                                           _Out_writes_bytes_opt_(*outl) unsigned char *out, _Out_ size_t *outl, size_t outsize,
+                                           _Out_writes_bytes_opt_(*outl) unsigned char *out, _Out_opt_ size_t *outl, size_t outsize,
                                            _In_reads_bytes_(inl) const unsigned char *in, size_t inl)
 {
     BYTE pbPartialBufOut[SYMCRYPT_AES_BLOCK_SIZE];
@@ -856,7 +861,10 @@ static SCOSSL_STATUS scossl_aes_cfb_cipher(_Inout_ SCOSSL_AES_CTX *ctx,
     SIZE_T cbInFullBlocks;
     SIZE_T cbInRemaining;
 
-    *outl = inl;
+    if (outl != NULL)
+    {
+        *outl = inl;
+    }
 
     if (ctx->cbBuf > 0)
     {

--- a/SymCryptProvider/src/ciphers/p_scossl_aes_xts.c
+++ b/SymCryptProvider/src/ciphers/p_scossl_aes_xts.c
@@ -123,7 +123,7 @@ static SCOSSL_STATUS p_scossl_aes_xts_cipher(SCOSSL_AES_XTS_CTX *ctx,
                                              _Out_writes_bytes_(*outl) unsigned char *out, _Out_ size_t *outl, size_t outsize,
                                              _In_reads_bytes_(inl) const unsigned char *in, size_t inl)
 {
-    if( inl < SYMCRYPT_AES_BLOCK_SIZE )
+    if (inl < SYMCRYPT_AES_BLOCK_SIZE)
     {
         ERR_raise(ERR_LIB_PROV, PROV_R_INVALID_INPUT_LENGTH);
         return SCOSSL_FAILURE;

--- a/SymCryptProvider/src/keyexch/p_scossl_dh.c
+++ b/SymCryptProvider/src/keyexch/p_scossl_dh.c
@@ -252,13 +252,19 @@ static SCOSSL_STATUS p_scossl_dh_plain_derive(_In_ SCOSSL_DH_CTX *ctx,
 
     if (secret != NULL)
     {
+        if (outlen < cbAgreedSecret)
+        {
+            ERR_raise(ERR_LIB_PROV, PROV_R_OUTPUT_BUFFER_TOO_SMALL);
+            return SCOSSL_FAILURE;
+        }
+
         scError = SymCryptDhSecretAgreement(
             ctx->provKey->keyCtx->dlkey,
             ctx->peerProvKey->keyCtx->dlkey,
             SYMCRYPT_NUMBER_FORMAT_MSB_FIRST,
             0,
             secret,
-            outlen);
+            cbAgreedSecret);
         if (scError != SYMCRYPT_NO_ERROR)
         {
             ERR_raise(ERR_LIB_PROV, ERR_R_INTERNAL_ERROR);

--- a/SymCryptProvider/src/keyexch/p_scossl_ecdh.c
+++ b/SymCryptProvider/src/keyexch/p_scossl_ecdh.c
@@ -107,19 +107,19 @@ static SCOSSL_STATUS p_scossl_ecdh_derive(_In_ SCOSSL_ECDH_CTX *ctx,
     if (ctx == NULL || secretlen == NULL)
     {
         ERR_raise(ERR_LIB_PROV, ERR_R_PASSED_NULL_PARAMETER);
-        goto cleanup;
+        return SCOSSL_FAILURE;
     }
 
     if (ctx->keyCtx == NULL || ctx->peerKeyCtx == NULL) {
         ERR_raise(ERR_LIB_PROV, PROV_R_MISSING_KEY);
-        goto cleanup;
+        return SCOSSL_FAILURE;
     }
 
     cbSecretBuf = SymCryptEckeySizeofPublicKey(ctx->keyCtx->key, SYMCRYPT_ECPOINT_FORMAT_X);
     if (secret == NULL)
     {
         *secretlen = cbSecretBuf;
-        goto cleanup;
+        return SCOSSL_SUCCESS;
     }
 
     if (outlen < cbSecretBuf)


### PR DESCRIPTION
This PR addresses behavior fixes for compatibility issues found when calling OpenSSL with the SymCryp provider though different wrapper libraries. These are behavior differences to make the SymCrypt provider act more like the default provider.
- Allow larger/smaller output sizes for ECDH secret. If the output size is smaller than the output of `SymCryptEcDhSecretAgreement`, the secret is truncated.
- Allow larger output sizes for DH secret.
- When `inl` passed to AES cipher update is zero, `*outl` should always be set to zero.
- Always return a sufficiently large buffer size for ECDSA digest sign