### PR TITLE
Hardcode SymCrypt minimum version instead of using value in headers

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,8 +2,11 @@ cmake_minimum_required(VERSION 3.13.0)
 
 project(SymCrypt-OpenSSL
     VERSION 1.7.0
-    DESCRIPTION "The SymCrypt engine for OpenSSL (SCOSSL)"
+    DESCRIPTION "The SymCrypt engine and provider for OpenSSL (SCOSSL)"
     HOMEPAGE_URL "https://github.com/microsoft/SymCrypt-OpenSSL")
+
+set(SYMCRYPT_MINIMUM_MAJOR "103")
+set(SYMCRYPT_MINIMUM_MINOR "6")
 
 find_package(OpenSSL REQUIRED)
 
@@ -12,7 +15,7 @@ if (SYMCRYPT_ROOT_DIR)
 else()
     find_package(PkgConfig)
     if (PKG_CONFIG_FOUND)
-        pkg_check_modules(SYMCRYPT REQUIRED symcrypt>=103.6.0)
+        pkg_check_modules(SYMCRYPT REQUIRED symcrypt>=${SYMCRYPT_MINIMUM_MAJOR}.${SYMCRYPT_MINIMUM_MINOR})
         message(STATUS "SymCrypt Includes: ${SYMCRYPT_INCLUDE_DIRS}")
         include_directories(${SYMCRYPT_INCLUDE_DIRS})
     else()

--- a/SymCryptProvider/inc/p_scossl_base.h.in
+++ b/SymCryptProvider/inc/p_scossl_base.h.in
@@ -15,6 +15,8 @@ extern "C" {
 // Value provided by CMake, defined in top level CMakeLists.txt
 #define P_SCOSSL_VERSION "@SymCrypt-OpenSSL_VERSION@"
 #define P_SCOSSL_NAME "symcryptprovider"
+#define P_SCOSSL_SYMCRYPT_MINIMUM_MAJOR @SYMCRYPT_MINIMUM_MAJOR@
+#define P_SCOSSL_SYMCRYPT_MINIMUM_MINOR @SYMCRYPT_MINIMUM_MINOR@
 
 typedef struct
 {

--- a/SymCryptProvider/src/p_scossl_base.c
+++ b/SymCryptProvider/src/p_scossl_base.c
@@ -598,7 +598,7 @@ SCOSSL_STATUS OSSL_provider_init(_In_ const OSSL_CORE_HANDLE *handle,
 
     if (!scossl_prov_initialized)
     {
-        SYMCRYPT_MODULE_INIT();
+        SymCryptModuleInit(P_SCOSSL_SYMCRYPT_MINIMUM_MAJOR, P_SCOSSL_SYMCRYPT_MINIMUM_MINOR);
         if (!scossl_dh_init_static() ||
             !scossl_ecc_init_static())
         {


### PR DESCRIPTION
The SymCrypt provider currently initialized SymCrypt with `SYMCRYPT_MODULE_INIT`. This macro expands to `SymCryptModuleInit` using the SymCrypt major and minor version defined in the SymCrypt headers. This makes the SymCrypt provider's minimum SymCrypt version the version it was compiled with, and not the minimum version it's ABI compatible with.

This PR adds CMAKE variables for the minimum SymCrypt version the project depends on. The SymCrypt provider uses these values in initialization, so the SymCrypt provider can be used with the lowest version of SymCrypt it's compatible with, regardless of which version it's compiled with.