### PR TITLE
HKDF and TLS1-PRF EVP_PKEY key exchange wrapper

### DIFF
--- a/EvpTestRecipes/3.0/evppkey_kdf_hkdf.txt
+++ b/EvpTestRecipes/3.0/evppkey_kdf_hkdf.txt
@@ -1,0 +1,195 @@
+#
+# Copyright 2001-2020 The OpenSSL Project Authors. All Rights Reserved.
+#
+# Licensed under the Apache License 2.0 (the "License").  You may not use
+# this file except in compliance with the License.  You can obtain a copy
+# in the file LICENSE in the source distribution or at
+# https://www.openssl.org/source/license.html
+
+# Tests start with one of these keywords
+#       Cipher Decrypt Derive Digest Encoding KDF MAC PBE
+#       PrivPubKeyPair Sign Verify VerifyRecover
+# and continue until a blank line. Lines starting with a pound sign are ignored.
+
+Title = HKDF tests (from RFC5869 test vectors) using PKEYKDF
+
+PKEYKDF = HKDF
+Ctrl.md = md:SHA256
+Ctrl.IKM = hexkey:0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b
+Ctrl.salt = hexsalt:000102030405060708090a0b0c
+Ctrl.info = hexinfo:f0f1f2f3f4f5f6f7f8f9
+Output = 3cb25f25faacd57a90434f64d0362f2a2d2d0a90cf1a5a4c5db02d56ecc4c5bf34007208d5b887185865
+
+PKEYKDF = HKDF
+Ctrl.mode = mode:EXTRACT_ONLY
+Ctrl.md = md:SHA256
+Ctrl.IKM = hexkey:0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b
+Ctrl.salt = hexsalt:000102030405060708090a0b0c
+Output = 077709362c2e32df0ddc3f0dc47bba6390b6c73bb50f9c3122ec844ad7c2b3e5
+
+PKEYKDF = HKDF
+Ctrl.mode = mode:EXPAND_ONLY
+Ctrl.md = md:SHA256
+Ctrl.IKM = hexkey:077709362c2e32df0ddc3f0dc47bba6390b6c73bb50f9c3122ec844ad7c2b3e5
+Ctrl.info = hexinfo:f0f1f2f3f4f5f6f7f8f9
+Output = 3cb25f25faacd57a90434f64d0362f2a2d2d0a90cf1a5a4c5db02d56ecc4c5bf34007208d5b887185865
+
+PKEYKDF = HKDF
+Ctrl.md = md:SHA256
+Ctrl.IKM = hexkey:000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f202122232425262728292a2b2c2d2e2f303132333435363738393a3b3c3d3e3f404142434445464748494a4b4c4d4e4f
+Ctrl.salt = hexsalt:606162636465666768696a6b6c6d6e6f707172737475767778797a7b7c7d7e7f808182838485868788898a8b8c8d8e8f909192939495969798999a9b9c9d9e9fa0a1a2a3a4a5a6a7a8a9aaabacadaeaf
+Ctrl.info = hexinfo:b0b1b2b3b4b5b6b7b8b9babbbcbdbebfc0c1c2c3c4c5c6c7c8c9cacbcccdcecfd0d1d2d3d4d5d6d7d8d9dadbdcdddedfe0e1e2e3e4e5e6e7e8e9eaebecedeeeff0f1f2f3f4f5f6f7f8f9fafbfcfdfeff
+Output = b11e398dc80327a1c8e7f78c596a49344f012eda2d4efad8a050cc4c19afa97c59045a99cac7827271cb41c65e590e09da3275600c2f09b8367793a9aca3db71cc30c58179ec3e87c14c01d5c1f3434f1d87
+
+PKEYKDF = HKDF
+Ctrl.mode = mode:EXTRACT_ONLY
+Ctrl.md = md:SHA256
+Ctrl.IKM = hexkey:000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f202122232425262728292a2b2c2d2e2f303132333435363738393a3b3c3d3e3f404142434445464748494a4b4c4d4e4f
+Ctrl.salt = hexsalt:606162636465666768696a6b6c6d6e6f707172737475767778797a7b7c7d7e7f808182838485868788898a8b8c8d8e8f909192939495969798999a9b9c9d9e9fa0a1a2a3a4a5a6a7a8a9aaabacadaeaf
+Output = 06a6b88c5853361a06104c9ceb35b45cef760014904671014a193f40c15fc244
+
+PKEYKDF = HKDF
+Ctrl.mode = mode:EXPAND_ONLY
+Ctrl.md = md:SHA256
+Ctrl.IKM = hexkey:06a6b88c5853361a06104c9ceb35b45cef760014904671014a193f40c15fc244
+Ctrl.info = hexinfo:b0b1b2b3b4b5b6b7b8b9babbbcbdbebfc0c1c2c3c4c5c6c7c8c9cacbcccdcecfd0d1d2d3d4d5d6d7d8d9dadbdcdddedfe0e1e2e3e4e5e6e7e8e9eaebecedeeeff0f1f2f3f4f5f6f7f8f9fafbfcfdfeff
+Output = b11e398dc80327a1c8e7f78c596a49344f012eda2d4efad8a050cc4c19afa97c59045a99cac7827271cb41c65e590e09da3275600c2f09b8367793a9aca3db71cc30c58179ec3e87c14c01d5c1f3434f1d87
+
+PKEYKDF = HKDF
+Ctrl.md = md:SHA256
+Ctrl.IKM = hexkey:0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b
+Ctrl.salt = salt:
+Ctrl.info = info:
+Output = 8da4e775a563c18f715f802a063c5a31b8a11f5c5ee1879ec3454e5f3c738d2d9d201395faa4b61a96c8
+
+PKEYKDF = HKDF
+Ctrl.mode = mode:EXTRACT_ONLY
+Ctrl.md = md:SHA256
+Ctrl.IKM = hexkey:0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b
+Ctrl.salt = salt:
+Ctrl.info = info:
+Output = 19ef24a32c717b167f33a91d6f648bdf96596776afdb6377ac434c1c293ccb04
+
+PKEYKDF = HKDF
+Ctrl.mode = mode:EXPAND_ONLY
+Ctrl.md = md:SHA256
+Ctrl.IKM = hexkey:19ef24a32c717b167f33a91d6f648bdf96596776afdb6377ac434c1c293ccb04
+Ctrl.info = info:
+Output = 8da4e775a563c18f715f802a063c5a31b8a11f5c5ee1879ec3454e5f3c738d2d9d201395faa4b61a96c8
+
+PKEYKDF = HKDF
+Ctrl.md = md:SHA1
+Ctrl.IKM = hexkey:0b0b0b0b0b0b0b0b0b0b0b
+Ctrl.salt = hexsalt:000102030405060708090a0b0c
+Ctrl.info = hexinfo:f0f1f2f3f4f5f6f7f8f9
+Output = 085a01ea1b10f36933068b56efa5ad81a4f14b822f5b091568a9cdd4f155fda2c22e422478d305f3f896
+
+PKEYKDF = HKDF
+Ctrl.mode = mode:EXTRACT_ONLY
+Ctrl.md = md:SHA1
+Ctrl.IKM = hexkey:0b0b0b0b0b0b0b0b0b0b0b
+Ctrl.salt = hexsalt:000102030405060708090a0b0c
+Output = 9b6c18c432a7bf8f0e71c8eb88f4b30baa2ba243
+
+PKEYKDF = HKDF
+Ctrl.mode = mode:EXPAND_ONLY
+Ctrl.md = md:SHA1
+Ctrl.IKM = hexkey:9b6c18c432a7bf8f0e71c8eb88f4b30baa2ba243
+Ctrl.info = hexinfo:f0f1f2f3f4f5f6f7f8f9
+Output = 085a01ea1b10f36933068b56efa5ad81a4f14b822f5b091568a9cdd4f155fda2c22e422478d305f3f896
+
+PKEYKDF = HKDF
+Ctrl.md = md:SHA1
+Ctrl.IKM = hexkey:000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f202122232425262728292a2b2c2d2e2f303132333435363738393a3b3c3d3e3f404142434445464748494a4b4c4d4e4f
+Ctrl.salt = hexsalt:606162636465666768696a6b6c6d6e6f707172737475767778797a7b7c7d7e7f808182838485868788898a8b8c8d8e8f909192939495969798999a9b9c9d9e9fa0a1a2a3a4a5a6a7a8a9aaabacadaeaf
+Ctrl.info = hexinfo:b0b1b2b3b4b5b6b7b8b9babbbcbdbebfc0c1c2c3c4c5c6c7c8c9cacbcccdcecfd0d1d2d3d4d5d6d7d8d9dadbdcdddedfe0e1e2e3e4e5e6e7e8e9eaebecedeeeff0f1f2f3f4f5f6f7f8f9fafbfcfdfeff
+Output = 0bd770a74d1160f7c9f12cd5912a06ebff6adcae899d92191fe4305673ba2ffe8fa3f1a4e5ad79f3f334b3b202b2173c486ea37ce3d397ed034c7f9dfeb15c5e927336d0441f4c4300e2cff0d0900b52d3b4
+
+PKEYKDF = HKDF
+Ctrl.mode = mode:EXTRACT_ONLY
+Ctrl.md = md:SHA1
+Ctrl.IKM = hexkey:000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f202122232425262728292a2b2c2d2e2f303132333435363738393a3b3c3d3e3f404142434445464748494a4b4c4d4e4f
+Ctrl.salt = hexsalt:606162636465666768696a6b6c6d6e6f707172737475767778797a7b7c7d7e7f808182838485868788898a8b8c8d8e8f909192939495969798999a9b9c9d9e9fa0a1a2a3a4a5a6a7a8a9aaabacadaeaf
+Output = 8adae09a2a307059478d309b26c4115a224cfaf6
+
+PKEYKDF = HKDF
+Ctrl.mode = mode:EXPAND_ONLY
+Ctrl.md = md:SHA1
+Ctrl.IKM = hexkey:8adae09a2a307059478d309b26c4115a224cfaf6
+Ctrl.info = hexinfo:b0b1b2b3b4b5b6b7b8b9babbbcbdbebfc0c1c2c3c4c5c6c7c8c9cacbcccdcecfd0d1d2d3d4d5d6d7d8d9dadbdcdddedfe0e1e2e3e4e5e6e7e8e9eaebecedeeeff0f1f2f3f4f5f6f7f8f9fafbfcfdfeff
+Output = 0bd770a74d1160f7c9f12cd5912a06ebff6adcae899d92191fe4305673ba2ffe8fa3f1a4e5ad79f3f334b3b202b2173c486ea37ce3d397ed034c7f9dfeb15c5e927336d0441f4c4300e2cff0d0900b52d3b4
+
+PKEYKDF = HKDF
+Ctrl.md = md:SHA1
+Ctrl.IKM = hexkey:0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b
+Ctrl.salt = salt:
+Ctrl.info = info:
+Output = 0ac1af7002b3d761d1e55298da9d0506b9ae52057220a306e07b6b87e8df21d0ea00033de03984d34918
+
+PKEYKDF = HKDF
+Ctrl.mode = mode:EXTRACT_ONLY
+Ctrl.md = md:SHA1
+Ctrl.IKM = hexkey:0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b
+Ctrl.salt = salt:
+Output = da8c8a73c7fa77288ec6f5e7c297786aa0d32d01
+
+PKEYKDF = HKDF
+Ctrl.mode = mode:EXPAND_ONLY
+Ctrl.md = md:SHA1
+Ctrl.IKM = hexkey:da8c8a73c7fa77288ec6f5e7c297786aa0d32d01
+Ctrl.info = info:
+Output = 0ac1af7002b3d761d1e55298da9d0506b9ae52057220a306e07b6b87e8df21d0ea00033de03984d34918
+
+PKEYKDF = HKDF
+Ctrl.md = md:SHA1
+Ctrl.IKM = hexkey:0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c
+Ctrl.salt = salt:
+Ctrl.info = info:
+Output = 2c91117204d745f3500d636a62f64f0ab3bae548aa53d423b0d1f27ebba6f5e5673a081d70cce7acfc48
+
+PKEYKDF = HKDF
+Ctrl.mode = mode:EXTRACT_ONLY
+Ctrl.md = md:SHA1
+Ctrl.IKM = hexkey:0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c
+Ctrl.salt = salt:
+Output = 2adccada18779e7c2077ad2eb19d3f3e731385dd
+
+PKEYKDF = HKDF
+Ctrl.mode = mode:EXPAND_ONLY
+Ctrl.md = md:SHA1
+Ctrl.IKM = hexkey:2adccada18779e7c2077ad2eb19d3f3e731385dd
+Ctrl.info = info:
+Output = 2c91117204d745f3500d636a62f64f0ab3bae548aa53d423b0d1f27ebba6f5e5673a081d70cce7acfc48
+
+PKEYKDF = HKDF
+Ctrl.IKM = hexkey:0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c
+Ctrl.salt = salt:
+Ctrl.info = info:
+Output = 00
+Result = KDF_DERIVE_ERROR
+
+PKEYKDF = HKDF
+Ctrl.md = md:SHA1
+Ctrl.salt = salt:
+Ctrl.info = info:
+Output = 00
+Result = KDF_DERIVE_ERROR
+
+PKEYKDF = HKDF
+Ctrl.md = md:SHA1
+Ctrl.IKM = hexkey:0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c
+Ctrl.info = info:
+Output = 2c91117204d745f3500d636a62f64f0ab3bae548aa53d423b0d1f27ebba6f5e5673a081d70cce7acfc48
+
+PKEYKDF = HKDF
+Ctrl.md = md:SHA1
+Ctrl.IKM = hexkey:0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c
+Ctrl.salt = salt:
+Output = 2c91117204d745f3500d636a62f64f0ab3bae548aa53d423b0d1f27ebba6f5e5673a081d70cce7acfc48
+
+PKEYKDF = HKDF
+Ctrl.mode = mode:EXTRACT_AND_EXPAND
+Ctrl.md = md:SHA1
+Ctrl.IKM = hexkey:0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c
+Ctrl.salt = salt:
+Output = 2c91117204d745f3500d636a62f64f0ab3bae548aa53d423b0d1f27ebba6f5e5673a081d70cce7acfc48

