### PR TITLE
Remove GCM nonce restriction comment

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,9 +42,8 @@ Note that just because an algorithm is FIPS certifiable, does not mean it is rec
 
 ## Known cases where SCOSSL will fail rather than fallback to default OpenSSL
 
-1. Use of an AES-GCM IV which is not 12-bytes (96-bits)
-2. Use of unsupported digests in RSA signatures, TLS PRF, and HMAC
-3. Use of multi-prime (more than 2-prime) RSA
+1. Use of unsupported digests in RSA signatures, TLS PRF, and HMAC
+2. Use of multi-prime (more than 2-prime) RSA
 
 ## Versioning and Servicing
 


### PR DESCRIPTION
In the README, it is mentioned that GCM IVs are restricted to 96 bits. It looks like that restriction was removed as part of https://github.com/microsoft/SymCrypt-OpenSSL/pull/80/.