### PR TITLE
Correct log messages to say hash where they said Hmac

### DIFF
--- a/ScosslCommon/src/scossl_rsa.c
+++ b/ScosslCommon/src/scossl_rsa.c
@@ -121,15 +121,15 @@ SCOSSL_STATUS scossl_rsa_pkcs1_sign(PSYMCRYPT_RSAKEY key, int mdnid,
     {
     case NID_md5_sha1:
         SCOSSL_LOG_INFO(SCOSSL_ERR_F_RSA_SIGN, SCOSSL_ERR_R_NOT_FIPS_ALGORITHM,
-                        "Using digest algorithm MD5+SHA1 which is not FIPS compliant");
+                        "Using hash algorithm MD5+SHA1 which is not FIPS compliant");
         break;
     case NID_md5:
         SCOSSL_LOG_INFO(SCOSSL_ERR_F_RSA_SIGN, SCOSSL_ERR_R_NOT_FIPS_ALGORITHM,
-                        "Using digest algorithm MD5 which is not FIPS compliant");
+                        "Using hash algorithm MD5 which is not FIPS compliant");
         break;
     case NID_sha1:
         SCOSSL_LOG_INFO(SCOSSL_ERR_F_RSA_SIGN, SCOSSL_ERR_R_NOT_FIPS_ALGORITHM,
-                        "Using digest algorithm SHA1 which is not FIPS compliant");
+                        "Using hash algorithm SHA1 which is not FIPS compliant");
         break;
     }
 
@@ -183,15 +183,15 @@ SCOSSL_STATUS scossl_rsa_pkcs1_verify(PSYMCRYPT_RSAKEY key, int mdnid,
     {
     case NID_md5_sha1:
         SCOSSL_LOG_INFO(SCOSSL_ERR_F_RSA_VERIFY, SCOSSL_ERR_R_NOT_FIPS_ALGORITHM,
-                        "Using digest algorithm MD5+SHA1 which is not FIPS compliant");
+                        "Using hash algorithm MD5+SHA1 which is not FIPS compliant");
         break;
     case NID_md5:
         SCOSSL_LOG_INFO(SCOSSL_ERR_F_RSA_VERIFY, SCOSSL_ERR_R_NOT_FIPS_ALGORITHM,
-                        "Using digest algorithm MD5 which is not FIPS compliant");
+                        "Using hash algorithm MD5 which is not FIPS compliant");
         break;
     case NID_sha1:
         SCOSSL_LOG_INFO(SCOSSL_ERR_F_RSA_VERIFY, SCOSSL_ERR_R_NOT_FIPS_ALGORITHM,
-                        "Using digest algorithm SHA1 which is not FIPS compliant");
+                        "Using hash algorithm SHA1 which is not FIPS compliant");
         break;
     }
 
@@ -287,12 +287,12 @@ SCOSSL_STATUS scossl_rsapss_sign(PSYMCRYPT_RSAKEY key, int mdnid, int cbSalt,
     if (mdnid == NID_md5)
     {
         SCOSSL_LOG_INFO(SCOSSL_ERR_F_RSAPSS_SIGN, SCOSSL_ERR_R_NOT_FIPS_ALGORITHM,
-                        "Using digest algorithm MD5 which is not FIPS compliant");
+                        "Using hash algorithm MD5 which is not FIPS compliant");
     }
     else if (mdnid == NID_sha1)
     {
         SCOSSL_LOG_INFO(SCOSSL_ERR_F_RSAPSS_SIGN, SCOSSL_ERR_R_NOT_FIPS_ALGORITHM,
-                        "Using digest algorithm SHA1 which is not FIPS compliant");
+                        "Using hash algorithm SHA1 which is not FIPS compliant");
     }
 
     if (cbHashValue != expectedHashLength)
@@ -381,12 +381,12 @@ SCOSSL_STATUS scossl_rsapss_verify(PSYMCRYPT_RSAKEY key, int mdnid, int cbSalt,
     if (mdnid == NID_md5)
     {
         SCOSSL_LOG_INFO(SCOSSL_ERR_F_RSAPSS_VERIFY, SCOSSL_ERR_R_NOT_FIPS_ALGORITHM,
-                        "Using digest algorithm MD5 which is not FIPS compliant");
+                        "Using hash algorithm MD5 which is not FIPS compliant");
     }
     else if (mdnid == NID_sha1)
     {
         SCOSSL_LOG_INFO(SCOSSL_ERR_F_RSAPSS_VERIFY, SCOSSL_ERR_R_NOT_FIPS_ALGORITHM,
-                        "Using digest algorithm SHA1 which is not FIPS compliant");
+                        "Using hash algorithm SHA1 which is not FIPS compliant");
     }
 
     scError = SymCryptRsaPssVerify(

--- a/ScosslCommon/src/scossl_rsa.c
+++ b/ScosslCommon/src/scossl_rsa.c
@@ -121,15 +121,15 @@ SCOSSL_STATUS scossl_rsa_pkcs1_sign(PSYMCRYPT_RSAKEY key, int mdnid,
     {
     case NID_md5_sha1:
         SCOSSL_LOG_INFO(SCOSSL_ERR_F_RSA_SIGN, SCOSSL_ERR_R_NOT_FIPS_ALGORITHM,
-                        "Using Hmac algorithm MD5+SHA1 which is not FIPS compliant");
+                        "Using digest algorithm MD5+SHA1 which is not FIPS compliant");
         break;
     case NID_md5:
         SCOSSL_LOG_INFO(SCOSSL_ERR_F_RSA_SIGN, SCOSSL_ERR_R_NOT_FIPS_ALGORITHM,
-                        "Using Hmac algorithm MD5 which is not FIPS compliant");
+                        "Using digest algorithm MD5 which is not FIPS compliant");
         break;
     case NID_sha1:
         SCOSSL_LOG_INFO(SCOSSL_ERR_F_RSA_SIGN, SCOSSL_ERR_R_NOT_FIPS_ALGORITHM,
-                        "Using Hmac algorithm SHA1 which is not FIPS compliant");
+                        "Using digest algorithm SHA1 which is not FIPS compliant");
         break;
     }
 
