### PR TITLE
Bugfixes for tests

### DIFF
--- a/SymCryptProvider/src/kdf/p_scossl_hkdf.c
+++ b/SymCryptProvider/src/kdf/p_scossl_hkdf.c
@@ -20,7 +20,8 @@ extern "C" {
     OSSL_PARAM_utf8_string(OSSL_KDF_PARAM_PROPERTIES, NULL, 0),     \
     OSSL_PARAM_utf8_string(OSSL_KDF_PARAM_DIGEST, NULL, 0),         \
     OSSL_PARAM_octet_string(OSSL_KDF_PARAM_KEY, NULL, 0),           \
-    OSSL_PARAM_octet_string(OSSL_KDF_PARAM_SALT, NULL, 0)
+    OSSL_PARAM_octet_string(OSSL_KDF_PARAM_SALT, NULL, 0),          \
+    OSSL_PARAM_octet_string(OSSL_KDF_PARAM_INFO, NULL, 0)
 
 static const OSSL_PARAM p_scossl_hkdf_gettable_ctx_param_types[] = {
     HKDF_COMMON_SETTABLES,

--- a/test/KeysInUseTest/KeysInUseTest.cpp
+++ b/test/KeysInUseTest/KeysInUseTest.cpp
@@ -91,7 +91,9 @@ static KEYSINUSE_TEST_KEY testKeys[] = {
     {EVP_PKEY_RSA,      2048,                   nullptr, nullptr, 0, {}},
     {EVP_PKEY_RSA,      3072,                   nullptr, nullptr, 0, {}},
     {EVP_PKEY_RSA,      4096,                   nullptr, nullptr, 0, {}},
+#ifdef NID_X9_62_prime192v1 // This curve is not available on Azure Linux 3
     {EVP_PKEY_EC,       NID_X9_62_prime192v1,   nullptr, nullptr, 0, {}},
+#endif
     {EVP_PKEY_EC,       NID_secp224r1,          nullptr, nullptr, 0, {}},
     {EVP_PKEY_EC,       NID_X9_62_prime256v1,   nullptr, nullptr, 0, {}},
     {EVP_PKEY_EC,       NID_secp384r1,          nullptr, nullptr, 0, {}},


### PR DESCRIPTION
- Expose `OSSL_KDF_PARAM_INFO` for HKDF and TLS13-KDF
- Only compile KeysInUse tests with `prime192v1` if it's available. The curve is not available on Azure Linux 3.