### PR TITLE
Fix crash when using an unavailable digest in RSA sign/verify

### DIFF
--- a/SymCryptProvider/src/signature/p_scossl_rsa_signature.c
+++ b/SymCryptProvider/src/signature/p_scossl_rsa_signature.c
@@ -331,7 +331,7 @@ static SCOSSL_STATUS p_scossl_rsa_digest_signverify_init(_In_ SCOSSL_RSA_SIGN_CT
             return SCOSSL_FAILURE;
         }
 
-        EVP_MD *md;
+        EVP_MD *md = NULL;
         const OSSL_ITEM *mdInfo = p_scossl_rsa_get_supported_md(ctx->libctx, ctx->padding, mdname, NULL, &md);
 
         if (mdInfo == NULL ||
@@ -441,7 +441,7 @@ static SCOSSL_STATUS p_scossl_rsa_set_ctx_params(_Inout_ SCOSSL_RSA_SIGN_CTX *ct
 
     if ((p = OSSL_PARAM_locate_const(params, OSSL_SIGNATURE_PARAM_DIGEST)) != NULL)
     {
-        EVP_MD *md;
+        EVP_MD *md = NULL;
         const OSSL_ITEM *mdInfo;
 
         if (!OSSL_PARAM_get_utf8_string_ptr(p, &mdName))
@@ -650,7 +650,7 @@ static SCOSSL_STATUS p_scossl_rsa_set_ctx_params(_Inout_ SCOSSL_RSA_SIGN_CTX *ct
             return SCOSSL_FAILURE;
         }
 
-        EVP_MD *md;
+        EVP_MD *md = NULL;
         const OSSL_ITEM *mgf1MdInfo;
 
         if (!OSSL_PARAM_get_utf8_string_ptr(p, &mdName))


### PR DESCRIPTION
`md` is only set by `p_scossl_rsa_get_supported_md` when `EVP_MD_fetch` succeeds. This normally always succeeds, but if a digest is queried with no supporting provider, `md` is left unchanged. Some of the calling functions in the provider did not initialize `md` to NULL and tried to free `md` on failure leading to a crash.