--- a/EvpTestRecipes/3.0/evppkey_kdf_tls1_prf.txt
+++ b/EvpTestRecipes/3.0/evppkey_kdf_tls1_prf.txt
@@ -1,0 +1,71 @@
+#
+# Copyright 2001-2020 The OpenSSL Project Authors. All Rights Reserved.
+#
+# Licensed under the Apache License 2.0 (the "License").  You may not use
+# this file except in compliance with the License.  You can obtain a copy
+# in the file LICENSE in the source distribution or at
+# https://www.openssl.org/source/license.html
+
+# Tests start with one of these keywords
+#       Cipher Decrypt Derive Digest Encoding KDF MAC PBE
+#       PrivPubKeyPair Sign Verify VerifyRecover
+# and continue until a blank line. Lines starting with a pound sign are ignored.
+
+Title = TLS1 PRF tests (from NIST test vectors)
+
+PKEYKDF = TLS1-PRF
+Ctrl.md = md:MD5-SHA1
+Ctrl.Secret = hexsecret:bded7fa5c1699c010be23dd06ada3a48349f21e5f86263d512c0c5cc379f0e780ec55d9844b2f1db02a96453513568d0
+Ctrl.label = seed:master secret
+Ctrl.client_random = hexseed:e5acaf549cd25c22d964c0d930fa4b5261d2507fad84c33715b7b9a864020693
+Ctrl.server_random = hexseed:135e4d557fdf3aa6406d82975d5c606a9734c9334b42136e96990fbd5358cdb2
+Output = 2f6962dfbc744c4b2138bb6b3d33054c5ecc14f24851d9896395a44ab3964efc2090c5bf51a0891209f46c1e1e998f62
+
+PKEYKDF = TLS1-PRF
+Ctrl.md = md:MD5-SHA1
+Ctrl.Secret = hexsecret:2f6962dfbc744c4b2138bb6b3d33054c5ecc14f24851d9896395a44ab3964efc2090c5bf51a0891209f46c1e1e998f62
+Ctrl.label = seed:key expansion
+Ctrl.server_random = hexseed:67267e650eb32444119d222a368c191af3082888dc35afe8368e638c828874be
+Ctrl.client_random = hexseed:d58a7b1cd4fedaa232159df652ce188f9d997e061b9bf48e83b62990440931f6
+Output = 3088825988e77fce68d19f756e18e43eb7fe672433504feaf99b3c503d9091b164f166db301d70c9fc0870b4a94563907bee1a61fb786cb717576890bcc51cb9ead97e01d0a2fea99c953377b195205ff07b369589178796edc963fd80fdbe518a2fc1c35c18ae8d
+
+# Missing secret.
+PKEYKDF = TLS1-PRF
+Ctrl.md = md:MD5-SHA1
+Ctrl.Seed = hexseed:02
+Output = 03
+Result = KDF_DERIVE_ERROR
+
+# PKEYKDF variants.
+
+PKEYKDF = TLS1-PRF
+Ctrl.md = md:SHA256
+Ctrl.Secret = hexsecret:f8938ecc9edebc5030c0c6a441e213cd24e6f770a50dda07876f8d55da062bcadb386b411fd4fe4313a604fce6c17fbc
+Ctrl.label = seed:master secret
+Ctrl.client_random = hexseed:36c129d01a3200894b9179faac589d9835d58775f9b5ea3587cb8fd0364cae8c
+Ctrl.server_random = hexseed:f6c9575ed7ddd73e1f7d16eca115415812a43c2b747daaaae043abfb50053fce
+Output = 202c88c00f84a17a20027079604787461176455539e705be730890602c289a5001e34eeb3a043e5d52a65e66125188bf
+
+PKEYKDF = TLS1-PRF
+Ctrl.md = md:SHA256
+Ctrl.Secret = hexsecret:202c88c00f84a17a20027079604787461176455539e705be730890602c289a5001e34eeb3a043e5d52a65e66125188bf
+Ctrl.label = seed:key expansion
+Ctrl.server_random = hexseed:ae6c806f8ad4d80784549dff28a4b58fd837681a51d928c3e30ee5ff14f39868
+Ctrl.client_random = hexseed:62e1fd91f23f558a605f28478c58cf72637b89784d959df7e946d3f07bd1b616
+Output = d06139889fffac1e3a71865f504aa5d0d2a2e89506c6f2279b670c3e1b74f531016a2530c51a3a0f7e1d6590d0f0566b2f387f8d11fd4f731cdd572d2eae927f6f2f81410b25e6960be68985add6c38445ad9f8c64bf8068bf9a6679485d966f1ad6f68b43495b10a683755ea2b858d70ccac7ec8b053c6bd41ca299d4e51928
+
+# As above but use long name for KDF
+PKEYKDF = tls1-prf
+Ctrl.md = md:SHA256
+Ctrl.Secret = hexsecret:202c88c00f84a17a20027079604787461176455539e705be730890602c289a5001e34eeb3a043e5d52a65e66125188bf
+Ctrl.label = seed:key expansion
+Ctrl.server_random = hexseed:ae6c806f8ad4d80784549dff28a4b58fd837681a51d928c3e30ee5ff14f39868
+Ctrl.client_random = hexseed:62e1fd91f23f558a605f28478c58cf72637b89784d959df7e946d3f07bd1b616
+Output = d06139889fffac1e3a71865f504aa5d0d2a2e89506c6f2279b670c3e1b74f531016a2530c51a3a0f7e1d6590d0f0566b2f387f8d11fd4f731cdd572d2eae927f6f2f81410b25e6960be68985add6c38445ad9f8c64bf8068bf9a6679485d966f1ad6f68b43495b10a683755ea2b858d70ccac7ec8b053c6bd41ca299d4e51928
+
+# Missing digest.
+PKEYKDF = TLS1-PRF
+Ctrl.Secret = hexsecret:01
+Ctrl.Seed = hexseed:02
+Output = 03
+Result = KDF_DERIVE_ERROR

