### PR TITLE
Mamckee/gcm leak

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.13.0)
 
 project(SymCrypt-OpenSSL
-    VERSION 1.8.0
+    VERSION 1.8.1
     DESCRIPTION "The SymCrypt engine and provider for OpenSSL (SCOSSL)"
     HOMEPAGE_URL "https://github.com/microsoft/SymCrypt-OpenSSL")
 

--- a/ScosslCommon/src/scossl_aes_aead.c
+++ b/ScosslCommon/src/scossl_aes_aead.c
@@ -39,13 +39,17 @@ SCOSSL_STATUS scossl_aes_gcm_init_key(SCOSSL_CIPHER_GCM_CTX *ctx,
     ctx->operationInProgress = 0;
     if (iv != NULL)
     {
-        if (!scossl_aes_gcm_set_iv_len(ctx, ivlen) ||
-            (ctx->iv = OPENSSL_memdup(iv, ctx->ivlen)) == NULL)
+        if (!scossl_aes_gcm_set_iv_len(ctx, ivlen))
         {
             return SCOSSL_FAILURE;
         }
 
-        ctx->ivlen = ivlen;
+        OPENSSL_free(ctx->iv);
+
+        if ((ctx->iv = OPENSSL_memdup(iv, ctx->ivlen)) == NULL)
+        {
+            return SCOSSL_FAILURE;
+        }
     }
     if (key != NULL)
     {


### PR DESCRIPTION
PR #112 fixed an issue where the GCM IV was incorrectly cleared if the IV length was set to the current IV length, and the IV was already set. This was because `scossl_aes_gcm_set_iv_len` unconditionally cleared the IV. In fixing this I missed a section where the IV should be freed outside the function. I have checked everywhere else `scossl_aes_ccm_set_iv_len` is called and confirmed this was the only spot missing a free.

Fixes #115 