### PR TITLE
KeysInUse and memory fixes

### DIFF
--- a/ScosslCommon/src/scossl_dh.c
+++ b/ScosslCommon/src/scossl_dh.c
@@ -8,6 +8,7 @@
 extern "C" {
 #endif
 
+static BOOL scossl_dh_initialized = FALSE;
 static PSYMCRYPT_DLGROUP _hidden_dlgroup_ffdhe2048 = NULL;
 static PSYMCRYPT_DLGROUP _hidden_dlgroup_ffdhe3072 = NULL;
 static PSYMCRYPT_DLGROUP _hidden_dlgroup_ffdhe4096 = NULL;
@@ -356,6 +357,9 @@ cleanup:
 
 SCOSSL_STATUS scossl_dh_init_static(void)
 {
+    if (scossl_dh_initialized)
+        return SCOSSL_SUCCESS;
+
     if (((_hidden_dlgroup_ffdhe2048 = scossl_initialize_safeprime_dlgroup(SYMCRYPT_DLGROUP_DH_SAFEPRIMETYPE_TLS_7919, 2048)) == NULL) ||
         ((_hidden_dlgroup_ffdhe3072 = scossl_initialize_safeprime_dlgroup(SYMCRYPT_DLGROUP_DH_SAFEPRIMETYPE_TLS_7919, 3072)) == NULL) ||
         ((_hidden_dlgroup_ffdhe4096 = scossl_initialize_safeprime_dlgroup(SYMCRYPT_DLGROUP_DH_SAFEPRIMETYPE_TLS_7919, 4096)) == NULL) ||
@@ -368,6 +372,8 @@ SCOSSL_STATUS scossl_dh_init_static(void)
     {
         return SCOSSL_FAILURE;
     }
+
+    scossl_dh_initialized = TRUE;
     return SCOSSL_SUCCESS;
 }
 
@@ -409,6 +415,8 @@ void scossl_destroy_safeprime_dlgroups(void)
     _hidden_bignum_modp3072 = NULL;
     BN_free(_hidden_bignum_modp4096);
     _hidden_bignum_modp4096 = NULL;
+
+    scossl_dh_initialized = FALSE;
 }
 
 // Other providers may export the group to the SymCrypt provider by parameters

--- a/ScosslCommon/src/scossl_ecc.c
+++ b/ScosslCommon/src/scossl_ecc.c
@@ -23,6 +23,7 @@ extern "C" {
 // Smallest supported curve is P192 => 24 * 2 byte SymCrypt signatures
 #define SCOSSL_ECDSA_MIN_SYMCRYPT_SIGNATURE_LEN (48)
 
+static BOOL scossl_ecc_initialized = FALSE;
 static PSYMCRYPT_ECURVE _hidden_curve_P192 = NULL;
 static PSYMCRYPT_ECURVE _hidden_curve_P224 = NULL;
 static PSYMCRYPT_ECURVE _hidden_curve_P256 = NULL;
@@ -32,6 +33,9 @@ static PSYMCRYPT_ECURVE _hidden_curve_X25519 = NULL;
 
 SCOSSL_STATUS scossl_ecc_init_static()
 {
+    if (scossl_ecc_initialized)
+        return SCOSSL_SUCCESS;
+
     if( ((_hidden_curve_P192 = SymCryptEcurveAllocate(SymCryptEcurveParamsNistP192, 0)) == NULL) ||
         ((_hidden_curve_P224 = SymCryptEcurveAllocate(SymCryptEcurveParamsNistP224, 0)) == NULL) ||
         ((_hidden_curve_P256 = SymCryptEcurveAllocate(SymCryptEcurveParamsNistP256, 0)) == NULL) ||
@@ -41,6 +45,7 @@ SCOSSL_STATUS scossl_ecc_init_static()
     {
         return SCOSSL_FAILURE;
     }
+    scossl_ecc_initialized = TRUE;
     return SCOSSL_SUCCESS;
 }
 
@@ -76,6 +81,7 @@ void scossl_ecc_destroy_ecc_curves()
         SymCryptEcurveFree(_hidden_curve_X25519);
         _hidden_curve_X25519 = NULL;
     }
+    scossl_ecc_initialized = FALSE;
 }
 
 _Use_decl_annotations_

--- a/SymCryptProvider/src/kdf/p_scossl_sskdf.c
+++ b/SymCryptProvider/src/kdf/p_scossl_sskdf.c
@@ -380,7 +380,6 @@ SCOSSL_STATUS p_scossl_sskdf_set_ctx_params(_Inout_ SCOSSL_PROV_SSKDF_CTX *ctx, 
 
     if ((p = OSSL_PARAM_locate_const(params, OSSL_KDF_PARAM_DIGEST)) != NULL)
     {
-        EVP_MD *md;
         const char *mdName;
     
         ctx->pHash = NULL;

--- a/SymCryptProvider/src/kdf/p_scossl_tls1prf.c
+++ b/SymCryptProvider/src/kdf/p_scossl_tls1prf.c
@@ -47,6 +47,7 @@ void p_scossl_tls1prf_freectx(_Inout_ SCOSSL_PROV_TLS1_PRF_CTX *ctx)
     if (ctx != NULL)
     {
         scossl_tls1prf_freectx(ctx->tls1prfCtx);
+        OPENSSL_free(ctx->mdName);
     }
 
     OPENSSL_free(ctx);

--- a/SymCryptProvider/src/kdf/p_scossl_tls1prf.c
+++ b/SymCryptProvider/src/kdf/p_scossl_tls1prf.c
@@ -148,22 +148,23 @@ SCOSSL_STATUS p_scossl_tls1prf_get_ctx_params(_In_ SCOSSL_PROV_TLS1_PRF_CTX *ctx
 
 SCOSSL_STATUS p_scossl_tls1prf_set_ctx_params(_Inout_ SCOSSL_PROV_TLS1_PRF_CTX *ctx, _In_ const OSSL_PARAM params[])
 {
+    const OSSL_PARAM *p;
+    EVP_MD *md = NULL;
+    char *mdName = NULL;
     PCBYTE pbSeed;
     SIZE_T cbSeed;
-    const OSSL_PARAM *p;
+    SCOSSL_STATUS ret = SCOSSL_FAILURE;
 
     if ((p = OSSL_PARAM_locate_const(params, OSSL_KDF_PARAM_DIGEST)) != NULL)
     {
         PCSYMCRYPT_MAC symcryptHmacAlg = NULL;
         BOOL isTlsPrf1_1 = FALSE;
         const char *paramMdName, *mdProps;
-        char *mdName;
-        EVP_MD *md;
 
         if (!OSSL_PARAM_get_utf8_string_ptr(p, &paramMdName))
         {
             ERR_raise(ERR_LIB_PROV, PROV_R_FAILED_TO_GET_PARAMETER);
-            return SCOSSL_FAILURE;
+            goto cleanup;
         }
 
         // Special case to always allow md5_sha1 for tls1.1 PRF compat
@@ -175,22 +176,21 @@ SCOSSL_STATUS p_scossl_tls1prf_set_ctx_params(_Inout_ SCOSSL_PROV_TLS1_PRF_CTX *
                 !OSSL_PARAM_get_utf8_string_ptr(p, &mdProps)))
             {
                 ERR_raise(ERR_LIB_PROV, PROV_R_FAILED_TO_GET_PARAMETER);
-                return SCOSSL_FAILURE;
+                goto cleanup;
             }
 
             if ((md = EVP_MD_fetch(ctx->libctx, paramMdName, mdProps)) == NULL)
             {
                 ERR_raise(ERR_LIB_PROV, PROV_R_INVALID_DIGEST);
-                return SCOSSL_FAILURE;
+                goto cleanup;
             }
 
             mdName = OPENSSL_strdup(EVP_MD_get0_name(md));
             symcryptHmacAlg = scossl_get_symcrypt_hmac_algorithm(EVP_MD_type(md));
-            EVP_MD_free(md);
 
             if (symcryptHmacAlg == NULL)
             {
-                return SCOSSL_FAILURE;
+                goto cleanup;
             }
         }
         else
@@ -201,6 +201,8 @@ SCOSSL_STATUS p_scossl_tls1prf_set_ctx_params(_Inout_ SCOSSL_PROV_TLS1_PRF_CTX *
 
         OPENSSL_free(ctx->mdName);
         ctx->mdName = mdName;
+        mdName = NULL;
+
         ctx->tls1prfCtx->pHmac = symcryptHmacAlg;
         ctx->tls1prfCtx->isTlsPrf1_1 = isTlsPrf1_1;
     }
@@ -214,7 +216,7 @@ SCOSSL_STATUS p_scossl_tls1prf_set_ctx_params(_Inout_ SCOSSL_PROV_TLS1_PRF_CTX *
             !OSSL_PARAM_get_octet_string(p, (void **)&pbSecret, 0, &cbSecret))
         {
             ERR_raise(ERR_LIB_PROV, PROV_R_FAILED_TO_GET_PARAMETER);
-            return SCOSSL_FAILURE;
+            goto cleanup;
         }
 
         OPENSSL_clear_free(ctx->tls1prfCtx->pbSecret, ctx->tls1prfCtx->cbSecret);
@@ -230,17 +232,23 @@ SCOSSL_STATUS p_scossl_tls1prf_set_ctx_params(_Inout_ SCOSSL_PROV_TLS1_PRF_CTX *
         if (!OSSL_PARAM_get_octet_string_ptr(p, (const void **)&pbSeed, &cbSeed))
         {
             ERR_raise(ERR_LIB_PROV, PROV_R_FAILED_TO_GET_PARAMETER);
-            return SCOSSL_FAILURE;
+            goto cleanup;
         }
 
         if (!scossl_tls1prf_append_seed(ctx->tls1prfCtx, pbSeed, cbSeed))
         {
             ERR_raise(ERR_LIB_PROV, PROV_R_LENGTH_TOO_LARGE);
-            return SCOSSL_FAILURE;
+            goto cleanup;
         }
     }
 
-    return SCOSSL_SUCCESS;
+    ret = SCOSSL_SUCCESS;
+
+cleanup:
+    EVP_MD_free(md);
+    OPENSSL_free(mdName);
+
+    return ret;
 }
 
 const OSSL_DISPATCH p_scossl_tls1prf_kdf_functions[] = {

--- a/SymCryptProvider/src/keymgmt/p_scossl_dh_keymgmt.c
+++ b/SymCryptProvider/src/keymgmt/p_scossl_dh_keymgmt.c
@@ -182,6 +182,8 @@ static void p_scossl_dh_keymgmt_free_key_ctx(_In_ SCOSSL_PROV_DH_KEY_CTX *ctx)
     {
         SymCryptDlgroupFree(ctx->pDlGroup);
     }
+
+    OPENSSL_free(ctx);
 }
 
 // Helper functions for retrieving public and private key size.
@@ -1238,10 +1240,10 @@ cleanup:
             SymCryptDlgroupFree(pDlGroup);
             ctx->pDlGroup = NULL;
         }
-
-        BN_clear_free(bnPrivateKey);
-        BN_free(bnPublicKey);
     }
+
+    BN_clear_free(bnPrivateKey);
+    BN_free(bnPublicKey);
 
     return ret;
 }