@@ -183,15 +183,15 @@ SCOSSL_STATUS scossl_rsa_pkcs1_verify(PSYMCRYPT_RSAKEY key, int mdnid,
     {
     case NID_md5_sha1:
         SCOSSL_LOG_INFO(SCOSSL_ERR_F_RSA_VERIFY, SCOSSL_ERR_R_NOT_FIPS_ALGORITHM,
-                        "Using Hmac algorithm MD5+SHA1 which is not FIPS compliant");
+                        "Using digest algorithm MD5+SHA1 which is not FIPS compliant");
         break;
     case NID_md5:
         SCOSSL_LOG_INFO(SCOSSL_ERR_F_RSA_VERIFY, SCOSSL_ERR_R_NOT_FIPS_ALGORITHM,
-                        "Using Hmac algorithm MD5 which is not FIPS compliant");
+                        "Using digest algorithm MD5 which is not FIPS compliant");
         break;
     case NID_sha1:
         SCOSSL_LOG_INFO(SCOSSL_ERR_F_RSA_VERIFY, SCOSSL_ERR_R_NOT_FIPS_ALGORITHM,
-                        "Using Hmac algorithm SHA1 which is not FIPS compliant");
+                        "Using digest algorithm SHA1 which is not FIPS compliant");
         break;
     }
 
@@ -287,12 +287,12 @@ SCOSSL_STATUS scossl_rsapss_sign(PSYMCRYPT_RSAKEY key, int mdnid, int cbSalt,
     if (mdnid == NID_md5)
     {
         SCOSSL_LOG_INFO(SCOSSL_ERR_F_RSAPSS_SIGN, SCOSSL_ERR_R_NOT_FIPS_ALGORITHM,
-                        "Using Hmac algorithm MD5 which is not FIPS compliant");
+                        "Using digest algorithm MD5 which is not FIPS compliant");
     }
     else if (mdnid == NID_sha1)
     {
         SCOSSL_LOG_INFO(SCOSSL_ERR_F_RSAPSS_SIGN, SCOSSL_ERR_R_NOT_FIPS_ALGORITHM,
-                        "Using Hmac algorithm SHA1 which is not FIPS compliant");
+                        "Using digest algorithm SHA1 which is not FIPS compliant");
     }
 
     if (cbHashValue != expectedHashLength)
@@ -381,12 +381,12 @@ SCOSSL_STATUS scossl_rsapss_verify(PSYMCRYPT_RSAKEY key, int mdnid, int cbSalt,
     if (mdnid == NID_md5)
     {
         SCOSSL_LOG_INFO(SCOSSL_ERR_F_RSAPSS_VERIFY, SCOSSL_ERR_R_NOT_FIPS_ALGORITHM,
-                        "Using Hmac algorithm MD5 which is not FIPS compliant");
+                        "Using digest algorithm MD5 which is not FIPS compliant");
     }
     else if (mdnid == NID_sha1)
     {
         SCOSSL_LOG_INFO(SCOSSL_ERR_F_RSAPSS_VERIFY, SCOSSL_ERR_R_NOT_FIPS_ALGORITHM,
-                        "Using Hmac algorithm SHA1 which is not FIPS compliant");
+                        "Using digest algorithm SHA1 which is not FIPS compliant");
     }
 
     scError = SymCryptRsaPssVerify(

--- a/ScosslCommon/src/scossl_tls1prf.c
+++ b/ScosslCommon/src/scossl_tls1prf.c
@@ -90,7 +90,7 @@ SCOSSL_STATUS scossl_tls1prf_derive(SCOSSL_TLS1_PRF_CTX *ctx,
     {
         // Special case to use TlsPrf1_1 to handle md5_sha1
         SCOSSL_LOG_INFO(SCOSSL_ERR_F_TLS1PRF_DERIVE, SCOSSL_ERR_R_NOT_FIPS_ALGORITHM,
-                        "Using digest algorithm MD5+SHA1 which is not FIPS compliant");
+                        "Using hash algorithm MD5+SHA1 which is not FIPS compliant");
 
         scError = SymCryptTlsPrf1_1(
             ctx->pbSecret, ctx->cbSecret,

--- a/ScosslCommon/src/scossl_tls1prf.c
+++ b/ScosslCommon/src/scossl_tls1prf.c
@@ -90,7 +90,7 @@ SCOSSL_STATUS scossl_tls1prf_derive(SCOSSL_TLS1_PRF_CTX *ctx,
     {
         // Special case to use TlsPrf1_1 to handle md5_sha1
         SCOSSL_LOG_INFO(SCOSSL_ERR_F_TLS1PRF_DERIVE, SCOSSL_ERR_R_NOT_FIPS_ALGORITHM,
-                        "Using Hmac algorithm MD5+SHA1 which is not FIPS compliant");
+                        "Using digest algorithm MD5+SHA1 which is not FIPS compliant");
 
         scError = SymCryptTlsPrf1_1(
             ctx->pbSecret, ctx->cbSecret,


### PR DESCRIPTION
Some log messages were indicating that HMAC algorithms were not FIPS compliant, when really they were referring to the digest algorithm. This corrects the log messages.