### PR TITLE
Proper state management for AES GCM and CCM

### DIFF
--- a/ScosslCommon/inc/scossl_aes_aead.h
+++ b/ScosslCommon/inc/scossl_aes_aead.h
@@ -88,10 +88,12 @@ typedef struct
     SCOSSL_CCM_STAGE ccmStage;
     BYTE iv[SCOSSL_CCM_MAX_IV_LENGTH];
     SIZE_T ivlen;
+    INT32 ivSet;
     SYMCRYPT_CCM_STATE state;
     SYMCRYPT_AES_EXPANDED_KEY key;
     BYTE tag[EVP_CCM_TLS_TAG_LEN];
     SIZE_T taglen;
+    INT32 tagSet;
     UINT64 cbData;
     BYTE tlsAad[EVP_AEAD_TLS1_AAD_LEN];
     INT32 tlsAadSet;

--- a/ScosslCommon/src/scossl_aes_aead.c
+++ b/ScosslCommon/src/scossl_aes_aead.c
@@ -666,6 +666,7 @@ SCOSSL_STATUS scossl_aes_ccm_cipher(SCOSSL_CIPHER_CCM_CTX *ctx, INT32 encrypt,
                 SymCryptCcmEncryptPart(&ctx->state, in, out, inl);
             }
             SymCryptCcmEncryptFinal(&ctx->state, ctx->tag, ctx->taglen);
+            ctx->tagSet = 1;
             ctx->ccmStage = SCOSSL_CCM_STAGE_COMPLETE;
         }
         else

--- a/ScosslCommon/src/scossl_aes_aead.c
+++ b/ScosslCommon/src/scossl_aes_aead.c
@@ -287,12 +287,15 @@ SCOSSL_STATUS scossl_aes_gcm_set_iv_len(SCOSSL_CIPHER_GCM_CTX *ctx, size_t ivlen
         return SCOSSL_FAILURE;
     }
 
-    ctx->ivlen = ivlen;
-
-    if (ctx->iv != NULL)
+    if (ivlen != ctx->ivlen)
     {
-        OPENSSL_free(ctx->iv);
-        ctx->iv = NULL;
+        ctx->ivlen = ivlen;
+    
+        if (ctx->iv != NULL)
+        {
+            OPENSSL_free(ctx->iv);
+            ctx->iv = NULL;
+        }
     }
 
     return SCOSSL_SUCCESS;
@@ -429,6 +432,8 @@ void scossl_aes_ccm_init_ctx(SCOSSL_CIPHER_CCM_CTX *ctx,
         memcpy(ctx->iv, iv, ctx->ivlen);
     }
     ctx->taglen = SCOSSL_CCM_MAX_TAG_LENGTH;
+    ctx->ivSet = 0;
+    ctx->tagSet = 0;
     ctx->tlsAadSet = 0;
 }
 
