### PR TITLE
Fix use of uninitialized memory and consistency of code handling allocations on SCOSSL 1.9

### DIFF
--- a/ScosslCommon/src/scossl_aes_aead.c
+++ b/ScosslCommon/src/scossl_aes_aead.c
@@ -21,9 +21,14 @@ SCOSSL_STATUS scossl_aes_gcm_init_ctx(SCOSSL_CIPHER_GCM_CTX *ctx, const unsigned
     ctx->useInvocation = 0;
     ctx->ivlen = SCOSSL_GCM_DEFAULT_IV_LENGTH;
 
-    if (iv != NULL && (ctx->iv = OPENSSL_memdup(iv, ctx->ivlen)) == NULL)
+    if (iv != NULL)
     {
-        return SCOSSL_FAILURE;
+        OPENSSL_free(ctx->iv);
+
+        if ((ctx->iv = OPENSSL_memdup(iv, ctx->ivlen)) == NULL)
+        {
+            return SCOSSL_FAILURE;
+        }
     }
 
     return SCOSSL_SUCCESS;
@@ -431,7 +436,7 @@ void scossl_aes_ccm_init_ctx(SCOSSL_CIPHER_CCM_CTX *ctx,
                              const unsigned char *iv)
 {
     ctx->ivlen = SCOSSL_CCM_MIN_IV_LENGTH;
-    if (iv)
+    if (iv != NULL)
     {
         memcpy(ctx->iv, iv, ctx->ivlen);
     }

--- a/ScosslCommon/src/scossl_helpers.c
+++ b/ScosslCommon/src/scossl_helpers.c
@@ -198,6 +198,11 @@ void SCOSSL_set_trace_level(int trace_level, int ossl_ERR_level)
 
 void SCOSSL_set_trace_log_filename(const char *filename)
 {
+    if( _loggingLock == NULL )
+    {
+        return;
+    }
+
     if( _traceLogFilename )
     {
         OPENSSL_free(_traceLogFilename);
@@ -239,6 +244,11 @@ static void _scossl_log_bytes_valist(
     char errStringBuf[SCOSSL_TRACELOG_PARA_LENGTH];
     char paraBuf[SCOSSL_TRACELOG_PARA_LENGTH];
     char *trace_level_prefix = "";
+    
+    if( _loggingLock == NULL )
+    {
+        return;
+    }
 
     if( SYMCRYPT_MAX(_traceLogLevel, _osslERRLogLevel) < trace_level )
     {

--- a/ScosslCommon/src/scossl_mac.c
+++ b/ScosslCommon/src/scossl_mac.c
@@ -129,7 +129,12 @@ SCOSSL_MAC_CTX *scossl_mac_dupctx(SCOSSL_MAC_CTX *ctx)
             }
         }
 
-        copyCtx->mdName = OPENSSL_strdup(ctx->mdName);
+        if (ctx->mdName != NULL &&
+            (copyCtx->mdName = OPENSSL_strdup(ctx->mdName)) == NULL)
+        {
+            goto cleanup;
+        }
+
         copyCtx->libctx = ctx->libctx;
     }
 

--- a/ScosslCommon/src/scossl_tls1prf.c
+++ b/ScosslCommon/src/scossl_tls1prf.c
@@ -17,23 +17,18 @@ _Use_decl_annotations_
 SCOSSL_TLS1_PRF_CTX *scossl_tls1prf_dupctx(SCOSSL_TLS1_PRF_CTX *ctx)
 {
     SCOSSL_TLS1_PRF_CTX *copyCtx = OPENSSL_malloc(sizeof(SCOSSL_TLS1_PRF_CTX));
+
     if (copyCtx != NULL)
     {
-        if (ctx->pbSecret == NULL)
-        {
-            copyCtx->pbSecret = NULL;
-        }
-        else if ((copyCtx->pbSecret = OPENSSL_memdup(ctx->pbSecret, ctx->cbSecret)) == NULL)
+        *copyCtx = *ctx;
+        copyCtx->pbSecret = NULL;
+        
+        if (ctx->pbSecret != NULL &&
+            (copyCtx->pbSecret = OPENSSL_memdup(ctx->pbSecret, ctx->cbSecret)) == NULL)
         {
             scossl_tls1prf_freectx(copyCtx);
-            return NULL;
+            copyCtx = NULL;
         }
-
-        copyCtx->isTlsPrf1_1 = ctx->isTlsPrf1_1;
-        copyCtx->pHmac = ctx->pHmac;
-        copyCtx->cbSecret = ctx->cbSecret;
-        copyCtx->cbSeed = ctx->cbSeed;
-        memcpy(copyCtx->seed, ctx->seed, ctx->cbSeed);
     }
 
     return copyCtx;

--- a/SymCryptProvider/src/ciphers/p_scossl_aes_aead.c
+++ b/SymCryptProvider/src/ciphers/p_scossl_aes_aead.c
@@ -65,10 +65,11 @@ static SCOSSL_CIPHER_GCM_CTX *p_scossl_aes_gcm_dupctx(_In_ SCOSSL_CIPHER_GCM_CTX
     SCOSSL_COMMON_ALIGNED_ALLOC(copy_ctx, OPENSSL_malloc, SCOSSL_CIPHER_GCM_CTX);
     if (copy_ctx != NULL)
     {
-        memcpy(copy_ctx, ctx, sizeof(SCOSSL_CIPHER_GCM_CTX));
+        *copy_ctx = *ctx;
 
         if (ctx->iv != NULL && (copy_ctx->iv = OPENSSL_memdup(ctx->iv, ctx->ivlen)) == NULL)
         {
+            ERR_raise(ERR_LIB_PROV, ERR_R_MALLOC_FAILURE);
             p_scossl_aes_gcm_freectx(copy_ctx);
             return NULL;
         }
@@ -552,7 +553,6 @@ static SCOSSL_STATUS p_scossl_aes_ccm_set_ctx_params(_Inout_ SCOSSL_CIPHER_CCM_C
         if (ctx != NULL)                                                                                     \
         {                                                                                                    \
             ctx->keylen = kbits >> 3;                                                                        \
-            ctx->ivlen = defaultIvLen;                                                                       \
             scossl_aes_##lcmode##_init_ctx(ctx, NULL);                                                       \
         }                                                                                                    \
                                                                                                              \

--- a/SymCryptProvider/src/ciphers/p_scossl_aes_xts.c
+++ b/SymCryptProvider/src/ciphers/p_scossl_aes_xts.c
@@ -40,7 +40,7 @@ static SCOSSL_STATUS p_scossl_aes_xts_set_ctx_params(_Inout_ SCOSSL_AES_XTS_CTX 
 
 static SCOSSL_AES_XTS_CTX *p_scossl_aes_xts_newctx_internal(size_t keylen)
 {
-    SCOSSL_COMMON_ALIGNED_ALLOC(ctx, OPENSSL_malloc, SCOSSL_AES_XTS_CTX);
+    SCOSSL_COMMON_ALIGNED_ALLOC(ctx, OPENSSL_zalloc, SCOSSL_AES_XTS_CTX);
     if (ctx != NULL)
     {
         ctx->keylen = keylen;

--- a/SymCryptProvider/src/digests/p_scossl_cshake.c
+++ b/SymCryptProvider/src/digests/p_scossl_cshake.c
@@ -132,43 +132,21 @@ static SCOSSL_CSHAKE_CTX *p_scossl_cshake_dupctx(_In_ SCOSSL_CSHAKE_CTX *ctx)
 
     SCOSSL_COMMON_ALIGNED_ALLOC(copyCtx, OPENSSL_zalloc, SCOSSL_CSHAKE_CTX);
 
-    if (ctx != NULL)
+    if (copyCtx != NULL)
     {
-        if (ctx->pbFunctionNameString != NULL)
-        {
-            copyCtx->pbFunctionNameString = OPENSSL_memdup(ctx->pbFunctionNameString, ctx->cbFunctionNameString);
-            if (copyCtx->pbFunctionNameString == NULL)
-            {
-                ERR_raise(ERR_LIB_PROV, ERR_R_MALLOC_FAILURE);
-                goto cleanup;
-            }
-        }
-        else
-        {
-            copyCtx->pbFunctionNameString = NULL;
-        }
-        copyCtx->cbFunctionNameString = ctx->cbFunctionNameString;
+        *copyCtx = *ctx;
 
-        if (ctx->pbCustomizationString != NULL)
+        copyCtx->pbFunctionNameString = OPENSSL_memdup(ctx->pbFunctionNameString, ctx->cbFunctionNameString);
+        copyCtx->pbCustomizationString = OPENSSL_memdup(ctx->pbCustomizationString, ctx->cbCustomizationString);
+
+        if ((ctx->pbFunctionNameString != NULL  && copyCtx->pbFunctionNameString == NULL) ||
+            (ctx->pbCustomizationString != NULL && copyCtx->pbCustomizationString == NULL))
         {
-            copyCtx->pbCustomizationString = OPENSSL_memdup(ctx->pbCustomizationString, ctx->cbCustomizationString);
-            if (copyCtx->pbCustomizationString == NULL)
-            {
-                ERR_raise(ERR_LIB_PROV, ERR_R_MALLOC_FAILURE);
-                goto cleanup;
-            }
+            ERR_raise(ERR_LIB_PROV, ERR_R_MALLOC_FAILURE);
+            goto cleanup;
         }
-        else
-        {
-            copyCtx->pbCustomizationString = NULL;
-        }
-        copyCtx->cbCustomizationString = ctx->cbCustomizationString;
 
         ctx->pHash->stateCopyFunc(&ctx->state, &copyCtx->state);
-
-        copyCtx->pHash = ctx->pHash;
-        copyCtx->xofState = ctx->xofState;
-        copyCtx->xofLen = ctx->xofLen;
     }
 
     status = SCOSSL_SUCCESS;

--- a/SymCryptProvider/src/kdf/p_scossl_hkdf.c
+++ b/SymCryptProvider/src/kdf/p_scossl_hkdf.c
@@ -53,12 +53,11 @@ SCOSSL_PROV_HKDF_CTX *p_scossl_hkdf_newctx(_In_ SCOSSL_PROVCTX *provctx)
 
 void p_scossl_hkdf_freectx(_Inout_ SCOSSL_PROV_HKDF_CTX *ctx)
 {
-    if (ctx != NULL)
-    {
-        EVP_MD_free(ctx->hkdfCtx->md);
-        scossl_hkdf_freectx(ctx->hkdfCtx);
-    }
+    if (ctx == NULL)
+        return;
 
+    EVP_MD_free(ctx->hkdfCtx->md);
+    scossl_hkdf_freectx(ctx->hkdfCtx);
     OPENSSL_free(ctx);
 }
 

--- a/SymCryptProvider/src/kdf/p_scossl_pbkdf2.c
+++ b/SymCryptProvider/src/kdf/p_scossl_pbkdf2.c
@@ -78,7 +78,7 @@ SCOSSL_PROV_PBKDF2_CTX *p_scossl_pbkdf2_dupctx(_In_ SCOSSL_PROV_PBKDF2_CTX *ctx)
 {
     SCOSSL_STATUS status = SCOSSL_FAILURE;
 
-    SCOSSL_PROV_PBKDF2_CTX *copyCtx = OPENSSL_malloc(sizeof(SCOSSL_PROV_PBKDF2_CTX));
+    SCOSSL_PROV_PBKDF2_CTX *copyCtx = OPENSSL_zalloc(sizeof(SCOSSL_PROV_PBKDF2_CTX));
     if (copyCtx != NULL)
     {
         copyCtx->libctx = ctx->libctx;
@@ -98,17 +98,12 @@ SCOSSL_PROV_PBKDF2_CTX *p_scossl_pbkdf2_dupctx(_In_ SCOSSL_PROV_PBKDF2_CTX *ctx)
             memcpy(copyCtx->pbPassword, ctx->pbPassword, ctx->cbPassword);
             copyCtx->cbPassword = ctx->cbPassword;
         }
-        else
-        {
-            copyCtx->pbPassword = NULL;
-            copyCtx->cbPassword = 0;
-        }
 
-        if ((copyCtx->pbSalt = OPENSSL_memdup(ctx->pbSalt, ctx->cbSalt)) == NULL &&
-            ctx->pbSalt != NULL)
+        if (ctx->pbSalt != NULL &&
+            (copyCtx->pbSalt = OPENSSL_memdup(ctx->pbSalt, ctx->cbSalt)) == NULL)
         {
             ERR_raise(ERR_LIB_PROV, ERR_R_MALLOC_FAILURE);
-            goto cleanup;            
+            goto cleanup;
         }
         copyCtx->cbSalt = ctx->cbSalt;
     }

--- a/SymCryptProvider/src/kdf/p_scossl_srtpkdf.c
+++ b/SymCryptProvider/src/kdf/p_scossl_srtpkdf.c
@@ -94,6 +94,9 @@ static SCOSSL_PROV_SRTPKDF_CTX *p_scossl_srtpkdf_dupctx(_In_ SCOSSL_PROV_SRTPKDF
 
     if (copyCtx != NULL)
     {
+        *copyCtx = *ctx;
+        copyCtx->pbKey = NULL;
+
         if (ctx->pbKey != NULL)
         {
             if ((copyCtx->pbKey = OPENSSL_secure_malloc(ctx->cbKey)) == NULL)
@@ -103,7 +106,6 @@ static SCOSSL_PROV_SRTPKDF_CTX *p_scossl_srtpkdf_dupctx(_In_ SCOSSL_PROV_SRTPKDF
             }
 
             memcpy(copyCtx->pbKey, ctx->pbKey, ctx->cbKey);
-            copyCtx->cbKey = ctx->cbKey;
 
             scError = SymCryptSrtpKdfExpandKey(&copyCtx->expandedKey, copyCtx->pbKey, copyCtx->cbKey);
             if (scError != SYMCRYPT_NO_ERROR)
@@ -112,23 +114,6 @@ static SCOSSL_PROV_SRTPKDF_CTX *p_scossl_srtpkdf_dupctx(_In_ SCOSSL_PROV_SRTPKDF
                 goto cleanup;
             }
         }
-        else
-        {
-            copyCtx->pbKey = NULL;
-            copyCtx->cbKey = 0;
-        }
-
-        if (ctx->isSaltSet)
-        {
-            memcpy(copyCtx->pbSalt, ctx->pbSalt, SCOSSL_SRTP_KDF_SALT_SIZE);
-        }
-
-        copyCtx->isSrtcp = ctx->isSrtcp;
-        copyCtx->isSaltSet = ctx->isSaltSet;
-        copyCtx->uKeyDerivationRate = ctx->uKeyDerivationRate;
-        copyCtx->uIndex = ctx->uIndex;
-        copyCtx->uIndexWidth = ctx->uIndexWidth;
-        copyCtx->label = ctx->label;
     }
 
     status = SCOSSL_SUCCESS;

--- a/SymCryptProvider/src/kdf/p_scossl_sshkdf.c
+++ b/SymCryptProvider/src/kdf/p_scossl_sshkdf.c
@@ -62,28 +62,44 @@ SCOSSL_PROV_SSHKDF_CTX *p_scossl_sshkdf_newctx(_In_ SCOSSL_PROVCTX *provctx)
 
 void p_scossl_sshkdf_freectx(_Inout_ SCOSSL_PROV_SSHKDF_CTX *ctx)
 {
-    if (ctx != NULL)
-    {
-        OPENSSL_free(ctx->mdName);
-        scossl_sshkdf_freectx(ctx->sshkdfCtx);
-    }
-
+    if (ctx == NULL)
+        return;
+    
+    OPENSSL_free(ctx->mdName);
+    scossl_sshkdf_freectx(ctx->sshkdfCtx);
     OPENSSL_free(ctx);
 }
 
 SCOSSL_PROV_SSHKDF_CTX *p_scossl_sshkdf_dupctx(_In_ SCOSSL_PROV_SSHKDF_CTX *ctx)
 {
-    SCOSSL_PROV_SSHKDF_CTX *copyCtx = OPENSSL_malloc(sizeof(SCOSSL_PROV_SSHKDF_CTX));
+    SCOSSL_STATUS status = SCOSSL_FAILURE;
+
+    SCOSSL_PROV_SSHKDF_CTX *copyCtx = OPENSSL_zalloc(sizeof(SCOSSL_PROV_SSHKDF_CTX));
     if (copyCtx != NULL)
     {
         if ((copyCtx->sshkdfCtx = scossl_sshkdf_dupctx(ctx->sshkdfCtx)) == NULL)
         {
-            OPENSSL_free(copyCtx);
-            return NULL;
+            ERR_raise(ERR_LIB_PROV, ERR_R_MALLOC_FAILURE);
+            goto cleanup;
+        }
+
+        if (ctx->mdName != NULL &&
+            (copyCtx->mdName = OPENSSL_strdup(ctx->mdName)) == NULL)
+        {
+            ERR_raise(ERR_LIB_PROV, ERR_R_MALLOC_FAILURE);
+            goto cleanup;
         }
 
         copyCtx->libctx = ctx->libctx;
-        copyCtx->mdName = OPENSSL_strdup(ctx->mdName);
+    }
+
+    status = SCOSSL_SUCCESS;
+
+cleanup:
+    if (status != SCOSSL_SUCCESS)
+    {
+        p_scossl_sshkdf_freectx(copyCtx);
+        copyCtx = NULL;
     }
 
     return copyCtx;
@@ -206,6 +222,12 @@ SCOSSL_STATUS p_scossl_sshkdf_set_ctx_params(_Inout_ SCOSSL_PROV_SSHKDF_CTX *ctx
         mdName = OPENSSL_strdup(EVP_MD_get0_name(md));
         symcryptHashAlg = scossl_get_symcrypt_hash_algorithm(EVP_MD_type(md));
         EVP_MD_free(md);
+
+        if (mdName == NULL)
+        {
+            ERR_raise(ERR_LIB_PROV, ERR_R_MALLOC_FAILURE);
+            return SCOSSL_FAILURE;
+        }
 
         if (symcryptHashAlg == NULL)
         {

--- a/SymCryptProvider/src/kdf/p_scossl_tls1prf.c
+++ b/SymCryptProvider/src/kdf/p_scossl_tls1prf.c
@@ -44,28 +44,44 @@ SCOSSL_PROV_TLS1_PRF_CTX *p_scossl_tls1prf_newctx(_In_ SCOSSL_PROVCTX *provctx)
 
 void p_scossl_tls1prf_freectx(_Inout_ SCOSSL_PROV_TLS1_PRF_CTX *ctx)
 {
-    if (ctx != NULL)
-    {
-        scossl_tls1prf_freectx(ctx->tls1prfCtx);
-        OPENSSL_free(ctx->mdName);
-    }
+    if (ctx == NULL)
+        return;
 
+    OPENSSL_free(ctx->mdName);
+    scossl_tls1prf_freectx(ctx->tls1prfCtx);
     OPENSSL_free(ctx);
 }
 
 SCOSSL_PROV_TLS1_PRF_CTX *p_scossl_tls1prf_dupctx(_In_ SCOSSL_PROV_TLS1_PRF_CTX *ctx)
 {
-    SCOSSL_PROV_TLS1_PRF_CTX *copyCtx = OPENSSL_malloc(sizeof(SCOSSL_PROV_TLS1_PRF_CTX));
+    SCOSSL_STATUS status = SCOSSL_FAILURE;
+
+    SCOSSL_PROV_TLS1_PRF_CTX *copyCtx = OPENSSL_zalloc(sizeof(SCOSSL_PROV_TLS1_PRF_CTX));
     if (copyCtx != NULL)
     {
         if ((copyCtx->tls1prfCtx = scossl_tls1prf_dupctx(ctx->tls1prfCtx)) == NULL)
         {
-            OPENSSL_free(copyCtx);
-            return NULL;
+            ERR_raise(ERR_LIB_PROV, ERR_R_MALLOC_FAILURE);
+            goto cleanup;
         }
 
-        copyCtx->mdName = OPENSSL_strdup(ctx->mdName);
+        if (ctx->mdName != NULL &&
+            (copyCtx->mdName = OPENSSL_strdup(ctx->mdName)) == NULL)
+        {
+            ERR_raise(ERR_LIB_PROV, ERR_R_MALLOC_FAILURE);
+            goto cleanup;
+        }
+
         copyCtx->libctx = ctx->libctx;
+    }
+
+    status = SCOSSL_SUCCESS;
+
+cleanup:
+    if (status != SCOSSL_SUCCESS)
+    {
+        p_scossl_tls1prf_freectx(copyCtx);
+        copyCtx = NULL;
     }
 
     return copyCtx;
@@ -203,6 +219,11 @@ SCOSSL_STATUS p_scossl_tls1prf_set_ctx_params(_Inout_ SCOSSL_PROV_TLS1_PRF_CTX *
         OPENSSL_free(ctx->mdName);
         ctx->mdName = mdName;
         mdName = NULL;
+        if (ctx->mdName == NULL)
+        {
+            ERR_raise(ERR_LIB_PROV, ERR_R_MALLOC_FAILURE);
+            goto cleanup;
+        }
 
         ctx->tls1prfCtx->pHmac = symcryptHmacAlg;
         ctx->tls1prfCtx->isTlsPrf1_1 = isTlsPrf1_1;

--- a/SymCryptProvider/src/keyexch/p_scossl_dh.c
+++ b/SymCryptProvider/src/keyexch/p_scossl_dh.c
@@ -97,10 +97,10 @@ static SCOSSL_DH_CTX *p_scossl_dh_dupctx(_In_ SCOSSL_DH_CTX *ctx)
         copyCtx->kdfCekAlg = OPENSSL_strdup(ctx->kdfCekAlg);
         copyCtx->kdfUkm = OPENSSL_memdup(ctx->kdfUkm, ctx->kdfUkmlen);
 
-        if ((ctx->kdfMdName != NULL && (copyCtx->kdfMdName == NULL)) ||
+        if ((ctx->kdfMdName != NULL  && (copyCtx->kdfMdName == NULL)) ||
             (ctx->kdfMdProps != NULL && (copyCtx->kdfMdProps == NULL)) ||
-            (ctx->kdfCekAlg != NULL && (copyCtx->kdfCekAlg == NULL)) ||
-            (ctx->kdfUkm != NULL && (copyCtx->kdfUkm == NULL)))
+            (ctx->kdfCekAlg != NULL  && (copyCtx->kdfCekAlg == NULL)) ||
+            (ctx->kdfUkm != NULL     && (copyCtx->kdfUkm == NULL)))
         {
             p_scossl_dh_freectx(copyCtx);
             copyCtx = NULL;

--- a/SymCryptProvider/src/keyexch/p_scossl_ecdh.c
+++ b/SymCryptProvider/src/keyexch/p_scossl_ecdh.c
@@ -47,9 +47,7 @@ static SCOSSL_ECDH_CTX *p_scossl_ecdh_dupctx(_In_ SCOSSL_ECDH_CTX *ctx)
     SCOSSL_ECDH_CTX *copyCtx = OPENSSL_malloc(sizeof(SCOSSL_ECDH_CTX));
     if (copyCtx != NULL)
     {
-        copyCtx->libctx = ctx->libctx;
-        copyCtx->keyCtx = ctx->keyCtx;
-        copyCtx->peerKeyCtx = ctx->peerKeyCtx;
+        *copyCtx = *ctx;
     }
 
     return copyCtx;

--- a/SymCryptProvider/src/keymgmt/p_scossl_dh_keymgmt.c
+++ b/SymCryptProvider/src/keymgmt/p_scossl_dh_keymgmt.c
@@ -12,7 +12,7 @@
 extern "C" {
 #endif
 
-#define SCOSSL_DH_KEYHEN_POSSIBLE_SELECTIONS (OSSL_KEYMGMT_SELECT_KEYPAIR | OSSL_KEYMGMT_SELECT_DOMAIN_PARAMETERS)
+#define SCOSSL_DH_KEYGEN_POSSIBLE_SELECTIONS (OSSL_KEYMGMT_SELECT_KEYPAIR | OSSL_KEYMGMT_SELECT_DOMAIN_PARAMETERS)
 
 #define SCOSSL_DH_PBITS_DEFAULT 2048
 // Private key length determined by group
@@ -105,15 +105,13 @@ static SCOSSL_PROV_DH_KEY_CTX *p_scossl_dh_keymgmt_new_ctx(_In_ SCOSSL_PROVCTX *
         if ((ctx->keyCtx = scossl_dh_new_key_ctx()) == NULL)
         {
             OPENSSL_free(ctx);
-            ctx = NULL;
+            return NULL;
         }
-        else
-        {
-            ctx->pDlGroup = NULL;
-            ctx->groupSetByParams = FALSE;
-            ctx->nBitsPriv = SCOSSL_DH_PRIVATE_BITS_DEFAULT;
-            ctx->libCtx = provCtx->libctx;
-        }
+
+        ctx->pDlGroup = NULL;
+        ctx->groupSetByParams = FALSE;
+        ctx->nBitsPriv = SCOSSL_DH_PRIVATE_BITS_DEFAULT;
+        ctx->libCtx = provCtx->libctx;
     }
 
     return ctx;
@@ -500,7 +498,7 @@ static SCOSSL_DH_KEYGEN_CTX *p_scossl_dh_keygen_init(_In_ SCOSSL_PROVCTX *provCt
 {
     SCOSSL_DH_KEYGEN_CTX *genCtx = NULL;
 
-    if ((selection & SCOSSL_DH_KEYHEN_POSSIBLE_SELECTIONS) != 0 &&
+    if ((selection & SCOSSL_DH_KEYGEN_POSSIBLE_SELECTIONS) != 0 &&
         (genCtx = OPENSSL_malloc(sizeof(SCOSSL_DH_KEYGEN_CTX))) != NULL)
     {
         genCtx->pDlGroup = NULL;

--- a/SymCryptProvider/src/keymgmt/p_scossl_rsa_keymgmt.c
+++ b/SymCryptProvider/src/keymgmt/p_scossl_rsa_keymgmt.c
@@ -233,7 +233,7 @@ cleanup:
 
 static SCOSSL_PROV_RSA_KEY_CTX *p_scossl_rsa_keymgmt_dup_ctx(_In_ const SCOSSL_PROV_RSA_KEY_CTX *keyCtx, int selection)
 {
-    SCOSSL_PROV_RSA_KEY_CTX *copyCtx = OPENSSL_malloc(sizeof(SCOSSL_PROV_RSA_KEY_CTX));
+    SCOSSL_PROV_RSA_KEY_CTX *copyCtx = OPENSSL_zalloc(sizeof(SCOSSL_PROV_RSA_KEY_CTX));
     if (copyCtx == NULL)
     {
         return NULL;

--- a/SymCryptProvider/src/keymgmt/p_scossl_rsa_keymgmt.c
+++ b/SymCryptProvider/src/keymgmt/p_scossl_rsa_keymgmt.c
@@ -88,6 +88,11 @@ static SCOSSL_PROV_RSA_KEY_CTX *p_scossl_rsa_keymgmt_new_ctx(ossl_unused void *p
         keyCtx->keyType = RSA_FLAG_TYPE_RSA;
 #ifdef KEYSINUSE_ENABLED
         keyCtx->keysinuseLock = CRYPTO_THREAD_lock_new();
+        if (keyCtx->keysinuseLock == NULL)
+        {
+            OPENSSL_free(keyCtx);
+            return NULL;
+        }
 #endif
     }
     return keyCtx;
@@ -102,6 +107,11 @@ static SCOSSL_PROV_RSA_KEY_CTX *p_scossl_rsapss_keymgmt_new_ctx(_In_ SCOSSL_PROV
         keyCtx->keyType = RSA_FLAG_TYPE_RSASSAPSS;
 #ifdef KEYSINUSE_ENABLED
         keyCtx->keysinuseLock = CRYPTO_THREAD_lock_new();
+        if (keyCtx->keysinuseLock == NULL)
+        {
+            OPENSSL_free(keyCtx);
+            return NULL;
+        }
 #endif
     }
     return keyCtx;
@@ -241,6 +251,11 @@ static SCOSSL_PROV_RSA_KEY_CTX *p_scossl_rsa_keymgmt_dup_ctx(_In_ const SCOSSL_P
 
 #ifdef KEYSINUSE_ENABLED
     copyCtx->keysinuseLock = CRYPTO_THREAD_lock_new();
+    if (copyCtx->keysinuseLock == NULL)
+    {
+        OPENSSL_free(copyCtx);
+        return NULL;
+    }
 
     if (keyCtx->keysinuseInfo == NULL ||
         p_scossl_keysinuse_upref(keyCtx->keysinuseInfo, NULL))
@@ -407,7 +422,7 @@ static SCOSSL_PROV_RSA_KEY_CTX *p_scossl_rsa_keygen(_In_ SCOSSL_RSA_KEYGEN_CTX *
     SYMCRYPT_ERROR scError;
     PUINT64 pPubExp64;
 
-    keyCtx = OPENSSL_malloc(sizeof(SCOSSL_PROV_RSA_KEY_CTX));
+    keyCtx = OPENSSL_zalloc(sizeof(SCOSSL_PROV_RSA_KEY_CTX));
     if (keyCtx == NULL)
     {
         goto cleanup;
@@ -433,15 +448,20 @@ static SCOSSL_PROV_RSA_KEY_CTX *p_scossl_rsa_keygen(_In_ SCOSSL_RSA_KEYGEN_CTX *
         goto cleanup;
     }
 
-    keyCtx->initialized = TRUE;
     keyCtx->keyType = genCtx->keyType;
     keyCtx->pssRestrictions = genCtx->pssRestrictions;
     genCtx->pssRestrictions = NULL;
 #ifdef KEYSINUSE_ENABLED
     keyCtx->isImported = FALSE;
     keyCtx->keysinuseLock = CRYPTO_THREAD_lock_new();
+    if (keyCtx->keysinuseLock == NULL)
+    {
+        goto cleanup;
+    }
     keyCtx->keysinuseInfo = NULL;
 #endif
+
+    keyCtx->initialized = TRUE;
 
 cleanup:
     if (keyCtx != NULL && !keyCtx->initialized)

--- a/SymCryptProvider/src/mac/p_scossl_hmac.c
+++ b/SymCryptProvider/src/mac/p_scossl_hmac.c
@@ -181,7 +181,11 @@ static SCOSSL_STATUS p_scossl_hmac_set_ctx_params(_Inout_ SCOSSL_MAC_CTX *ctx, _
             goto cleanup;
         }
 
-        ctx->mdName = OPENSSL_strdup(mdName);
+        if ((ctx->mdName = OPENSSL_strdup(mdName)) == NULL)
+        {
+            ERR_raise(ERR_LIB_PROV, ERR_R_MALLOC_FAILURE);
+            goto cleanup;
+        }
     }
 
     if ((p = OSSL_PARAM_locate_const(params, OSSL_MAC_PARAM_KEY)) != NULL)

--- a/SymCryptProvider/src/p_scossl_keysinuse.c
+++ b/SymCryptProvider/src/p_scossl_keysinuse.c
@@ -149,6 +149,11 @@ static void p_scossl_keysinuse_init_once()
 
     sk_keysinuse_info_lock = CRYPTO_THREAD_lock_new();
     sk_keysinuse_info = sk_SCOSSL_PROV_KEYSINUSE_INFO_new_null();
+    if (sk_keysinuse_info_lock == NULL || sk_keysinuse_info == NULL)
+    {
+        p_scossl_keysinuse_log_error("Failed to create global objects used by keysinuse");
+        goto cleanup;
+    }
 
     // Try to create /var/log/keysinuse if it isn't present.
     // This is a best attempt and only succeeds if the callers


### PR DESCRIPTION
This is mostly a cherry-pick of #133, but there has been some divergence between 1.9 and main, specifically around KeysInUse and ECC, so needed a little extra work.

- Found a couple of extra hardening measures to bring back to main in the second commit, notably:
  - Remove paths for UB in failure to allocate `CRYPTO_THREAD_lock`
  - Remove paths for use of uninitialized memory `p_scossl_rsa_keygen`

Tests:
- Ran SslPlay under valgrind on AzL3 with these changes and no regressions