--- a/SymCryptProvider/src/keymgmt/p_scossl_ecc_keymgmt.c
+++ b/SymCryptProvider/src/keymgmt/p_scossl_ecc_keymgmt.c
@@ -117,9 +117,6 @@ static SCOSSL_ECC_KEY_CTX *p_scossl_x25519_keymgmt_new_ctx(_In_ SCOSSL_PROVCTX *
     {
         keyCtx->curve = scossl_ecc_get_x25519_curve();
         keyCtx->isX25519 = TRUE;
-#ifdef KEYSINUSE_ENABLED
-        keyCtx->keysinuseLock = CRYPTO_THREAD_lock_new();
-#endif
     }
 
     return keyCtx;

--- a/SymCryptProvider/src/p_scossl_base.c
+++ b/SymCryptProvider/src/p_scossl_base.c
@@ -26,7 +26,7 @@ extern "C" {
 #define CONF_KEYSINUSE_LOGGING_DELAY "keysinuse.logging_delay_seconds"
 
 // Cap configured file size at 2GB
-#define SCOSSL_MAX_CONFIGURABLE_FILE_SIZE (2 << 30)
+#define SCOSSL_MAX_CONFIGURABLE_FILE_SIZE (2l << 30)
 #endif
 
 #define OSSL_TLS_GROUP_ID_secp192r1        0x0013

--- a/SymCryptProvider/src/p_scossl_keysinuse.c
+++ b/SymCryptProvider/src/p_scossl_keysinuse.c
@@ -149,7 +149,16 @@ static void p_scossl_keysinuse_init_once()
     sk_keysinuse_info = sk_SCOSSL_PROV_KEYSINUSE_INFO_new_null();
 
     // Make sure /var/log/keysinuse exists
-    if (mkdir(LOG_DIR, 1733) == -1 && errno != EEXIST)
+    if (mkdir(LOG_DIR, 1733) == 0)
+    {
+        if (chown(LOG_DIR, 0, 0) == -1)
+        {
+            p_scossl_keysinuse_log_error("Failed to set ownership of logging directory at %s,SYS_%d", LOG_DIR, errno);
+            rmdir(LOG_DIR);
+            goto cleanup;
+        }
+    }    
+    else if (errno != EEXIST)
     {
         p_scossl_keysinuse_log_error("Failed to create logging directory at %s,SYS_%d", LOG_DIR, errno);
         goto cleanup;

--- a/SymCryptProvider/src/p_scossl_keysinuse.c
+++ b/SymCryptProvider/src/p_scossl_keysinuse.c
@@ -30,7 +30,8 @@ static BOOL keysinuse_enabled = FALSE;
 #define KEYSINUSE_NOTICE 1
 // Log files separated by UID.
 // /var/log/keysinuse/keysinuse_<level>_<euid>.log
-#define LOG_PATH_TMPL "/var/log/keysinuse/keysinuse_%.3s_%08x.log"
+#define LOG_DIR       "/var/log/keysinuse"
+#define LOG_PATH_TMPL LOG_DIR "/keysinuse_%.3s_%08x.log"
 #define LOG_MSG_MAX 256
 static const char *default_prefix = "";
 static char *prefix = NULL;
@@ -146,6 +147,13 @@ static void p_scossl_keysinuse_init_once()
 
     sk_keysinuse_info_lock = CRYPTO_THREAD_lock_new();
     sk_keysinuse_info = sk_SCOSSL_PROV_KEYSINUSE_INFO_new_null();
+
+    // Make sure /var/log/keysinuse exists
+    if (mkdir(LOG_DIR, 1733) == -1 && errno != EEXIST)
+    {
+        p_scossl_keysinuse_log_error("Failed to create logging directory at %s,SYS_%d", LOG_DIR, errno);
+        goto cleanup;
+    }
 
     // Start the logging thread. Monotonic clock needs to be set to
     // prevent wall clock changes from affecting the logging delay sleep time

--- a/SymCryptProvider/src/p_scossl_rsa.c
+++ b/SymCryptProvider/src/p_scossl_rsa.c
@@ -261,8 +261,8 @@ void p_scossl_rsa_init_keysinuse(SCOSSL_PROV_RSA_KEY_CTX *keyCtx)
             }
 
             OPENSSL_free(pbPublicKey);
-            CRYPTO_THREAD_unlock(keyCtx->keysinuseLock);
         }
+        CRYPTO_THREAD_unlock(keyCtx->keysinuseLock);
     }
 }
 


### PR DESCRIPTION
This PR fixes a couple bugs related to keysinuse and memory leaks found with additional valgrind testing.
- Create `/var/log/keysinuse` with correct permissions and ownership if not found on keysinuse start.
- Fix double alloc in X25519 case. Fixes #108 
- Fix edge case potential deadlock with RSA keys
- Add static flag to initialize DH and ECC curves only once. If the engine and provider are both loaded these hidden curves were re-initialized and the originally created curves are leaked.
- Fix some additional leaks found with valgrind testing