### PR TITLE
Clamp keysinuse max file size to SCOSSL_MAX_CONFIGURABLE_FILE_SIZE

### DIFF
--- a/SymCryptProvider/src/p_scossl_base.c
+++ b/SymCryptProvider/src/p_scossl_base.c
@@ -453,8 +453,9 @@ static void p_scossl_start_keysinuse(_In_ const OSSL_CORE_HANDLE *handle)
 
                 maxFileSizeBytes = maxFileSizeBytes * 10 + (confMaxFileSize[i++] - '0');
 
-                // Clamp to SCOSSL_MAX_CONFIGURABLE_FILE_SIZE in case of overflow
-                if (maxFileSizeBytes < maxFileSizeBytesTmp)
+                // Clamp to SCOSSL_MAX_CONFIGURABLE_FILE_SIZE
+                if (maxFileSizeBytes >= SCOSSL_MAX_CONFIGURABLE_FILE_SIZE ||
+                    maxFileSizeBytes < maxFileSizeBytesTmp)
                 {
                     maxFileSizeBytes = SCOSSL_MAX_CONFIGURABLE_FILE_SIZE;
                     break;
@@ -484,8 +485,9 @@ static void p_scossl_start_keysinuse(_In_ const OSSL_CORE_HANDLE *handle)
                     break;
                 }
 
-                // Clamp to SCOSSL_MAX_CONFIGURABLE_FILE_SIZE in case of overflow
-                if (maxFileSizeBytes < maxFileSizeBytesTmp)
+                // Clamp to SCOSSL_MAX_CONFIGURABLE_FILE_SIZE
+                if (maxFileSizeBytes >= SCOSSL_MAX_CONFIGURABLE_FILE_SIZE ||
+                    maxFileSizeBytes < maxFileSizeBytesTmp)
                 {
                     maxFileSizeBytes = SCOSSL_MAX_CONFIGURABLE_FILE_SIZE;
                 }


### PR DESCRIPTION
`SCOSSL_MAX_CONFIGURABLE_FILE_SIZE` was originally intended to be the default max file size for KeysInUse in cases where the configured max file size overflowed an `off_t`. This behavior is inconsistent and confusing, since a user would be allowed to set the max file size to something like 100GB but would be capped at 2GB in case of a bad configuration leading to overflow. Either case is unlikely, and there isn't a real use case for letting this file grow past 2GB.

This PR enforces `SCOSSL_MAX_CONFIGURABLE_FILE_SIZE` as the max configurable file size as the name implies.