### PR TITLE
Support RSA512 generate in SymCrypt provider

### DIFF
--- a/SslPlay/SslPlay.cpp
+++ b/SslPlay/SslPlay.cpp
@@ -1121,6 +1121,7 @@ end:
 
 void TestRsaEvpAll()
 {
+    TestRsaEvp(512, 65537);
     TestRsaEvp(1024, 65537);
     TestRsaEvp(2048, 65537);
     TestRsaEvp(2049, 65537);

--- a/SslPlay/SslPlay.cpp
+++ b/SslPlay/SslPlay.cpp
@@ -387,6 +387,13 @@ void TestRsaEncryptDecrypt(
         plaintext[0] &= 0xff >> (8 - ((EVP_PKEY_bits(encryptionKey) - 1) & 7));
     }
 
+    if (EVP_PKEY_bits(encryptionKey) <= 512 &&
+        padding == RSA_PKCS1_OAEP_PADDING)
+    {
+        printf("Skipping test: RSA key size ≤ 512 bits is not supported with OAEP padding\n");
+        goto end;
+    }
+
     //
     // Encrypt
     //
@@ -517,8 +524,14 @@ void TestRsaSignVerify(
     size_t message_digest_len = digest_length;
     int ret = 0;
 
-    while(!RAND_bytes(message_digest, digest_length));
+    if (EVP_PKEY_bits(signingKey) <= 512 &&
+        EVP_MD_size(digest) >= 32)
+    {
+        printf("Skipping test: key size ≤ 512 bits is not supported with SHA-256 or stronger digests\n");
+        goto end;
+    }
 
+    while(!RAND_bytes(message_digest, digest_length));
     printf("\nTesting EVP_PKEY_sign* Functions - PKCS1 PADDING\n\n");
     printf("Command EVP_PKEY_CTX_new\n");
     pSignContext = EVP_PKEY_CTX_new(signingKey, NULL);
@@ -653,6 +666,13 @@ void TestRsaDigestSignVerify(
     int AuthStatus = 0;
     EVP_PKEY_CTX *pSigningKeyContext = NULL;
     EVP_PKEY_CTX *pVerificationKeyContext = NULL;
+
+    if (EVP_PKEY_bits(signingKey) <= 512 &&
+        EVP_MD_size(digest) >= 32)
+    {
+        printf("Skipping test: key size ≤ 512 bits is not supported with SHA-256 or stronger digests\n");
+        goto end;
+    }
 
     printf("\nTesting DigestSign* Functions\n\n");
 

--- a/SymCryptEngine/src/e_scossl_rsa.c
+++ b/SymCryptEngine/src/e_scossl_rsa.c
@@ -258,8 +258,9 @@ SCOSSL_STATUS e_scossl_rsa_keygen(_Out_ RSA* rsa, int bits, _In_ BIGNUM* e,
     if (bits < SYMCRYPT_RSAKEY_FIPS_MIN_BITSIZE_MODULUS)
     {
         genFlags |= SYMCRYPT_FLAG_KEY_NO_FIPS;
-        SCOSSL_PROV_LOG_SYMCRYPT_INFO("Generating RSA key with size < %u bits. This operation is not FIPS compliant.", 
-                                       SYMCRYPT_RSAKEY_FIPS_MIN_BITSIZE_MODULUS);
+        SCOSSL_LOG_INFO(SCOSSL_ERR_F_ENG_RSA_KEYGEN, SCOSSL_ERR_R_NOT_FIPS_ALGORITHM,
+            "Generating RSA key with size < %u bits. This operation is not FIPS compliant.", 
+            SYMCRYPT_RSAKEY_FIPS_MIN_BITSIZE_MODULUS);
     }
 
     scError = SymCryptRsakeyGenerate(keyCtx->key, &pubExp64, 1, genFlags);

--- a/SymCryptEngine/src/e_scossl_rsa.c
+++ b/SymCryptEngine/src/e_scossl_rsa.c
@@ -218,6 +218,7 @@ SCOSSL_STATUS e_scossl_rsa_keygen(_Out_ RSA* rsa, int bits, _In_ BIGNUM* e,
     SCOSSL_STATUS ret = SCOSSL_FAILURE;
     SCOSSL_RSA_KEY_CONTEXT *keyCtx = RSA_get_ex_data(rsa, e_scossl_rsa_idx);
     SCOSSL_RSA_EXPORT_PARAMS *rsaParams = NULL;
+    UINT32 genFlags = SYMCRYPT_FLAG_RSAKEY_SIGN | SYMCRYPT_FLAG_RSAKEY_ENCRYPT;
 
     if( keyCtx == NULL )
     {
@@ -253,7 +254,15 @@ SCOSSL_STATUS e_scossl_rsa_keygen(_Out_ RSA* rsa, int bits, _In_ BIGNUM* e,
             "SymCryptLoadMsbFirstUint64 failed");
         goto cleanup;
     }
-    scError = SymCryptRsakeyGenerate(keyCtx->key, &pubExp64, 1, SYMCRYPT_FLAG_RSAKEY_SIGN | SYMCRYPT_FLAG_RSAKEY_ENCRYPT);
+
+    if (bits < SYMCRYPT_RSAKEY_FIPS_MIN_BITSIZE_MODULUS)
+    {
+        genFlags |= SYMCRYPT_FLAG_KEY_NO_FIPS;
+        SCOSSL_PROV_LOG_SYMCRYPT_INFO("Generating RSA key with size < %u bits. This operation is not FIPS compliant.", 
+                                       SYMCRYPT_RSAKEY_FIPS_MIN_BITSIZE_MODULUS);
+    }
+
+    scError = SymCryptRsakeyGenerate(keyCtx->key, &pubExp64, 1, genFlags);
     if( scError != SYMCRYPT_NO_ERROR )
     {
         SCOSSL_LOG_SYMCRYPT_ERROR(SCOSSL_ERR_F_ENG_RSA_KEYGEN,


### PR DESCRIPTION
support RSA key size 512 generate in SymCrypt provider.

Testing:
added: TestRsaEvp(512, 65537)
sslplay passed.