### PR TITLE
Support forking processes for KeysInUse

### DIFF
--- a/SymCryptProvider/src/p_scossl_keysinuse.c
+++ b/SymCryptProvider/src/p_scossl_keysinuse.c
@@ -241,6 +241,8 @@ static void p_scossl_keysinuse_atfork_reinit()
     is_logging = FALSE;
     logging_thread_exit_status = SCOSSL_FAILURE;
 
+    logging_thread_mutex = (pthread_mutex_t) PTHREAD_MUTEX_INITIALIZER;
+
     // Recreate global locks in case they were held by the logging
     // thread in the parent process at the time of the fork.
     CRYPTO_THREAD_lock_free(sk_keysinuse_info_lock);
@@ -250,8 +252,6 @@ static void p_scossl_keysinuse_atfork_reinit()
         p_scossl_keysinuse_log_error("Failed to create keysinuse lock in child process");
         goto cleanup;
     }
-
-    logging_thread_mutex = (pthread_mutex_t) PTHREAD_MUTEX_INITIALIZER;
 
     // If any keysinuseInfo were in either stack, they will
     // be logged by the parent process. Remove them from the child process's


### PR DESCRIPTION
KeysInUse relies on the logging thread to periodically log events. The logging thread is created when the SymCrypt provider is initialized, and runs for the lifetime of the provider. If the process forks, only the main thread and all global data are copied. Any additional threads, including the main thread, are not cloned in the child process. This means that only the parent process will emit KeysInUse events, and child processes will not.

This PR adds a new function to keysinuse `p_scossl_keysinuse_atfork_reinit`. This function is registered to run in the child process after `fork` with [`pthread_atfork`](https://man7.org/linux/man-pages/man3/pthread_atfork.3.html). The function will recreate the logging thread and reinitialize global state in the child process to enable continued keysinuse logging.

This change was verified with a test application that creates a private key, forks child processes, and uses the cloned key object in the child processes to ensure keys loaded in the parent process continue to emit keysinuse telemetry in child processes. I also verified this with nginx and confirmed keysinuse events were correctly written after the change.

- Added `p_scossl_keysinuse_atfork_reinit` callback to recreate the logging thread in the child process after `fork`
- Moved the `sk_keysinuse_info_pending` pointer to be global instead of local to the logging thread
    - The underlying stack object is allocated on the heap and therefore gets cloned after `fork`. It needs to be properly cleaned up in the child process to avoid duplicate events and prevent a memory leak.