### PR TITLE
Only compile with optimizations for release builds and fix typos

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.13.0)
 
 project(SymCrypt-OpenSSL
-    VERSION 1.10.0-dev
+    VERSION 1.10.0
     DESCRIPTION "The SymCrypt engine and provider for OpenSSL (SCOSSL)"
     HOMEPAGE_URL "https://github.com/microsoft/SymCrypt-OpenSSL")
 

--- a/SslPlay/CMakeLists.txt
+++ b/SslPlay/CMakeLists.txt
@@ -14,9 +14,9 @@ set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wno-deprecated-declarations")
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-deprecated-declarations")
 
 if (CMAKE_SYSTEM_PROCESSOR MATCHES AMD64)
-    set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wl,-z,now -fstack-protector-strong -fstack-clash-protection")
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wl,-z,now -fstack-protector-strong -fstack-clash-protection")
-    target_compile_definitions(SslPlay PRIVATE _FORTIFY_SOURCE=2)
+    set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -O2 -Wl,-z,now -fstack-protector-strong -fstack-clash-protection")
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -O2 -Wl,-z,now -fstack-protector-strong -fstack-clash-protection")
+    target_compile_definitions(SslPlay PUBLIC _FORTIFY_SOURCE=2)
 endif()
 
 if (SCOSSL_SSHKDF)

--- a/SslPlay/CMakeLists.txt
+++ b/SslPlay/CMakeLists.txt
@@ -13,12 +13,6 @@ add_executable (SslPlay
 set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wno-deprecated-declarations")
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-deprecated-declarations")
 
-if (CMAKE_SYSTEM_PROCESSOR MATCHES AMD64)
-    set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -O2 -Wl,-z,now -fstack-protector-strong -fstack-clash-protection")
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -O2 -Wl,-z,now -fstack-protector-strong -fstack-clash-protection")
-    target_compile_definitions(SslPlay PUBLIC _FORTIFY_SOURCE=2)
-endif()
-
 if (SCOSSL_SSHKDF)
     set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -DSCOSSL_SSHKDF")
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DSCOSSL_SSHKDF")

--- a/SslPlay/CMakeLists.txt
+++ b/SslPlay/CMakeLists.txt
@@ -14,8 +14,9 @@ set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wno-deprecated-declarations")
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-deprecated-declarations")
 
 if (CMAKE_SYSTEM_PROCESSOR MATCHES AMD64)
-    set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -fhardened")
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fhardened")
+    set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wl,-z,now -fstack-protector-strong -fstack-clash-protection")
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wl,-z,now -fstack-protector-strong -fstack-clash-protection")
+    target_compile_definitions(SslPlay PRIVATE _FORTIFY_SOURCE=2)
 endif()
 
 if (SCOSSL_SSHKDF)

--- a/SslPlay/CMakeLists.txt
+++ b/SslPlay/CMakeLists.txt
@@ -13,6 +13,11 @@ add_executable (SslPlay
 set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wno-deprecated-declarations")
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-deprecated-declarations")
 
+if (CMAKE_SYSTEM_PROCESSOR MATCHES AMD64)
+    set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -fhardened")
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fhardened")
+endif()
+
 if (SCOSSL_SSHKDF)
     set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -DSCOSSL_SSHKDF")
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DSCOSSL_SSHKDF")

--- a/SymCryptProvider/README.md
+++ b/SymCryptProvider/README.md
@@ -129,7 +129,7 @@ The SymCrypt provider can be configured in the SymCrypt provider section of the 
 ### Debug Logging
 | Key           | Description                                                                                                                                   | Default   |
 | -             | -                                                                                                                                             | -         |
-| logging_file  | Location to write debug logging events to.                                                                                                     | NULL      |
+| logging_file  | Location to write debug logging events to.                                                                                                    | NULL      |
 | logging_level | Maximum level to log to logging file. In order, can be <ul><li>off</li><li>error</li><li>info</li><li>debug</li></ul>                         | off       |
 | error_level   | Maximum level to push logging events to OpenSSL error stack. In order, can be <ul><li>off</li><li>error</li><li>info</li><li>debug</li></ul>  | error     |
 
@@ -143,4 +143,4 @@ separate section. This section must be referenced in the symcrypt provider secti
 | -                     | -                                                                                                                                             | -         |
 | enabled               | 0 or 1 to disable or enable keysinuse logging.                                                                                                | 0         |
 | max_file_size         | Maximum size of the file events are written to. May be written as raw byte size or suffixed with KB/MB/GB                                     | 5KB       |
-| logging_delay_seconds | Duration in seconds between events being written to the file. Any events that happen in between will be aggregate and logged as one event.    | error     |
+| logging_delay_seconds | Duration in seconds between events being written to the file. Any events that happen in between will be aggregate and logged as one event.    | 3600      |

--- a/cmake-toolchain/LinuxUserMode-AMD64.cmake
+++ b/cmake-toolchain/LinuxUserMode-AMD64.cmake
@@ -7,7 +7,9 @@ set(CMAKE_SYSTEM_PROCESSOR AMD64)
 
 # Define _AMD64_ to set up the correct SymCrypt macros, e.g. SYMCRYPT_CPU_AMD64
 add_compile_options(-D_AMD64_)
-add_compile_options(-O3)
+if (CMAKE_BUILD_TYPE MATCHES Release|RelWithDebInfo)
+    add_compile_options(-O3)
+endif()
 
 # Enable a baseline of features for the compiler to support everywhere
 # Other than for SSSE3 we do not expect the compiler to generate these instructions anywhere other than with intrinsics

--- a/cmake-toolchain/LinuxUserMode-ARM.cmake
+++ b/cmake-toolchain/LinuxUserMode-ARM.cmake
@@ -25,4 +25,6 @@ if(NOT CMAKE_HOST_SYSTEM_PROCESSOR MATCHES armv8l|ARM$|ARM32|aarch32 AND NOT SCO
 endif()
 
 add_compile_options(-D_ARM_)
-add_compile_options(-O3)
+if (CMAKE_BUILD_TYPE MATCHES Release|RelWithDebInfo)
+    add_compile_options(-O3)
+endif()

--- a/cmake-toolchain/LinuxUserMode-ARM64.cmake
+++ b/cmake-toolchain/LinuxUserMode-ARM64.cmake
@@ -32,4 +32,6 @@ endif()
 
 # Define _ARM64_ to set up the correct SymCrypt macros, e.g. SYMCRYPT_CPU_ARM64
 add_compile_options(-D_ARM64_)
-add_compile_options(-O3)
+if (CMAKE_BUILD_TYPE MATCHES Release|RelWithDebInfo)
+    add_compile_options(-O3)
+endif()


### PR DESCRIPTION
This is a small PR to disable optimizations for debug and sanitize builds, and fixes typos in the readme. This PR also removes '-dev' from the cmake lists since cmake only supports numeric version numbers.