### PR TITLE
Fix double unlock in keysinuse teardown

### DIFF
--- a/SymCryptProvider/src/p_scossl_keysinuse.c
+++ b/SymCryptProvider/src/p_scossl_keysinuse.c
@@ -239,12 +239,15 @@ void p_scossl_keysinuse_teardown()
                 p_scossl_keysinuse_log_error("Logging thread exited with status %d", logging_thread_exit_status);
             }
         }
+        else
+        {
+            pthread_mutex_unlock(&logging_thread_mutex);
+        }
     }
     else
     {
         p_scossl_keysinuse_log_error("Cleanup failed to acquire mutex,SYS_%d", pthreadErr);
     }
-    pthread_mutex_unlock(&logging_thread_mutex);
 
     if (prefix != default_prefix)
     {


### PR DESCRIPTION
KeysInUse has a double mutex unlock in `p_scossl_keysinuse_teardown`. This was fixed in main, and this PR brings this fix to 1.9.