### PR TITLE
Additional fixes for block ciphers in TLS connections

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.13.0)
 
 project(SymCrypt-OpenSSL
-    VERSION 1.9.1
+    VERSION 1.9.2
     DESCRIPTION "The SymCrypt engine and provider for OpenSSL (SCOSSL)"
     HOMEPAGE_URL "https://github.com/microsoft/SymCrypt-OpenSSL")
 

--- a/SymCryptProvider/src/ciphers/p_scossl_aes.c
+++ b/SymCryptProvider/src/ciphers/p_scossl_aes.c
@@ -296,11 +296,6 @@ static SCOSSL_STATUS p_scossl_aes_generic_block_update(_Inout_ SCOSSL_AES_CTX *c
     SIZE_T cbInFullBlocks = 0;
     *outl = 0;
 
-    if (inl == 0)
-    {
-        return SCOSSL_SUCCESS;
-    }
-
     if (ctx->tlsVersion > 0)
     {
         // Each update call corresponds to a TLS record and is individually padded


### PR DESCRIPTION
This PR fixes a regression where encrypt-then-mac was failing with block ciphers provided by the symcrypt provider. When ETM is used, the mac size passed to the provider is 0. Instead of removing the padding and skipping mac extraction, the SymCrypt provider treated a zero-mac length as invalid and failed before removing padding.

This PR also fixes a corner case issue when the SymCrypt provider is used with TLSv1, where an empty block was passed for encryption, and the caller expected an encrypted block of padding bytes.