### PR TITLE
DHE-RSA-AES256-GCM-SHA384 cipher not working on client side

### DIFF
--- a/ScosslCommon/src/scossl_dh.c
+++ b/ScosslCommon/src/scossl_dh.c
@@ -308,7 +308,7 @@ SCOSSL_STATUS scossl_dh_generate_keypair(SCOSSL_DH_KEY_CTX *ctx, int nBitsPriv, 
         }
     }
 
-    scError = SymCryptDlkeyGenerate(SYMCRYPT_FLAG_DLKEY_DH, ctx->dlkey);
+    scError = SymCryptDlkeyGenerate(SYMCRYPT_FLAG_DLKEY_DH | SYMCRYPT_FLAG_DLKEY_GEN_MODP | SYMCRYPT_FLAG_KEY_NO_FIPS, ctx->dlkey);
     if (scError != SYMCRYPT_NO_ERROR)
     {
         SCOSSL_LOG_SYMCRYPT_ERROR(SCOSSL_ERR_F_DH_GENERATE_KEYPAIR,

--- a/SymCryptProvider/src/keymgmt/p_scossl_dh_keymgmt.c
+++ b/SymCryptProvider/src/keymgmt/p_scossl_dh_keymgmt.c
@@ -1260,7 +1260,7 @@ static SCOSSL_STATUS p_scossl_dh_keymgmt_export(_In_ SCOSSL_PROV_DH_KEY_CTX *ctx
     OSSL_PARAM_BLD *bld = NULL;
     OSSL_PARAM *params = NULL;
     // Always export public key if key is initialized
-    BOOL includePublic = ctx->keyCtx->initialized;
+    BOOL includePublic = (selection & OSSL_KEYMGMT_SELECT_PUBLIC_KEY) != 0;;
     BOOL includePrivate = (selection & OSSL_KEYMGMT_SELECT_PRIVATE_KEY) != 0;
     PBYTE pbPrimeP = NULL;
     PBYTE pbPrimeQ = NULL;

--- a/SymCryptProvider/src/keymgmt/p_scossl_dh_keymgmt.c
+++ b/SymCryptProvider/src/keymgmt/p_scossl_dh_keymgmt.c
@@ -1259,7 +1259,6 @@ static SCOSSL_STATUS p_scossl_dh_keymgmt_export(_In_ SCOSSL_PROV_DH_KEY_CTX *ctx
 {
     OSSL_PARAM_BLD *bld = NULL;
     OSSL_PARAM *params = NULL;
-    // Always export public key if key is initialized
     BOOL includePublic = (selection & OSSL_KEYMGMT_SELECT_PUBLIC_KEY) != 0;;
     BOOL includePrivate = (selection & OSSL_KEYMGMT_SELECT_PRIVATE_KEY) != 0;
     PBYTE pbPrimeP = NULL;

--- a/SymCryptProvider/src/keymgmt/p_scossl_dh_keymgmt.c
+++ b/SymCryptProvider/src/keymgmt/p_scossl_dh_keymgmt.c
@@ -1259,7 +1259,7 @@ static SCOSSL_STATUS p_scossl_dh_keymgmt_export(_In_ SCOSSL_PROV_DH_KEY_CTX *ctx
 {
     OSSL_PARAM_BLD *bld = NULL;
     OSSL_PARAM *params = NULL;
-    BOOL includePublic = (selection & OSSL_KEYMGMT_SELECT_PUBLIC_KEY) != 0;;
+    BOOL includePublic = (selection & OSSL_KEYMGMT_SELECT_PUBLIC_KEY) != 0;
     BOOL includePrivate = (selection & OSSL_KEYMGMT_SELECT_PRIVATE_KEY) != 0;
     PBYTE pbPrimeP = NULL;
     PBYTE pbPrimeQ = NULL;

--- a/SymCryptProvider/src/keymgmt/p_scossl_dh_keymgmt.c
+++ b/SymCryptProvider/src/keymgmt/p_scossl_dh_keymgmt.c
@@ -961,7 +961,7 @@ static SCOSSL_STATUS p_scossl_dh_keymgmt_get_params(_In_ SCOSSL_PROV_DH_KEY_CTX 
         (privKeyBits < 0 || !OSSL_PARAM_set_int(p, privKeyBits)))
     {
         ERR_raise(ERR_LIB_PROV, PROV_R_FAILED_TO_SET_PARAMETER);
-        return SCOSSL_SUCCESS;
+        return SCOSSL_FAILURE;
     }
 
     if ((p = OSSL_PARAM_locate(params, OSSL_PKEY_PARAM_GROUP_NAME)) != NULL)

--- a/SymCryptProvider/src/keymgmt/p_scossl_dh_keymgmt.c
+++ b/SymCryptProvider/src/keymgmt/p_scossl_dh_keymgmt.c
@@ -89,7 +89,6 @@ static const OSSL_PARAM p_scossl_dh_keymgmt_gettable_param_types[] = {
     OSSL_PARAM_int(OSSL_PKEY_PARAM_SECURITY_BITS, NULL),
     OSSL_PARAM_int(OSSL_PKEY_PARAM_MAX_SIZE, NULL),
     OSSL_PARAM_octet_string(OSSL_PKEY_PARAM_ENCODED_PUBLIC_KEY, NULL, 0),
-    OSSL_PARAM_utf8_string(OSSL_PKEY_PARAM_GROUP_NAME, NULL, 0),
     OSSL_PARAM_BN(OSSL_PKEY_PARAM_FFC_P, NULL, 0),
     OSSL_PARAM_BN(OSSL_PKEY_PARAM_FFC_Q, NULL, 0),
     OSSL_PARAM_BN(OSSL_PKEY_PARAM_FFC_G, NULL, 0),
@@ -937,7 +936,7 @@ static SCOSSL_STATUS p_scossl_dh_keymgmt_get_params(_In_ SCOSSL_PROV_DH_KEY_CTX 
         (pubKeyBits < 0 || !OSSL_PARAM_set_int(p, pubKeyBits)))
     {
         ERR_raise(ERR_LIB_PROV, PROV_R_FAILED_TO_SET_PARAMETER);
-        return SCOSSL_SUCCESS;
+        return SCOSSL_FAILURE;
     }
 
     if ((p = OSSL_PARAM_locate(params, OSSL_PKEY_PARAM_SECURITY_BITS)) != NULL)
@@ -947,7 +946,7 @@ static SCOSSL_STATUS p_scossl_dh_keymgmt_get_params(_In_ SCOSSL_PROV_DH_KEY_CTX 
             !OSSL_PARAM_set_int(p, BN_security_bits(pubKeyBits, privKeyBits)))
         {
             ERR_raise(ERR_LIB_PROV, PROV_R_FAILED_TO_SET_PARAMETER);
-            return SCOSSL_SUCCESS;
+            return SCOSSL_FAILURE;
         }
     }
 
@@ -955,7 +954,7 @@ static SCOSSL_STATUS p_scossl_dh_keymgmt_get_params(_In_ SCOSSL_PROV_DH_KEY_CTX 
         (pubKeyBits < 0 || !OSSL_PARAM_set_int(p, pubKeyBits / 8)))
     {
         ERR_raise(ERR_LIB_PROV, PROV_R_FAILED_TO_SET_PARAMETER);
-        return SCOSSL_SUCCESS;
+        return SCOSSL_FAILURE;
     }
 
     if ((p = OSSL_PARAM_locate(params, OSSL_PKEY_PARAM_DH_PRIV_LEN)) != NULL &&
@@ -1229,7 +1228,7 @@ static SCOSSL_STATUS p_scossl_dh_keymgmt_import(_Inout_ SCOSSL_PROV_DH_KEY_CTX *
     ctx->pDlGroup = pDlGroup;
     ctx->groupSetByParams = groupSetByParams;
     ctx->nBitsPriv = nBitsPriv;
-    ctx->keyCtx->initialized = TRUE;
+
     ret = SCOSSL_SUCCESS;
 
 cleanup:


### PR DESCRIPTION
AFD operates as TLS server and uses symcrypt provider, they are seeing below error
Error with DHE cipher on client side (DHE-RSA-AES256-GCM-SHA384):
3613489686336:error:14094438:SSL routines:ssl3_read_bytes:tlsv1 alert internal error:ssl/record/rec_layer_s3.c:1562:SSL alert number 80

To reproduce:
curl -v https://tlsv12-2022.int.protocols.spectest.z01.azfdtest.xyz/ -o /dev/null --resolve tlsv12-2022.int.protocols.spectest.z01.azfdtest.xyz:443:104.209.91.7 --tlsv1.2 --tls-max 1.2 --ciphers DHE-RSA-AES256-GCM-SHA384
or 
 OPENSSL_TRACE=KEYMGMT,KEYEXCH openssl s_client -connect 172.22.122.133:443 -provider symcryptprovider -cipher DHE-RSA-AES256-GCM-SHA384 -CAfile cert.pem -tls1_2
 their server stopped working, need to setup own server.
 
Root Cause:
The internal error was caused by mix use of openssl default provider and symcryptprovider. The keygen was done by openssl, while keymgmt was done by symcryptoprovider.

 (1) symcryptprovider needs to advertise p q g, so openssl knows symcryptprovider support keygen, so after keygen_set_params, the symcrypt keygen will be called. 
 (2) DHE-RSA-AES256-GCM-SHA384 is not FIPS cipher, so need to add NO_FIPS option when keygen
 (3)  if OpenSSL passes p, g via params instead of a named group, groupSetByParams == TRUE, but should not block keygen entirely.
 
Testing:
(1) setup server using: openssl s_server -accept 443   -cert cert.pem   -key key.pem   -dhparam dhparam.pem   -tls1_2   -cipher DHE-RSA-AES256-GCM-SHA384
(2) test with:
 OPENSSL_TRACE=KEYMGMT,KEYEXCH openssl s_client -connect 172.22.122.133:443 -provider symcryptprovider -cipher DHE-RSA-AES256-GCM-SHA384 -CAfile cert.pem -tls1_2
and
 curl -v https://tlsv12-2022.int.protocols.spectest.z01.azfdtest.xyz/   --resolve tlsv12-2022.int.protocols.spectest.z01.azfdtest.xyz:443:172.22.122.133   --tlsv1.2 --tls-max 1.2   --ciphers DHE-RSA-AES256-GCM-SHA384   --cacert cert.pem   -o /dev/null 
