### PR TITLE
Fix engine behavior

### DIFF
--- a/ScosslCommon/src/scossl_helpers.c
+++ b/ScosslCommon/src/scossl_helpers.c
@@ -18,7 +18,7 @@ extern "C" {
 #define SCOSSL_LOG_LEVEL_PREFIX_DEBUG       "DEBUG"
 
 // Level of tracing that is output to stderr / log file
-static int _traceLogLevel = SCOSSL_LOG_LEVEL_INFO;
+static int _traceLogLevel = SCOSSL_LOG_LEVEL_OFF;
 static char *_traceLogFilename = NULL;
 static FILE *_traceLogFile = NULL;
 

--- a/SymCryptEngine/src/e_scossl_rsa.c
+++ b/SymCryptEngine/src/e_scossl_rsa.c
@@ -114,7 +114,7 @@ SCOSSL_RETURNLENGTH e_scossl_rsa_priv_dec(int flen, _In_reads_bytes_(flen) const
             "Unsupported Padding: %d. Forwarding to OpenSSL. Size: %d.", padding, flen);
         ossl_rsa_meth = RSA_PKCS1_OpenSSL();
         pfn_rsa_meth_priv_dec = RSA_meth_get_priv_dec(ossl_rsa_meth);
-        if( !pfn_rsa_meth_priv_dec )
+        if( pfn_rsa_meth_priv_dec )
         {
             ret = pfn_rsa_meth_priv_dec(flen, from, to, rsa, padding);
         }


### PR DESCRIPTION
- Fixes RSA decrypt fallback when padding is unsupported
- Turn default logging level to off to avoid printing unnecessary errors to stdout