### PR TITLE
Provider behavior fixes

### DIFF
--- a/ScosslCommon/src/scossl_aes_aead.c
+++ b/ScosslCommon/src/scossl_aes_aead.c
@@ -176,7 +176,7 @@ SCOSSL_STATUS scossl_aes_gcm_cipher(SCOSSL_CIPHER_GCM_CTX *ctx, INT32 encrypt,
     {
         // Auth Data Passed in
         SymCryptGcmAuthPart(&ctx->state, in, inl);
-        *outl = 0;
+        *outl = inl;
         return SCOSSL_SUCCESS;
     }
 
@@ -638,7 +638,7 @@ SCOSSL_STATUS scossl_aes_ccm_cipher(SCOSSL_CIPHER_CCM_CTX *ctx, INT32 encrypt,
         if (out == NULL)
         {
             // Auth Data Passed in
-            *outl = 0;
+            *outl = cbAuthdata;
             return SCOSSL_SUCCESS;
         }
     }

--- a/ScosslCommon/src/scossl_ecc.c
+++ b/ScosslCommon/src/scossl_ecc.c
@@ -362,6 +362,15 @@ static SCOSSL_STATUS scossl_ecdsa_remove_der(_In_reads_bytes_(cbDerSignature) PC
         goto cleanup;
     }
 
+    if (pbS + cbS != pbSeq + cbSeq)
+    {
+        SCOSSL_LOG_ERROR(SCOSSL_ERR_F_ECDSA_REMOVE_DER, ERR_R_PASSED_INVALID_ARGUMENT,
+                         "Unexpected value in sequence");
+        SCOSSL_LOG_BYTES_DEBUG(SCOSSL_ERR_F_ECDSA_REMOVE_DER, ERR_R_PASSED_INVALID_ARGUMENT,
+                               "pbDerSignature", pbDerSignature, cbDerSignature);
+        goto cleanup;
+    }
+
     // Check R's validity
     if (((pbR[0] & 0x80) == 0x80) ||                                  // R is negative
         ((cbR > 1) && (pbR[0] == 0x00) && ((pbR[1] & 0x80) != 0x80))) // R is non-zero, and has a redundant leading 0 byte
@@ -411,6 +420,13 @@ static SCOSSL_STATUS scossl_ecdsa_remove_der(_In_reads_bytes_(cbDerSignature) PC
 cleanup:
     return res;
 }
+
+/*
+ECDSA-Sig-Value ::= SEQUENCE {
+    r INTEGER,
+    s INTEGER
+}
+*/
 
 // Quick hack function to generate precisely the DER encodings which we want for ECDSA signatures for the NIST prime curves
 // Takes 2 same-size big-endian integers output from SymCrypt and encodes them in the minimally sized (strict) equivalent DER encoding


### PR DESCRIPTION
This PR addresses some incorrect behavior in the provider. These fixes are for behavior that isn't strictly speaking correct, but likely won't cause real-world issues.

- Check that ECDSA signature is a sequence of two integers without trailing data
- Return authenticated bytes for AEAD ciphers if out is NULL