--- a/SymCryptProvider/CMakeLists.txt
+++ b/SymCryptProvider/CMakeLists.txt
@@ -33,8 +33,10 @@ set(SCOSSL_SOURCES
     ./src/kdf/p_scossl_tls1prf.c
     ./src/keyexch/p_scossl_dh.c
     ./src/keyexch/p_scossl_ecdh.c
+    ./src/keyexch/p_scossl_kdf_keyexch.c
     ./src/keymgmt/p_scossl_dh_keymgmt.c
     ./src/keymgmt/p_scossl_ecc_keymgmt.c
+    ./src/keymgmt/p_scossl_kdf_keymgmt.c
     ./src/keymgmt/p_scossl_rsa_keymgmt.c
     ./src/mac/p_scossl_cmac.c
     ./src/mac/p_scossl_hmac.c

--- a/SymCryptProvider/inc/p_scossl_base.h.in
+++ b/SymCryptProvider/inc/p_scossl_base.h.in
@@ -2,6 +2,8 @@
 // Copyright (c) Microsoft Corporation. Licensed under the MIT license.
 //
 
+#pragma once
+
 #include <openssl/core_names.h>
 #include <openssl/params.h>
 #include "scossl_helpers.h"

--- a/SymCryptProvider/src/kdf/p_scossl_hkdf.c
+++ b/SymCryptProvider/src/kdf/p_scossl_hkdf.c
@@ -2,23 +2,13 @@
 // Copyright (c) Microsoft Corporation. Licensed under the MIT license.
 //
 
-#include "scossl_hkdf.h"
-#include "p_scossl_base.h"
+#include "kdf/p_scossl_hkdf.h"
 
 #include <openssl/proverr.h>
-
 
 #ifdef __cplusplus
 extern "C" {
 #endif
-
-typedef struct
-{
-    // Needed for fetching md
-    OSSL_LIB_CTX *libctx;
-
-    SCOSSL_HKDF_CTX *hkdfCtx;
-} SCOSSL_PROV_HKDF_CTX;
 
 #define HKDF_MODE_EXTRACT_AND_EXPAND "EXTRACT_AND_EXPAND"
 #define HKDF_MODE_EXTRACT_ONLY       "EXTRACT_ONLY"
@@ -44,9 +34,7 @@ static const OSSL_PARAM p_scossl_hkdf_settable_ctx_param_types[] = {
     OSSL_PARAM_octet_string(OSSL_KDF_PARAM_INFO, NULL, 0),
     OSSL_PARAM_END};
 
-static SCOSSL_STATUS p_scossl_hkdf_set_ctx_params(_Inout_ SCOSSL_PROV_HKDF_CTX *ctx, const _In_ OSSL_PARAM params[]);
-
-static SCOSSL_PROV_HKDF_CTX *p_scossl_hkdf_newctx(_In_ SCOSSL_PROVCTX *provctx)
+SCOSSL_PROV_HKDF_CTX *p_scossl_hkdf_newctx(_In_ SCOSSL_PROVCTX *provctx)
 {
     SCOSSL_PROV_HKDF_CTX *ctx = OPENSSL_malloc(sizeof(SCOSSL_PROV_HKDF_CTX));
     if (ctx != NULL)
@@ -63,7 +51,7 @@ static SCOSSL_PROV_HKDF_CTX *p_scossl_hkdf_newctx(_In_ SCOSSL_PROVCTX *provctx)
     return ctx;
 }
 
-static void p_scossl_hkdf_freectx(_Inout_ SCOSSL_PROV_HKDF_CTX *ctx)
+void p_scossl_hkdf_freectx(_Inout_ SCOSSL_PROV_HKDF_CTX *ctx)
 {
     if (ctx != NULL)
     {
@@ -74,7 +62,7 @@ static void p_scossl_hkdf_freectx(_Inout_ SCOSSL_PROV_HKDF_CTX *ctx)
     OPENSSL_free(ctx);
 }
 
-static SCOSSL_PROV_HKDF_CTX *p_scossl_hkdf_dupctx(_In_ SCOSSL_PROV_HKDF_CTX *ctx)
+SCOSSL_PROV_HKDF_CTX *p_scossl_hkdf_dupctx(_In_ SCOSSL_PROV_HKDF_CTX *ctx)
 {
     SCOSSL_PROV_HKDF_CTX *copyCtx = OPENSSL_malloc(sizeof(SCOSSL_PROV_HKDF_CTX));
     if (copyCtx != NULL)
@@ -99,9 +87,9 @@ static SCOSSL_STATUS p_scossl_hkdf_reset(_Inout_ SCOSSL_PROV_HKDF_CTX *ctx)
     return scossl_hkdf_reset(ctx->hkdfCtx);
 }
 
-static SCOSSL_STATUS p_scossl_hkdf_derive(_In_ SCOSSL_PROV_HKDF_CTX *ctx,
-                                          _Out_writes_bytes_(keylen) unsigned char *key, size_t keylen,
-                                          _In_ const OSSL_PARAM params[])
+SCOSSL_STATUS p_scossl_hkdf_derive(_In_ SCOSSL_PROV_HKDF_CTX *ctx,
+                                   _Out_writes_bytes_(keylen) unsigned char *key, size_t keylen,
+                                   _In_ const OSSL_PARAM params[])
 {
     if (!p_scossl_hkdf_set_ctx_params(ctx, params))
     {
@@ -123,17 +111,17 @@ static SCOSSL_STATUS p_scossl_hkdf_derive(_In_ SCOSSL_PROV_HKDF_CTX *ctx,
     return scossl_hkdf_derive(ctx->hkdfCtx, key, keylen);
 }
 
-static const OSSL_PARAM *p_scossl_hkdf_gettable_ctx_params(ossl_unused void *ctx, ossl_unused void *provctx)
+const OSSL_PARAM *p_scossl_hkdf_gettable_ctx_params(ossl_unused void *ctx, ossl_unused void *provctx)
 {
     return p_scossl_hkdf_gettable_ctx_param_types;
 }
 
-static const OSSL_PARAM *p_scossl_hkdf_settable_ctx_params(ossl_unused void *ctx, ossl_unused void *provctx)
+const OSSL_PARAM *p_scossl_hkdf_settable_ctx_params(ossl_unused void *ctx, ossl_unused void *provctx)
 {
     return p_scossl_hkdf_settable_ctx_param_types;
 }
 
-static SCOSSL_STATUS p_scossl_hkdf_get_ctx_params(_In_ SCOSSL_PROV_HKDF_CTX *ctx, _Inout_ OSSL_PARAM params[])
+SCOSSL_STATUS p_scossl_hkdf_get_ctx_params(_In_ SCOSSL_PROV_HKDF_CTX *ctx, _Inout_ OSSL_PARAM params[])
 {
     OSSL_PARAM *p;
 
@@ -225,7 +213,7 @@ static SCOSSL_STATUS p_scossl_hkdf_get_ctx_params(_In_ SCOSSL_PROV_HKDF_CTX *ctx
     return SCOSSL_SUCCESS;
 }
 
-static SCOSSL_STATUS p_scossl_hkdf_set_ctx_params(_Inout_ SCOSSL_PROV_HKDF_CTX *ctx, const _In_ OSSL_PARAM params[])
+SCOSSL_STATUS p_scossl_hkdf_set_ctx_params(_Inout_ SCOSSL_PROV_HKDF_CTX *ctx, const _In_ OSSL_PARAM params[])
 {
     PCBYTE pbInfo;
     SIZE_T cbInfo;

--- a/SymCryptProvider/src/kdf/p_scossl_hkdf.h
+++ b/SymCryptProvider/src/kdf/p_scossl_hkdf.h
@@ -32,7 +32,6 @@ const OSSL_PARAM *p_scossl_hkdf_settable_ctx_params(ossl_unused void *ctx, ossl_
 SCOSSL_STATUS p_scossl_hkdf_get_ctx_params(_In_ SCOSSL_PROV_HKDF_CTX *ctx, _Inout_ OSSL_PARAM params[]);
 SCOSSL_STATUS p_scossl_hkdf_set_ctx_params(_Inout_ SCOSSL_PROV_HKDF_CTX *ctx, const _In_ OSSL_PARAM params[]);
 
-
 #ifdef __cplusplus
 }
 #endif

--- a/SymCryptProvider/src/kdf/p_scossl_hkdf.h
+++ b/SymCryptProvider/src/kdf/p_scossl_hkdf.h
@@ -1,0 +1,38 @@
+//
+// Copyright (c) Microsoft Corporation. Licensed under the MIT license.
+//
+
+#pragma once
+
+#include "scossl_hkdf.h"
+#include "p_scossl_base.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+typedef struct
+{
+    // Needed for fetching md
+    OSSL_LIB_CTX *libctx;
+
+    SCOSSL_HKDF_CTX *hkdfCtx;
+} SCOSSL_PROV_HKDF_CTX;
+
+SCOSSL_PROV_HKDF_CTX *p_scossl_hkdf_newctx(_In_ SCOSSL_PROVCTX *provctx);
+void p_scossl_hkdf_freectx(_Inout_ SCOSSL_PROV_HKDF_CTX *ctx);
+SCOSSL_PROV_HKDF_CTX *p_scossl_hkdf_dupctx(_In_ SCOSSL_PROV_HKDF_CTX *ctx);
+
+SCOSSL_STATUS p_scossl_hkdf_derive(_In_ SCOSSL_PROV_HKDF_CTX *ctx,
+                                   _Out_writes_bytes_(keylen) unsigned char *key, size_t keylen,
+                                   _In_ const OSSL_PARAM params[]);
+
+const OSSL_PARAM *p_scossl_hkdf_gettable_ctx_params(ossl_unused void *ctx, ossl_unused void *provctx);
+const OSSL_PARAM *p_scossl_hkdf_settable_ctx_params(ossl_unused void *ctx, ossl_unused void *provctx);
+SCOSSL_STATUS p_scossl_hkdf_get_ctx_params(_In_ SCOSSL_PROV_HKDF_CTX *ctx, _Inout_ OSSL_PARAM params[]);
+SCOSSL_STATUS p_scossl_hkdf_set_ctx_params(_Inout_ SCOSSL_PROV_HKDF_CTX *ctx, const _In_ OSSL_PARAM params[]);
+
+
+#ifdef __cplusplus
+}
+#endif

--- a/SymCryptProvider/src/kdf/p_scossl_tls1prf.c
+++ b/SymCryptProvider/src/kdf/p_scossl_tls1prf.c
@@ -2,24 +2,13 @@
 // Copyright (c) Microsoft Corporation. Licensed under the MIT license.
 //
 
-#include <openssl/proverr.h>
+#include "kdf/p_scossl_tls1prf.h"
 
-#include "scossl_tls1prf.h"
-#include "p_scossl_base.h"
+#include <openssl/proverr.h>
 
 #ifdef __cplusplus
 extern "C" {
 #endif
-
-typedef struct {
-    // Needed for fetching md
-    OSSL_LIB_CTX *libctx;
-
-    // Purely informational
-    char *mdName;
-
-    SCOSSL_TLS1_PRF_CTX *tls1prfCtx;
-} SCOSSL_PROV_TLS1_PRF_CTX;
 
 static const OSSL_PARAM p_scossl_tls1prf_gettable_ctx_param_types[] = {
     OSSL_PARAM_size_t(OSSL_KDF_PARAM_SIZE, NULL),
@@ -34,8 +23,6 @@ static const OSSL_PARAM p_scossl_tls1prf_settable_ctx_param_types[] = {
     OSSL_PARAM_octet_string(OSSL_KDF_PARAM_SECRET, NULL, 0),
     OSSL_PARAM_octet_string(OSSL_KDF_PARAM_SEED, NULL, 0),
     OSSL_PARAM_END};
-
-SCOSSL_STATUS p_scossl_tls1prf_set_ctx_params(_Inout_ SCOSSL_PROV_TLS1_PRF_CTX *ctx, _In_ const OSSL_PARAM params[]);
 
 SCOSSL_PROV_TLS1_PRF_CTX *p_scossl_tls1prf_newctx(_In_ SCOSSL_PROVCTX *provctx)
 {
@@ -83,7 +70,7 @@ SCOSSL_PROV_TLS1_PRF_CTX *p_scossl_tls1prf_dupctx(_In_ SCOSSL_PROV_TLS1_PRF_CTX 
     return copyCtx;
 }
 
-SCOSSL_STATUS p_scossl_tls1prf_reset(_Inout_ SCOSSL_PROV_TLS1_PRF_CTX *ctx)
+static SCOSSL_STATUS p_scossl_tls1prf_reset(_Inout_ SCOSSL_PROV_TLS1_PRF_CTX *ctx)
 {
     OPENSSL_free(ctx->mdName);
     ctx->mdName = NULL;

--- a/SymCryptProvider/src/kdf/p_scossl_tls1prf.h
+++ b/SymCryptProvider/src/kdf/p_scossl_tls1prf.h
@@ -34,7 +34,6 @@ const OSSL_PARAM *p_scossl_tls1prf_settable_ctx_params(ossl_unused void *ctx, os
 SCOSSL_STATUS p_scossl_tls1prf_get_ctx_params(_In_ SCOSSL_PROV_TLS1_PRF_CTX *ctx, _Inout_ OSSL_PARAM params[]);
 SCOSSL_STATUS p_scossl_tls1prf_set_ctx_params(_Inout_ SCOSSL_PROV_TLS1_PRF_CTX *ctx, const _In_ OSSL_PARAM params[]);
 
-
 #ifdef __cplusplus
 }
 #endif

--- a/SymCryptProvider/src/kdf/p_scossl_tls1prf.h
+++ b/SymCryptProvider/src/kdf/p_scossl_tls1prf.h
@@ -1,0 +1,40 @@
+//
+// Copyright (c) Microsoft Corporation. Licensed under the MIT license.
+//
+
+#pragma once
+
+#include "scossl_tls1prf.h"
+#include "p_scossl_base.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+typedef struct {
+    // Needed for fetching md
+    OSSL_LIB_CTX *libctx;
+
+    // Purely informational
+    char *mdName;
+
+    SCOSSL_TLS1_PRF_CTX *tls1prfCtx;
+} SCOSSL_PROV_TLS1_PRF_CTX;
+
+SCOSSL_PROV_TLS1_PRF_CTX *p_scossl_tls1prf_newctx(_In_ SCOSSL_PROVCTX *provctx);
+void p_scossl_tls1prf_freectx(_Inout_ SCOSSL_PROV_TLS1_PRF_CTX *ctx);
+SCOSSL_PROV_TLS1_PRF_CTX *p_scossl_tls1prf_dupctx(_In_ SCOSSL_PROV_TLS1_PRF_CTX *ctx);
+
+SCOSSL_STATUS p_scossl_tls1prf_derive(_In_ SCOSSL_PROV_TLS1_PRF_CTX *ctx,
+                                      _Out_writes_bytes_(keylen) unsigned char *key, size_t keylen,
+                                      _In_ const OSSL_PARAM params[]);
+
+const OSSL_PARAM *p_scossl_tls1prf_gettable_ctx_params(ossl_unused void *ctx, ossl_unused void *provctx);
+const OSSL_PARAM *p_scossl_tls1prf_settable_ctx_params(ossl_unused void *ctx, ossl_unused void *provctx);
+SCOSSL_STATUS p_scossl_tls1prf_get_ctx_params(_In_ SCOSSL_PROV_TLS1_PRF_CTX *ctx, _Inout_ OSSL_PARAM params[]);
+SCOSSL_STATUS p_scossl_tls1prf_set_ctx_params(_Inout_ SCOSSL_PROV_TLS1_PRF_CTX *ctx, const _In_ OSSL_PARAM params[]);
+
+
+#ifdef __cplusplus
+}
+#endif

--- a/SymCryptProvider/src/keyexch/p_scossl_kdf_keyexch.c
+++ b/SymCryptProvider/src/keyexch/p_scossl_kdf_keyexch.c
@@ -1,0 +1,213 @@
+//
+// Copyright (c) Microsoft Corporation. Licensed under the MIT license.
+//
+
+// Before OpenSSL 3, HKDF and TLS1-PRF were available through the EVP_PKEY API.
+// In OpenSSL 3, these are available through the EVP_KDF API, which uses the
+// provider kdf interface. Some callers may still be using the EVP_PKEY API
+// for HKDF and TLS1-PRF. These implementations below provide HKDF and TLS1-PRF
+// for the EVP_PKEY API.
+
+#include "kdf/p_scossl_hkdf.h"
+#include "kdf/p_scossl_tls1prf.h"
+
+#include <openssl/proverr.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+typedef struct
+{
+    OSSL_FUNC_kdf_newctx_fn                 *newCtx;
+    OSSL_FUNC_kdf_freectx_fn                *freeCtx;
+    OSSL_FUNC_kdf_dupctx_fn                 *dupCtx;
+    OSSL_FUNC_kdf_derive_fn                 *derive;
+    OSSL_FUNC_kdf_gettable_ctx_params_fn    *gettableCtxParams;
+    OSSL_FUNC_kdf_settable_ctx_params_fn    *settableCtxParams;
+    OSSL_FUNC_kdf_get_ctx_params_fn         *getCtxParams;
+    OSSL_FUNC_kdf_set_ctx_params_fn         *setCtxParams;
+} SCOSSL_KDF_FNS;
+
+const SCOSSL_KDF_FNS hkdfKdfFunctions = {
+    (OSSL_FUNC_kdf_newctx_fn *)                 p_scossl_hkdf_newctx,
+    (OSSL_FUNC_kdf_freectx_fn *)                p_scossl_hkdf_freectx,
+    (OSSL_FUNC_kdf_dupctx_fn *)                 p_scossl_hkdf_dupctx,
+    (OSSL_FUNC_kdf_derive_fn *)                 p_scossl_hkdf_derive,
+    (OSSL_FUNC_kdf_gettable_ctx_params_fn *)    p_scossl_hkdf_gettable_ctx_params,
+    (OSSL_FUNC_kdf_settable_ctx_params_fn *)    p_scossl_hkdf_settable_ctx_params,
+    (OSSL_FUNC_kdf_get_ctx_params_fn *)         p_scossl_hkdf_get_ctx_params,
+    (OSSL_FUNC_kdf_set_ctx_params_fn *)         p_scossl_hkdf_set_ctx_params};
+
+const SCOSSL_KDF_FNS tls1PrfKdfFunctions = {
+    (OSSL_FUNC_kdf_newctx_fn *)                 p_scossl_tls1prf_newctx,
+    (OSSL_FUNC_kdf_freectx_fn *)                p_scossl_tls1prf_freectx,
+    (OSSL_FUNC_kdf_dupctx_fn *)                 p_scossl_tls1prf_dupctx,
+    (OSSL_FUNC_kdf_derive_fn *)                 p_scossl_tls1prf_derive,
+    (OSSL_FUNC_kdf_gettable_ctx_params_fn *)    p_scossl_tls1prf_gettable_ctx_params,
+    (OSSL_FUNC_kdf_settable_ctx_params_fn *)    p_scossl_tls1prf_settable_ctx_params,
+    (OSSL_FUNC_kdf_get_ctx_params_fn *)         p_scossl_tls1prf_get_ctx_params,
+    (OSSL_FUNC_kdf_set_ctx_params_fn *)         p_scossl_tls1prf_set_ctx_params};
+
+typedef struct
+{
+    PVOID kdfCtx;
+    const SCOSSL_KDF_FNS *kdfFns;
+} SCOSSL_KDF_KEYEXCH_CTX;
+
+static SCOSSL_KDF_KEYEXCH_CTX *p_scossl_kdf_keyexch_newctx(_In_ SCOSSL_PROVCTX *provctx,
+                                                           _In_ const SCOSSL_KDF_FNS *kdfFns)
+{
+    SCOSSL_KDF_KEYEXCH_CTX *ctx = OPENSSL_malloc(sizeof(SCOSSL_KDF_KEYEXCH_CTX));
+
+    if (ctx != NULL)
+    {
+        ctx->kdfFns = kdfFns;
+
+        if ((ctx->kdfCtx = ctx->kdfFns->newCtx(provctx)) == NULL)
+        {
+            OPENSSL_free(ctx);
+            ctx = NULL;
+        }
+    }
+
+    return ctx;
+}
+
+static SCOSSL_KDF_KEYEXCH_CTX *p_scossl_hkdf_keyexch_newctx(_In_ SCOSSL_PROVCTX *provctx)
+{
+    return p_scossl_kdf_keyexch_newctx(provctx, &hkdfKdfFunctions);
+}
+
+static SCOSSL_KDF_KEYEXCH_CTX *p_scossl_tls1prf_keyexch_newctx(_In_ SCOSSL_PROVCTX *provctx)
+{
+    return p_scossl_kdf_keyexch_newctx(provctx, &tls1PrfKdfFunctions);
+}
+
+static void p_scossl_kdf_keyexch_freectx(_In_ SCOSSL_KDF_KEYEXCH_CTX *ctx)
+{
+    if (ctx == NULL)
+        return;
+
+    ctx->kdfFns->freeCtx(ctx->kdfCtx);
+    OPENSSL_free(ctx);
+}
+
+static SCOSSL_KDF_KEYEXCH_CTX *p_scossl_kdf_keyexch_dupctx(_In_ SCOSSL_KDF_KEYEXCH_CTX *ctx)
+{
+    SCOSSL_KDF_KEYEXCH_CTX *copyCtx = OPENSSL_malloc(sizeof(SCOSSL_KDF_KEYEXCH_CTX));
+
+    if (copyCtx != NULL)
+    {
+        copyCtx->kdfFns = ctx->kdfFns;
+
+        if ((copyCtx->kdfCtx = copyCtx->kdfFns->dupCtx(ctx->kdfCtx)) == NULL)
+        {
+            OPENSSL_free(copyCtx);
+            copyCtx = NULL;
+        }
+    }
+
+    return copyCtx;
+}
+
+static SCOSSL_STATUS p_scossl_kdf_keyexch_init(_In_ SCOSSL_KDF_KEYEXCH_CTX *ctx, ossl_unused void *provKey,
+                                               _In_ const OSSL_PARAM params[])
+{
+    if (ctx == NULL)
+    {
+        ERR_raise(ERR_LIB_PROV, ERR_R_PASSED_NULL_PARAMETER);
+        return SCOSSL_FAILURE;
+    }
+
+    return ctx->kdfFns->setCtxParams(ctx->kdfCtx, params);
+}
+
+static SCOSSL_STATUS p_scossl_kdf_keyexch_derive(_In_ SCOSSL_KDF_KEYEXCH_CTX *ctx,
+                                                 _Out_writes_bytes_opt_(*secretlen) unsigned char *secret, _Out_ size_t *secretlen,
+                                                 size_t outlen)
+{
+    SIZE_T cbKdfResult;
+    OSSL_PARAM kdfParams[2] = {
+        OSSL_PARAM_construct_size_t(OSSL_KDF_PARAM_SIZE, &cbKdfResult),
+        OSSL_PARAM_END};
+
+    if (ctx->kdfFns->getCtxParams(ctx->kdfCtx, kdfParams) != SCOSSL_SUCCESS)
+    {
+        return SCOSSL_FAILURE;
+    }
+
+    if (secret == NULL)
+    {
+        *secretlen = cbKdfResult;
+        return SCOSSL_SUCCESS;
+    }
+
+    if (cbKdfResult != SIZE_MAX)
+    {
+        if (outlen < cbKdfResult)
+        {
+            ERR_raise(ERR_LIB_PROV, PROV_R_OUTPUT_BUFFER_TOO_SMALL);
+            return SCOSSL_FAILURE;
+        }
+
+        outlen = cbKdfResult;
+    }
+
+    if (ctx->kdfFns->derive(ctx->kdfCtx, secret, outlen, NULL) != SCOSSL_SUCCESS)
+    {
+        return SCOSSL_FAILURE;
+    }
+
+    *secretlen = outlen;
+
+    return SCOSSL_SUCCESS;
+}
+
+static SCOSSL_STATUS p_scossl_kdf_keyexch_set_ctx_params(_Inout_ SCOSSL_KDF_KEYEXCH_CTX *ctx, _In_ const OSSL_PARAM params[])
+{
+    return ctx->kdfFns->setCtxParams(ctx->kdfCtx, params);
+}
+
+static const OSSL_PARAM *p_scossl_kdf_keyexch_ctx_settable_params(_In_ SCOSSL_KDF_KEYEXCH_CTX *ctx, _In_ SCOSSL_PROVCTX *provctx)
+{
+    return ctx->kdfFns->settableCtxParams(ctx->kdfCtx, provctx);
+}
+
+static SCOSSL_STATUS p_scossl_kdf_keyexch_get_ctx_params(_In_ SCOSSL_KDF_KEYEXCH_CTX *ctx, _Inout_ OSSL_PARAM params[])
+{
+    return ctx->kdfFns->getCtxParams(ctx->kdfCtx, params);
+}
+
+static const OSSL_PARAM *p_scossl_kdf_keyexch_ctx_gettable_params(_In_ SCOSSL_KDF_KEYEXCH_CTX *ctx, _In_ SCOSSL_PROVCTX *provctx)
+{
+    return ctx->kdfFns->gettableCtxParams(ctx->kdfCtx, provctx);
+}
+
+const OSSL_DISPATCH p_scossl_hkdf_keyexch_functions[] = {
+    {OSSL_FUNC_KEYEXCH_NEWCTX, (void (*)(void))p_scossl_hkdf_keyexch_newctx},
+    {OSSL_FUNC_KEYEXCH_FREECTX, (void (*)(void))p_scossl_kdf_keyexch_freectx},
+    {OSSL_FUNC_KEYEXCH_DUPCTX, (void (*)(void))p_scossl_kdf_keyexch_dupctx},
+    {OSSL_FUNC_KEYEXCH_INIT, (void (*)(void))p_scossl_kdf_keyexch_init},
+    {OSSL_FUNC_KEYEXCH_DERIVE, (void (*)(void))p_scossl_kdf_keyexch_derive},
+    {OSSL_FUNC_KEYEXCH_SET_CTX_PARAMS, (void (*)(void))p_scossl_kdf_keyexch_set_ctx_params},
+    {OSSL_FUNC_KEYEXCH_SETTABLE_CTX_PARAMS, (void (*)(void))p_scossl_kdf_keyexch_ctx_settable_params},
+    {OSSL_FUNC_KEYEXCH_GET_CTX_PARAMS, (void (*)(void))p_scossl_kdf_keyexch_get_ctx_params},
+    {OSSL_FUNC_KEYEXCH_GETTABLE_CTX_PARAMS, (void (*)(void))p_scossl_kdf_keyexch_ctx_gettable_params},
+    {0, NULL}};
+
+const OSSL_DISPATCH p_scossl_tls1prf_keyexch_functions[] = {
+    {OSSL_FUNC_KEYEXCH_NEWCTX, (void (*)(void))p_scossl_tls1prf_keyexch_newctx},
+    {OSSL_FUNC_KEYEXCH_FREECTX, (void (*)(void))p_scossl_kdf_keyexch_freectx},
+    {OSSL_FUNC_KEYEXCH_DUPCTX, (void (*)(void))p_scossl_kdf_keyexch_dupctx},
+    {OSSL_FUNC_KEYEXCH_INIT, (void (*)(void))p_scossl_kdf_keyexch_init},
+    {OSSL_FUNC_KEYEXCH_DERIVE, (void (*)(void))p_scossl_kdf_keyexch_derive},
+    {OSSL_FUNC_KEYEXCH_SET_CTX_PARAMS, (void (*)(void))p_scossl_kdf_keyexch_set_ctx_params},
+    {OSSL_FUNC_KEYEXCH_SETTABLE_CTX_PARAMS, (void (*)(void))p_scossl_kdf_keyexch_ctx_settable_params},
+    {OSSL_FUNC_KEYEXCH_GET_CTX_PARAMS, (void (*)(void))p_scossl_kdf_keyexch_get_ctx_params},
+    {OSSL_FUNC_KEYEXCH_GETTABLE_CTX_PARAMS, (void (*)(void))p_scossl_kdf_keyexch_ctx_gettable_params},
+    {0, NULL}};
+
+#ifdef __cplusplus
+}
+#endif

--- a/SymCryptProvider/src/keymgmt/p_scossl_kdf_keymgmt.c
+++ b/SymCryptProvider/src/keymgmt/p_scossl_kdf_keymgmt.c
@@ -1,0 +1,48 @@
+//
+// Copyright (c) Microsoft Corporation. Licensed under the MIT license.
+//
+
+// Before OpenSSL 3, HKDF and TLS1-PRF were available through the EVP_PKEY API.
+// In OpenSSL 3, these are available through the EVP_KDF API, which uses the
+// provider kdf interface. Some callers may still be using the EVP_PKEY API
+// for HKDF and TLS1-PRF. The implementations in keyexch/p_scossl_kdf_keyexch
+// provide HKDF and TLS1-PRF for the EVP_PKEY API. This keymgmt interface is
+// mostly empty but necessary for algorithms exposed through the EVP_PKEY API.
+
+#include "scossl_helpers.h"
+
+#include <openssl/core_dispatch.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+typedef BYTE SCOSSL_KDF_KEYMGMT_CTX;
+
+SCOSSL_KDF_KEYMGMT_CTX *p_scossl_kdf_keymgmt_new_ctx(ossl_unused void *provctx)
+{
+    return OPENSSL_malloc(sizeof(SCOSSL_KDF_KEYMGMT_CTX));
+}
+
+void p_scossl_kdf_keymgmt_free_ctx(SCOSSL_KDF_KEYMGMT_CTX *keyCtx)
+{
+    if (keyCtx == NULL)
+        return;
+
+    OPENSSL_free(keyCtx);
+}
+
+static BOOL p_scossl_kdf_keymgmt_has(ossl_unused const void *keydata, ossl_unused int selection)
+{
+    return TRUE;
+}
+
+const OSSL_DISPATCH p_scossl_kdf_keymgmt_functions[] = {
+    {OSSL_FUNC_KEYMGMT_NEW, (void (*)(void))p_scossl_kdf_keymgmt_new_ctx},
+    {OSSL_FUNC_KEYMGMT_FREE, (void (*)(void))p_scossl_kdf_keymgmt_free_ctx},
+    {OSSL_FUNC_KEYMGMT_HAS, (void (*)(void))p_scossl_kdf_keymgmt_has},
+    {0, NULL}};
+
+#ifdef __cplusplus
+}
+#endif

--- a/SymCryptProvider/src/keymgmt/p_scossl_kdf_keymgmt.c
+++ b/SymCryptProvider/src/keymgmt/p_scossl_kdf_keymgmt.c
@@ -7,7 +7,7 @@
 // provider kdf interface. Some callers may still be using the EVP_PKEY API
 // for HKDF and TLS1-PRF. The implementations in keyexch/p_scossl_kdf_keyexch
 // provide HKDF and TLS1-PRF for the EVP_PKEY API. This keymgmt interface is
-// mostly empty but necessary for algorithms exposed through the EVP_PKEY API.
+// mostly empty but necessary to expose both KDFs through the EVP_PKEY API.
 
 #include "scossl_helpers.h"
 

--- a/SymCryptProvider/src/keymgmt/p_scossl_kdf_keymgmt.c
+++ b/SymCryptProvider/src/keymgmt/p_scossl_kdf_keymgmt.c
@@ -17,20 +17,14 @@
 extern "C" {
 #endif
 
-typedef BYTE SCOSSL_KDF_KEYMGMT_CTX;
+static const BYTE dummy_kdf_keymgmt_ctx = 0;
 
-SCOSSL_KDF_KEYMGMT_CTX *p_scossl_kdf_keymgmt_new_ctx(ossl_unused void *provctx)
+const BYTE *p_scossl_kdf_keymgmt_new_ctx(ossl_unused void *provctx)
 {
-    return OPENSSL_malloc(sizeof(SCOSSL_KDF_KEYMGMT_CTX));
+    return &dummy_kdf_keymgmt_ctx;
 }
 
-void p_scossl_kdf_keymgmt_free_ctx(SCOSSL_KDF_KEYMGMT_CTX *keyCtx)
-{
-    if (keyCtx == NULL)
-        return;
-
-    OPENSSL_free(keyCtx);
-}
+void p_scossl_kdf_keymgmt_free_ctx(ossl_unused void *keyCtx){}
 
 static BOOL p_scossl_kdf_keymgmt_has(ossl_unused const void *keydata, ossl_unused int selection)
 {

--- a/SymCryptProvider/src/p_scossl_base.c
+++ b/SymCryptProvider/src/p_scossl_base.c
@@ -238,27 +238,34 @@ static const OSSL_ALGORITHM p_scossl_rand[] = {
 
 // Key management
 extern const OSSL_DISPATCH p_scossl_dh_keymgmt_functions[];
+extern const OSSL_DISPATCH p_scossl_ecc_keymgmt_functions[];
+extern const OSSL_DISPATCH p_scossl_kdf_keymgmt_functions[];
 extern const OSSL_DISPATCH p_scossl_rsa_keymgmt_functions[];
 extern const OSSL_DISPATCH p_scossl_rsapss_keymgmt_functions[];
-extern const OSSL_DISPATCH p_scossl_ecc_keymgmt_functions[];
 extern const OSSL_DISPATCH p_scossl_x25519_keymgmt_functions[];
 
 static const OSSL_ALGORITHM p_scossl_keymgmt[] = {
     ALG("DH:dhKeyAgreement:1.2.840.113549.1.3.1", p_scossl_dh_keymgmt_functions),
+    ALG("EC:id-ecPublicKey:1.2.840.10045.2.1", p_scossl_ecc_keymgmt_functions),
+    ALG("HKDF", p_scossl_kdf_keymgmt_functions),
     ALG("RSA:rsaEncryption:1.2.840.113549.1.1.1:", p_scossl_rsa_keymgmt_functions),
     ALG("RSA-PSS:RSASSA-PSS:1.2.840.113549.1.1.10", p_scossl_rsapss_keymgmt_functions),
-    ALG("EC:id-ecPublicKey:1.2.840.10045.2.1", p_scossl_ecc_keymgmt_functions),
+    ALG("TLS1-PRF", p_scossl_kdf_keymgmt_functions),
     ALG("X25519:1.3.101.110", p_scossl_x25519_keymgmt_functions),
     ALG_TABLE_END};
 
 // Key exchange
 extern const OSSL_DISPATCH p_scossl_dh_functions[];
 extern const OSSL_DISPATCH p_scossl_ecdh_functions[];
+extern const OSSL_DISPATCH p_scossl_hkdf_keyexch_functions[];
+extern const OSSL_DISPATCH p_scossl_tls1prf_keyexch_functions[];
 extern const OSSL_DISPATCH p_scossl_x25519_functions[];
 
 static const OSSL_ALGORITHM p_scossl_keyexch[] = {
     ALG("DH:dhKeyAgreement:1.2.840.113549.1.3.1", p_scossl_dh_functions),
     ALG("ECDH", p_scossl_ecdh_functions),
+    ALG("HKDF", p_scossl_hkdf_keyexch_functions),
+    ALG("TLS1-PRF", p_scossl_tls1prf_keyexch_functions),
     ALG("X25519:1.3.101.110", p_scossl_ecdh_functions),
     ALG_TABLE_END};
 

--- a/SymCryptProvider/src/p_scossl_rand.c
+++ b/SymCryptProvider/src/p_scossl_rand.c
@@ -15,7 +15,7 @@
 extern "C" {
 #endif
 
-const BYTE dummy_scossl_ctx = 0;
+static const BYTE dummy_scossl_ctx = 0;
 
 static const OSSL_PARAM gettable_ctx_param_types[] = {
     OSSL_PARAM_int(OSSL_RAND_PARAM_STATE, NULL),


### PR DESCRIPTION
HKDF and TLS1-PRF were available in OpenSSL 1.1.1 through the EVP_PKEY API. OpenSSL 3 introduced the EVP_KDF API, but some callers may still be using the EVP_PKEY API for KDF and TLS1-PRF. We have previously relied on the default provider's key exchange wrapper for these KDFs, which exposes them to the EVP_PKEY API. If the default provider is not enabled, or the caller sets "fips=yes", then the KDFs are no longer available to EVP_PKEY. 

This PR adds a similar wrapper in the SymCrypt provider. Only TLS1-PRF and HKDF are needed for existing callers using EVP_PKEY functions. All other KDFs were not supported in OpenSSL 1.1.1, and new applications using those KDFs should use the EVP_KDF API.