### PR TITLE
FFDHE: Support ffdhe6144 and ffdhe8192 in the SymCrypt provider

### DIFF
--- a/ScosslCommon/src/scossl_dh.c
+++ b/ScosslCommon/src/scossl_dh.c
@@ -12,6 +12,8 @@ static BOOL scossl_dh_initialized = FALSE;
 static PSYMCRYPT_DLGROUP _hidden_dlgroup_ffdhe2048 = NULL;
 static PSYMCRYPT_DLGROUP _hidden_dlgroup_ffdhe3072 = NULL;
 static PSYMCRYPT_DLGROUP _hidden_dlgroup_ffdhe4096 = NULL;
+static PSYMCRYPT_DLGROUP _hidden_dlgroup_ffdhe6144 = NULL;
+static PSYMCRYPT_DLGROUP _hidden_dlgroup_ffdhe8192 = NULL;
 static PSYMCRYPT_DLGROUP _hidden_dlgroup_modp2048 = NULL;
 static PSYMCRYPT_DLGROUP _hidden_dlgroup_modp3072 = NULL;
 static PSYMCRYPT_DLGROUP _hidden_dlgroup_modp4096 = NULL;
@@ -363,6 +365,8 @@ SCOSSL_STATUS scossl_dh_init_static(void)
     if (((_hidden_dlgroup_ffdhe2048 = scossl_initialize_safeprime_dlgroup(SYMCRYPT_DLGROUP_DH_SAFEPRIMETYPE_TLS_7919, 2048)) == NULL) ||
         ((_hidden_dlgroup_ffdhe3072 = scossl_initialize_safeprime_dlgroup(SYMCRYPT_DLGROUP_DH_SAFEPRIMETYPE_TLS_7919, 3072)) == NULL) ||
         ((_hidden_dlgroup_ffdhe4096 = scossl_initialize_safeprime_dlgroup(SYMCRYPT_DLGROUP_DH_SAFEPRIMETYPE_TLS_7919, 4096)) == NULL) ||
+        ((_hidden_dlgroup_ffdhe6144 = scossl_initialize_safeprime_dlgroup(SYMCRYPT_DLGROUP_DH_SAFEPRIMETYPE_TLS_7919, 6144)) == NULL) ||
+        ((_hidden_dlgroup_ffdhe8192 = scossl_initialize_safeprime_dlgroup(SYMCRYPT_DLGROUP_DH_SAFEPRIMETYPE_TLS_7919, 8192)) == NULL) ||    
         ((_hidden_dlgroup_modp2048 = scossl_initialize_safeprime_dlgroup(SYMCRYPT_DLGROUP_DH_SAFEPRIMETYPE_IKE_3526, 2048)) == NULL) ||
         ((_hidden_dlgroup_modp3072 = scossl_initialize_safeprime_dlgroup(SYMCRYPT_DLGROUP_DH_SAFEPRIMETYPE_IKE_3526, 3072)) == NULL) ||
         ((_hidden_dlgroup_modp4096 = scossl_initialize_safeprime_dlgroup(SYMCRYPT_DLGROUP_DH_SAFEPRIMETYPE_IKE_3526, 4096)) == NULL) ||
@@ -393,6 +397,16 @@ void scossl_destroy_safeprime_dlgroups(void)
     {
         SymCryptDlgroupFree(_hidden_dlgroup_ffdhe4096);
         _hidden_dlgroup_ffdhe4096 = NULL;
+    }
+    if (_hidden_dlgroup_ffdhe6144)
+    {
+        SymCryptDlgroupFree(_hidden_dlgroup_ffdhe6144);
+        _hidden_dlgroup_ffdhe6144 = NULL;
+    }
+    if (_hidden_dlgroup_ffdhe8192)
+    {
+        SymCryptDlgroupFree(_hidden_dlgroup_ffdhe8192);
+        _hidden_dlgroup_ffdhe8192 = NULL;
     }
     if (_hidden_dlgroup_modp2048)
     {
@@ -439,6 +453,14 @@ PCSYMCRYPT_DLGROUP scossl_dh_get_known_group(PCSYMCRYPT_DLGROUP pDlGroup)
     {
         pKnownDlGroup = _hidden_dlgroup_ffdhe4096;
     }
+    else if (SymCryptDlgroupIsSame(_hidden_dlgroup_ffdhe6144, pDlGroup))
+    {
+        pKnownDlGroup = _hidden_dlgroup_ffdhe6144;
+    }
+    else if (SymCryptDlgroupIsSame(_hidden_dlgroup_ffdhe8192, pDlGroup))
+    {
+        pKnownDlGroup = _hidden_dlgroup_ffdhe8192;
+    }
     else if (SymCryptDlgroupIsSame(_hidden_dlgroup_modp2048, pDlGroup))
     {
         pKnownDlGroup = _hidden_dlgroup_modp2048;
@@ -470,6 +492,12 @@ SCOSSL_STATUS scossl_dh_get_group_by_nid(int dlGroupNid, const BIGNUM* p,
         break;
     case NID_ffdhe4096:
         *ppDlGroup = _hidden_dlgroup_ffdhe4096;
+        break;
+    case NID_ffdhe6144:
+        *ppDlGroup = _hidden_dlgroup_ffdhe6144;
+        break;
+    case NID_ffdhe8192:
+        *ppDlGroup = _hidden_dlgroup_ffdhe8192;
         break;
 #if OPENSSL_VERSION_MAJOR >= 3
     case NID_modp_2048:
@@ -533,6 +561,14 @@ int scossl_dh_get_group_nid(PCSYMCRYPT_DLGROUP pDlGroup)
     else if (pDlGroup == _hidden_dlgroup_ffdhe4096)
     {
         dlGroupNid = NID_ffdhe4096;
+    }
+    else if (pDlGroup == _hidden_dlgroup_ffdhe6144)
+    {
+        dlGroupNid = NID_ffdhe6144;
+    }
+    else if (pDlGroup == _hidden_dlgroup_ffdhe8192)
+    {
+        dlGroupNid = NID_ffdhe8192;
     }
 #if OPENSSL_VERSION_MAJOR >= 3
     else if (pDlGroup == _hidden_dlgroup_modp2048)

--- a/SslPlay/SslPlay.cpp
+++ b/SslPlay/SslPlay.cpp
@@ -166,8 +166,8 @@ void TestEcc()
     printf("%s", SeparatorLine);
 }
 
-// Largest supported dlgroup is ffdhe4096/MODP4096 => 512 byte shared secret is largest secret that can be generated
-#define SCOSSL_DH_SHARED_SECRET_MAX_LEN (512)
+// Largest supported dlgroup is ffdhe8192/MODP8192 => 1024 byte shared secret is largest secret that can be generated
+#define SCOSSL_DH_SHARED_SECRET_MAX_LEN (1024)
 
 void TestDhDlgroup(const BIGNUM* p)
 {
@@ -307,7 +307,14 @@ void TestDh()
     DH_get0_pqg(dh_ffdhe, &p_ffdhe, NULL, NULL);
     TestDhDlgroup(p_ffdhe);
     DH_free(dh_ffdhe);
-
+    dh_ffdhe = DH_new_by_nid(NID_ffdhe6144);
+    DH_get0_pqg(dh_ffdhe, &p_ffdhe, NULL, NULL);
+    TestDhDlgroup(p_ffdhe);
+    DH_free(dh_ffdhe);
+    dh_ffdhe = DH_new_by_nid(NID_ffdhe8192);
+    DH_get0_pqg(dh_ffdhe, &p_ffdhe, NULL, NULL);
+    TestDhDlgroup(p_ffdhe);
+    DH_free(dh_ffdhe);
     // Test an unsupported DH group
     TestDhDlgroup(NULL);
 

--- a/SslPlay/SslPlay.cpp
+++ b/SslPlay/SslPlay.cpp
@@ -166,7 +166,7 @@ void TestEcc()
     printf("%s", SeparatorLine);
 }
 
-// Largest supported dlgroup is ffdhe8192/MODP8192 => 1024 byte shared secret is largest secret that can be generated
+// Largest supported dlgroup is ffdhe8192 => 1024 byte shared secret is largest secret that can be generated
 #define SCOSSL_DH_SHARED_SECRET_MAX_LEN (1024)
 
 void TestDhDlgroup(const BIGNUM* p)

--- a/SymCryptEngine/README.md
+++ b/SymCryptEngine/README.md
@@ -24,7 +24,7 @@ Note that just because an algorithm is FIPS certifiable, does not mean it is rec
    + SSH-KDF (SHA1, SHA2-256, SHA2-384, SHA2-512)
  + Key Agreement
    + ECDH (P256, P384, P521)
-   + Finite Field DH (ffdhe2048, ffdhe3072, ffdhe4096, modp2048, modp3072, modp4096)
+   + Finite Field DH (ffdhe2048, ffdhe3072, ffdhe4096, ffdhe6144, ffdhe8192, modp2048, modp3072, modp4096)
  + Hashing
    + SHA1
    + SHA2-256

--- a/SymCryptEngine/src/e_scossl_dh.c
+++ b/SymCryptEngine/src/e_scossl_dh.c
@@ -11,8 +11,8 @@ extern "C" {
 
 int e_scossl_dh_idx = -1;
 
-// Largest supported safe-prime group is 4096b => 512 byte Public key
-#define SCOSSL_DH_MAX_PUBLIC_KEY_LEN (512)
+// Largest supported safe-prime group is 8192b => 1024 byte Public key
+#define SCOSSL_DH_MAX_PUBLIC_KEY_LEN (1024)
 
 typedef int (*PFN_DH_meth_generate_key) (DH*);
 typedef int (*PFN_DH_meth_compute_key)(unsigned char* key, const BIGNUM* pub_key, DH* dh);

--- a/SymCryptProvider/README.md
+++ b/SymCryptProvider/README.md
@@ -62,7 +62,7 @@ Note that just because an algorithm is FIPS certifiable, does not mean it is rec
 
 ### Key Exchange
 - DH (Named groups only)
-    - ffdhe2048, ffdhe3072, ffdhe4096
+    - ffdhe2048, ffdhe3072, ffdhe4096, ffdhe6144, ffdhe8192
     - modp2048, modp3072, modp4096
 - ECDH (Named curves only)
     - P-192, P-224, P-256, P-384, P-521

--- a/SymCryptProvider/src/keymgmt/p_scossl_dh_keymgmt.c
+++ b/SymCryptProvider/src/keymgmt/p_scossl_dh_keymgmt.c
@@ -560,6 +560,12 @@ static SCOSSL_PROV_DH_KEY_CTX *p_scossl_dh_keygen(_In_ SCOSSL_DH_KEYGEN_CTX *gen
             case 4096:
                 dlGroupNid = NID_ffdhe4096;
                 break;
+            case 6144:
+                dlGroupNid = NID_ffdhe6144;
+                break;
+            case 8192:
+                dlGroupNid = NID_ffdhe8192;
+                break;
         }
 
         if (scossl_dh_get_group_by_nid(dlGroupNid, NULL, &genCtx->pDlGroup) != SCOSSL_SUCCESS)

--- a/SymCryptProvider/src/p_scossl_base.c
+++ b/SymCryptProvider/src/p_scossl_base.c
@@ -138,6 +138,16 @@ const SCOSSL_TLS_GROUP_INFO scossl_tls_group_info_ffdhe4096 = {
     TLS1_3_VERSION, 0,
     -1, -1};
 
+const SCOSSL_TLS_GROUP_INFO scossl_tls_group_info_ffdhe6144 = {
+    SCOSSL_TLS_GROUP_ID_ffdhe6144, 128, 0,
+    TLS1_3_VERSION, 0,
+    -1, -1};
+
+const SCOSSL_TLS_GROUP_INFO scossl_tls_group_info_ffdhe8192 = {
+    SCOSSL_TLS_GROUP_ID_ffdhe8192, 128, 0,
+    TLS1_3_VERSION, 0,
+    -1, -1};
+
 const SCOSSL_TLS_GROUP_INFO scossl_tls_group_info_mlkem512 = {
     SCOSSL_TLS_GROUP_ID_mlkem512, 128, 1,
     TLS1_3_VERSION, 0,
@@ -201,6 +211,8 @@ static const OSSL_PARAM p_scossl_supported_group_list[][NUM_PARAMS_TLS_GROUP_ENT
     TLS_GROUP_ENTRY("ffdhe2048", SN_ffdhe2048, "DH", scossl_tls_group_info_ffdhe2048),
     TLS_GROUP_ENTRY("ffdhe3072", SN_ffdhe3072, "DH", scossl_tls_group_info_ffdhe3072),
     TLS_GROUP_ENTRY("ffdhe4096", SN_ffdhe4096, "DH", scossl_tls_group_info_ffdhe4096),
+    TLS_GROUP_ENTRY("ffdhe6144", SN_ffdhe6144, "DH", scossl_tls_group_info_ffdhe6144),
+    TLS_GROUP_ENTRY("ffdhe8192", SN_ffdhe8192, "DH", scossl_tls_group_info_ffdhe8192),
     TLS_GROUP_ENTRY("MLKEM512", SCOSSL_SN_MLKEM512, "MLKEM", scossl_tls_group_info_mlkem512),
     TLS_GROUP_ENTRY("MLKEM768", SCOSSL_SN_MLKEM768, "MLKEM", scossl_tls_group_info_mlkem768),
     TLS_GROUP_ENTRY("MLKEM1024", SCOSSL_SN_MLKEM1024, "MLKEM", scossl_tls_group_info_mlkem1024),

--- a/SymCryptProvider/src/p_scossl_base.c
+++ b/SymCryptProvider/src/p_scossl_base.c
@@ -40,6 +40,8 @@ extern "C" {
 #define SCOSSL_TLS_GROUP_ID_ffdhe2048           0x0100
 #define SCOSSL_TLS_GROUP_ID_ffdhe3072           0x0101
 #define SCOSSL_TLS_GROUP_ID_ffdhe4096           0x0102
+#define SCOSSL_TLS_GROUP_ID_ffdhe6144           0x0103
+#define SCOSSL_TLS_GROUP_ID_ffdhe8192           0x0104
 #define SCOSSL_TLS_GROUP_ID_mlkem512            0x0200
 #define SCOSSL_TLS_GROUP_ID_mlkem768            0x0201
 #define SCOSSL_TLS_GROUP_ID_mlkem1024           0x0202


### PR DESCRIPTION
Support ffdhe6144 and ffdhe8192 in the SymCrypt provider

testing:
added ffdhe6144 and ffdhe8192 in sslplay. sslplay passed.