@@ -450,6 +455,7 @@ SCOSSL_STATUS scossl_aes_ccm_init_key(SCOSSL_CIPHER_CCM_CTX *ctx,
 
         ctx->ivlen = ivlen;
         memcpy(ctx->iv, iv, ctx->ivlen);
+        ctx->ivSet = 1;
     }
     if (key)
     {
@@ -618,6 +624,13 @@ SCOSSL_STATUS scossl_aes_ccm_cipher(SCOSSL_CIPHER_CCM_CTX *ctx, INT32 encrypt,
 
     if (ctx->ccmStage == SCOSSL_CCM_STAGE_SET_CBDATA)
     {
+        if (!ctx->ivSet)
+        {
+            SCOSSL_LOG_ERROR(SCOSSL_ERR_F_AES_CCM_CIPHER, ERR_R_PASSED_INVALID_ARGUMENT,
+                "No IV provided to CCM");
+            return SCOSSL_FAILURE;
+        }
+
         if (out == NULL)
         {
             // Auth Data Passed in
@@ -657,6 +670,12 @@ SCOSSL_STATUS scossl_aes_ccm_cipher(SCOSSL_CIPHER_CCM_CTX *ctx, INT32 encrypt,
         }
         else
         {
+            if (!ctx->tagSet)
+            {
+                SCOSSL_LOG_ERROR(SCOSSL_ERR_F_AES_CCM_CIPHER, ERR_R_PASSED_INVALID_ARGUMENT,
+                    "No tag provided to CCM Decrypt");
+                return SCOSSL_FAILURE;
+            }
             // Decryption
             if (in != NULL)
             {
@@ -680,7 +699,7 @@ SCOSSL_STATUS scossl_aes_ccm_get_aead_tag(SCOSSL_CIPHER_CCM_CTX *ctx, INT32 encr
                                           unsigned char *tag, size_t taglen)
 {
     if ((taglen & 1) || taglen < SCOSSL_CCM_MIN_TAG_LENGTH || taglen > SCOSSL_CCM_MAX_TAG_LENGTH ||
-        taglen > ctx->taglen || !encrypt)
+        taglen > ctx->taglen || !encrypt || !ctx->tagSet)
     {
         return SCOSSL_FAILURE;
     }
@@ -702,6 +721,7 @@ SCOSSL_STATUS scossl_aes_ccm_set_aead_tag(SCOSSL_CIPHER_CCM_CTX *ctx, INT32 encr
         memcpy(ctx->tag, tag, taglen);
     }
     ctx->taglen = taglen;
+    ctx->tagSet = 1;
 
     return SCOSSL_SUCCESS;
 }
@@ -717,7 +737,12 @@ SCOSSL_STATUS scossl_aes_ccm_set_iv_len(SCOSSL_CIPHER_CCM_CTX *ctx, size_t ivlen
         return SCOSSL_FAILURE;
     }
 
-    ctx->ivlen = ivlen;
+    if (ctx->ivlen != ivlen)
+    {
+        ctx->ivlen = ivlen;
+        ctx->ivSet = 0;
+    }
+
     return SCOSSL_SUCCESS;
 }
 
@@ -750,6 +775,8 @@ SCOSSL_STATUS scossl_aes_ccm_set_iv_fixed(SCOSSL_CIPHER_CCM_CTX *ctx, INT32 encr
     {
         return SCOSSL_FAILURE;
     }
+
+    ctx->ivSet = 1;
 
     return SCOSSL_SUCCESS;
 }

--- a/SymCryptProvider/src/keymgmt/p_scossl_rsa_keymgmt.c
+++ b/SymCryptProvider/src/keymgmt/p_scossl_rsa_keymgmt.c
@@ -1064,8 +1064,8 @@ static BOOL p_scossl_rsa_keymgmt_match(_In_ SCOSSL_PROV_RSA_KEY_CTX *keyCtx1, _I
 cleanup:
     OPENSSL_free(pbModulus1);
     OPENSSL_free(pbModulus2);
-    OPENSSL_secure_free(pbPrivateExponent1);
-    OPENSSL_secure_free(pbPrivateExponent2);
+    OPENSSL_secure_clear_free(pbPrivateExponent1, cbModulus);
+    OPENSSL_secure_clear_free(pbPrivateExponent2, cbModulus);
 
     return ret;
 }
@@ -1114,7 +1114,7 @@ static SCOSSL_STATUS p_scossl_rsa_keymgmt_import(_Inout_ SCOSSL_PROV_RSA_KEY_CTX
         {
             cbModulus = p->data_size;
 
-            pbModulus = OPENSSL_zalloc(cbModulus);
+            pbModulus = OPENSSL_malloc(cbModulus);
             if (pbModulus == NULL)
             {
                 ERR_raise(ERR_LIB_PROV, ERR_R_MALLOC_FAILURE);
@@ -1141,7 +1141,7 @@ static SCOSSL_STATUS p_scossl_rsa_keymgmt_import(_Inout_ SCOSSL_PROV_RSA_KEY_CTX
             {
                 pcbPrimes[0] = p->data_size;
 
-                ppbPrimes[0] = OPENSSL_zalloc(pcbPrimes[0]);
+                ppbPrimes[0] = OPENSSL_secure_malloc(pcbPrimes[0]);
                 if (ppbPrimes[0] == NULL)
                 {
                     ERR_raise(ERR_LIB_PROV, ERR_R_MALLOC_FAILURE);
@@ -1160,7 +1160,7 @@ static SCOSSL_STATUS p_scossl_rsa_keymgmt_import(_Inout_ SCOSSL_PROV_RSA_KEY_CTX
             {
                 pcbPrimes[1] = p->data_size;
 
-                ppbPrimes[1] = OPENSSL_zalloc(pcbPrimes[1]);
+                ppbPrimes[1] = OPENSSL_secure_malloc(pcbPrimes[1]);
                 if(ppbPrimes[1] == NULL)
                 {
                     ERR_raise(ERR_LIB_PROV, ERR_R_MALLOC_FAILURE);
@@ -1182,7 +1182,7 @@ static SCOSSL_STATUS p_scossl_rsa_keymgmt_import(_Inout_ SCOSSL_PROV_RSA_KEY_CTX
             {
                 cbPrivateExponent = p->data_size;
 
-                pbPrivateExponent = OPENSSL_zalloc(cbPrivateExponent);
+                pbPrivateExponent = OPENSSL_secure_malloc(cbPrivateExponent);
                 if(pbPrivateExponent == NULL)
                 {
                     ERR_raise(ERR_LIB_PROV, ERR_R_MALLOC_FAILURE);
@@ -1271,10 +1271,10 @@ static SCOSSL_STATUS p_scossl_rsa_keymgmt_import(_Inout_ SCOSSL_PROV_RSA_KEY_CTX
     ret = SCOSSL_SUCCESS;
 
 cleanup:
-    OPENSSL_free(pbPrivateExponent);
+    OPENSSL_secure_clear_free(pbPrivateExponent, cbModulus);
+    OPENSSL_secure_clear_free(ppbPrimes[0], pcbPrimes[0]);
+    OPENSSL_secure_clear_free(ppbPrimes[1], pcbPrimes[1]);
     OPENSSL_free(pbModulus);
-    OPENSSL_free(ppbPrimes[0]);
-    OPENSSL_free(ppbPrimes[1]);
     BN_free(bn);
 
     return ret;

--- a/SymCryptProvider/src/keymgmt/p_scossl_rsa_keymgmt.c
+++ b/SymCryptProvider/src/keymgmt/p_scossl_rsa_keymgmt.c
@@ -1271,6 +1271,7 @@ static SCOSSL_STATUS p_scossl_rsa_keymgmt_import(_Inout_ SCOSSL_PROV_RSA_KEY_CTX
     ret = SCOSSL_SUCCESS;
 
 cleanup:
+    OPENSSL_free(pbPrivateExponent);
     OPENSSL_free(pbModulus);
     OPENSSL_free(ppbPrimes[0]);
     OPENSSL_free(ppbPrimes[1]);


### PR DESCRIPTION
The SymCrypt unit tests with OpenSSL and SCOSSL revealed an edge case when calling `EVP_CipherInit_ex2` and passing the IV length as a parameter alongside the IV. The SCOSSL implementation unconditionally freed the set IV if an IV length was set, even if the IV length did not change. If the IV length matches what's set, then the IV should not be reset.

This PR also adds state checks for the IV and tag in CCM to bring the behavior and failure points more in line with the default provider.