### PR TITLE
Restrict padding for generated RSASSA-PSS keys

### DIFF
--- a/EvpTestRecipes/3.0/evppkey_rsa_common.txt
+++ b/EvpTestRecipes/3.0/evppkey_rsa_common.txt
@@ -1214,18 +1214,51 @@ Title = Test RSA keygen
 KeyGen = RSASSA-PSS
 KeyName = tmppss
 Ctrl = rsa_pss_keygen_md:sha256
-Ctrl = rsa_pss_keygen_mgf1_md:sha512
+Ctrl = rsa_pss_keygen_mgf1_md:sha256
+Ctrl = saltlen:32
 
-# Check MGF1 restrictions
-DigestVerify = SHA256
-Key = tmppss
+# Check digest restrictions
+Verify = tmppss
+Ctrl = digest:SHA1
+Result = PKEY_CTRL_ERROR
+
+# Check MGF1 digest restriction
+Verify = tmppss
+Ctrl = rsa_mgf1_md:sha1
+Result = PKEY_CTRL_ERROR
+
+# Check minimum saltlen restriction
+Verify = tmppss
+Ctrl = saltlen:20
+Result = PKEY_CTRL_ERROR
+
+# Check padding restriction
+Verify = tmppss
+Ctrl = rsa_padding_mode:pkcs1
+Result = PKEY_CTRL_ERROR
+
+# RSA-PSS with default restrictions, should succeed.
+KeyGen = RSASSA-PSS
+KeyName = tmppss_default
+
+# Check digest restrictions
+Verify = tmppss_default
+Ctrl = digest:SHA256
+Result = PKEY_CTRL_ERROR
+
+# Check MGF1 digest restriction
+Verify = tmppss_default
 Ctrl = rsa_mgf1_md:sha256
 Result = PKEY_CTRL_ERROR
 
-# Check caching of key MGF1 digest restriction
-DigestVerify = SHA256
-Key = tmppss
-Ctrl = rsa_mgf1_md:sha1
+# Check minimum saltlen restriction
+Verify = tmppss_default
+Ctrl = saltlen:16
+Result = PKEY_CTRL_ERROR
+
+# Check padding restriction
+Verify = tmppss_default
+Ctrl = rsa_padding_mode:pkcs1
 Result = PKEY_CTRL_ERROR
 
 Title = RSA FIPS tests

--- a/EvpTestRecipes/3.0/evppkey_rsa_common.txt
+++ b/EvpTestRecipes/3.0/evppkey_rsa_common.txt
@@ -1237,27 +1237,12 @@ Verify = tmppss
 Ctrl = rsa_padding_mode:pkcs1
 Result = PKEY_CTRL_ERROR
 
-# RSA-PSS with default restrictions, should succeed.
+# RSA-PSS with no restrictions, should succeed.
 KeyGen = RSASSA-PSS
-KeyName = tmppss_default
-
-# Check digest restrictions
-Verify = tmppss_default
-Ctrl = digest:SHA256
-Result = PKEY_CTRL_ERROR
-
-# Check MGF1 digest restriction
-Verify = tmppss_default
-Ctrl = rsa_mgf1_md:sha256
-Result = PKEY_CTRL_ERROR
-
-# Check minimum saltlen restriction
-Verify = tmppss_default
-Ctrl = saltlen:16
-Result = PKEY_CTRL_ERROR
+KeyName = tmppss_unrestricted
 
 # Check padding restriction
-Verify = tmppss_default
+Verify = tmppss_unrestricted
 Ctrl = rsa_padding_mode:pkcs1
 Result = PKEY_CTRL_ERROR
 

--- a/SymCryptProvider/src/asymcipher/p_scossl_rsa_cipher.c
+++ b/SymCryptProvider/src/asymcipher/p_scossl_rsa_cipher.c
@@ -93,7 +93,7 @@ static SCOSSL_STATUS p_scossl_rsa_cipher_init(_Inout_ SCOSSL_RSA_CIPHER_CTX *ctx
         return SCOSSL_FAILURE;
     }
 
-    if (keyCtx->padding == RSA_PKCS1_PSS_PADDING)
+    if (keyCtx->keyType == RSA_FLAG_TYPE_RSASSAPSS)
     {
         ERR_raise(ERR_LIB_PROV, PROV_R_OPERATION_NOT_SUPPORTED_FOR_THIS_KEYTYPE);
         return SCOSSL_FAILURE;

--- a/SymCryptProvider/src/keymgmt/p_scossl_rsa_keymgmt.c
+++ b/SymCryptProvider/src/keymgmt/p_scossl_rsa_keymgmt.c
@@ -23,7 +23,6 @@ typedef struct
     UINT32 nBitsOfModulus;
     UINT64 pubExp64;
     UINT32 nPubExp;
-    UINT padding;
 } SCOSSL_RSA_KEYGEN_CTX;
 
 #define SCOSSL_RSA_DEFAULT_DIGEST SN_sha256

--- a/SymCryptProvider/src/p_scossl_rsa.h
+++ b/SymCryptProvider/src/p_scossl_rsa.h
@@ -23,7 +23,6 @@ typedef struct
     OSSL_LIB_CTX *libctx;
     BOOL initialized;
     PSYMCRYPT_RSAKEY key;
-    UINT padding;
     UINT keyType;
     SCOSSL_RSA_PSS_RESTRICTIONS *pssRestrictions;
 

--- a/SymCryptProvider/src/signature/p_scossl_rsa_signature.c
+++ b/SymCryptProvider/src/signature/p_scossl_rsa_signature.c
@@ -195,7 +195,7 @@ static SCOSSL_STATUS p_scossl_rsa_signverify_init(_Inout_ SCOSSL_RSA_SIGN_CTX *c
         }
 
         ctx->keyCtx = keyCtx;
-        ctx->padding = keyCtx->padding;
+        ctx->padding = keyCtx->keyType == RSA_FLAG_TYPE_RSASSAPSS ? RSA_PKCS1_PSS_PADDING : RSA_PKCS1_PADDING;
 
 #ifdef KEYSINUSE_ENABLED
         if (p_scossl_keysinuse_running() &&


### PR DESCRIPTION
Generated RSASSA-PSS format keys were not properly restricted to PSS padding. This PR properly restricts generated RSASSA-PSS keys to PSS padding and cleans up how those keys are indicated by key type.