### PR TITLE
Revert "Support forking processes for KeysInUse (#146)"

### DIFF
--- a/SymCryptProvider/src/p_scossl_keysinuse.c
+++ b/SymCryptProvider/src/p_scossl_keysinuse.c
@@ -45,10 +45,6 @@ DEFINE_STACK_OF(SCOSSL_PROV_KEYSINUSE_INFO);
 // This is destroyed if the logging thread fails to start, or when the logging thread exits.
 // Always check this is non-NULL outside the logging thread.
 static STACK_OF(SCOSSL_PROV_KEYSINUSE_INFO) *sk_keysinuse_info = NULL;
-// Stack of keysinuseInfo that have been popped by the logging thread, but not yet logged.
-// This should only be used in the logging thread. It is defined here to avoid reallocation
-// and leaks if the process forks and a new logging thread is created in the child process.
-static STACK_OF(SCOSSL_PROV_KEYSINUSE_INFO) *sk_keysinuse_info_pending = NULL;
 // This lock should be aquired before accessing sk_keysinuse_info
 static CRYPTO_RWLOCK *sk_keysinuse_info_lock = NULL;
 
@@ -70,7 +66,6 @@ static BOOL is_logging = FALSE;
 // Internal function declarations
 //
 static void p_scossl_keysinuse_init_once();
-static void p_scossl_keysinuse_atfork_reinit();
 
 static void p_scossl_keysinuse_add_use(_In_ SCOSSL_PROV_KEYSINUSE_INFO *keysinuseInfo, BOOL isSigning);
 
@@ -83,7 +78,7 @@ static void *p_scossl_keysinuse_logging_thread_start(ossl_unused void *arg);
 //
 // Setup/teardown
 //
-static void p_scossl_keysinuse_logging_thread_cleanup()
+static void p_scossl_keysinuse_cleanup()
 {
     if (CRYPTO_THREAD_write_lock(sk_keysinuse_info_lock))
     {
@@ -102,9 +97,6 @@ static void p_scossl_keysinuse_logging_thread_cleanup()
     {
         p_scossl_keysinuse_log_error("Failed to lock keysinuse info stack,OPENSSL_%d", ERR_get_error());
     }
-
-    sk_SCOSSL_PROV_KEYSINUSE_INFO_free(sk_keysinuse_info_pending);
-    sk_keysinuse_info_pending = NULL;
 }
 
 static void p_scossl_keysinuse_init_once()
@@ -157,10 +149,7 @@ static void p_scossl_keysinuse_init_once()
 
     sk_keysinuse_info_lock = CRYPTO_THREAD_lock_new();
     sk_keysinuse_info = sk_SCOSSL_PROV_KEYSINUSE_INFO_new_null();
-    sk_keysinuse_info_pending = sk_SCOSSL_PROV_KEYSINUSE_INFO_new_null();
-    if (sk_keysinuse_info_lock == NULL || 
-        sk_keysinuse_info == NULL ||
-        sk_keysinuse_info_pending == NULL)
+    if (sk_keysinuse_info_lock == NULL || sk_keysinuse_info == NULL)
     {
         p_scossl_keysinuse_log_error("Failed to create global objects used by keysinuse");
         goto cleanup;
@@ -201,17 +190,14 @@ static void p_scossl_keysinuse_init_once()
         goto cleanup;
     }
 
-    if ((pthreadErr = pthread_atfork(NULL, NULL, p_scossl_keysinuse_atfork_reinit)) != 0)
-    {
-        p_scossl_keysinuse_log_error("Failed to register child process reinit. Child processes will not log events,SYS_%d", pthreadErr);
-    }
-
     keysinuse_enabled = TRUE;
     status = SCOSSL_SUCCESS;
 
 cleanup:
-    if (status != SCOSSL_SUCCESS)
+    if (!status)
     {
+        sk_SCOSSL_PROV_KEYSINUSE_INFO_free(sk_keysinuse_info);
+        sk_keysinuse_info = NULL;
         p_scossl_keysinuse_teardown();
     }
 
@@ -222,119 +208,6 @@ cleanup:
 void p_scossl_keysinuse_init()
 {
     CRYPTO_THREAD_run_once(&keysinuse_init_once, p_scossl_keysinuse_init_once);
-}
-
-// If the calling process forks, the logging thread needs to be restarted in the
-// child process, and any locks should be reinitialized in case the parent
-// process held a lock at the time of the fork. 
-static void p_scossl_keysinuse_atfork_reinit()
-{
-    SCOSSL_PROV_KEYSINUSE_INFO *pKeysinuseInfo = NULL;
-    pthread_condattr_t attr;
-    int pthreadErr;
-    SCOSSL_STATUS status = SCOSSL_FAILURE;
-    int is_parent_logging = is_logging;
-
-    // Reset global state
-    keysinuse_enabled = FALSE;
-    first_use_pending = FALSE;
-    is_logging = FALSE;
-    logging_thread_exit_status = SCOSSL_FAILURE;
-
-    logging_thread_mutex = (pthread_mutex_t) PTHREAD_MUTEX_INITIALIZER;
-
-    // Recreate global locks in case they were held by the logging
-    // thread in the parent process at the time of the fork.
-    CRYPTO_THREAD_lock_free(sk_keysinuse_info_lock);
-    sk_keysinuse_info_lock = CRYPTO_THREAD_lock_new();
-    if (sk_keysinuse_info_lock == NULL)
-    {
-        p_scossl_keysinuse_log_error("Failed to create keysinuse lock in child process");
-        goto cleanup;
-    }
-
-    // If any keysinuseInfo were in either stack, they will
-    // be logged by the parent process. Remove them from the child process's
-    // stacks and reset them. 
-    if (CRYPTO_THREAD_write_lock(sk_keysinuse_info_lock))
-    {
-        while (sk_SCOSSL_PROV_KEYSINUSE_INFO_num(sk_keysinuse_info) > 0)
-        {
-            pKeysinuseInfo = sk_SCOSSL_PROV_KEYSINUSE_INFO_pop(sk_keysinuse_info);
-            if (pKeysinuseInfo != NULL)
-            {
-                if (CRYPTO_THREAD_write_lock(pKeysinuseInfo->lock))
-                {
-                    pKeysinuseInfo->logPending = FALSE;
-                    pKeysinuseInfo->decryptCounter = 0;
-                    pKeysinuseInfo->signCounter = 0;
-    
-                    CRYPTO_THREAD_unlock(pKeysinuseInfo->lock);
-                }
-                else
-                {
-                    p_scossl_keysinuse_log_error("Failed to lock keysinuse info,OPENSSL_%d", ERR_get_error());
-                }
-
-                p_scossl_keysinuse_info_free(pKeysinuseInfo);
-            }
-        }
-
-        CRYPTO_THREAD_unlock(sk_keysinuse_info_lock);
-    }
-    else
-    {
-        p_scossl_keysinuse_log_error("Failed to lock keysinuse info stack,OPENSSL_%d", ERR_get_error());
-    }
-
-    while (sk_SCOSSL_PROV_KEYSINUSE_INFO_num(sk_keysinuse_info_pending) > 0)
-    {
-        pKeysinuseInfo = sk_SCOSSL_PROV_KEYSINUSE_INFO_pop(sk_keysinuse_info_pending);
-        if (pKeysinuseInfo != NULL)
-        {
-            if (CRYPTO_THREAD_write_lock(pKeysinuseInfo->lock))
-            {
-                pKeysinuseInfo->logPending = FALSE;
-                pKeysinuseInfo->decryptCounter = 0;
-                pKeysinuseInfo->signCounter = 0;
-
-                CRYPTO_THREAD_unlock(pKeysinuseInfo->lock);
-            }
-            else
-            {
-                p_scossl_keysinuse_log_error("Failed to lock keysinuse info,OPENSSL_%d", ERR_get_error());
-            }
-
-            p_scossl_keysinuse_info_free(pKeysinuseInfo);
-        }
-    }
-
-    // Only recreate logging thread if it was running in the parent process
-    if (is_parent_logging)
-    {     
-        // Start the logging thread. Monotonic clock needs to be set to
-        // prevent wall clock changes from affecting the logging delay sleep time
-        is_logging = TRUE;
-        if ((pthreadErr = pthread_condattr_init(&attr)) != 0 ||
-            (pthreadErr = pthread_condattr_setclock(&attr, CLOCK_MONOTONIC)) != 0 ||
-            (pthreadErr = pthread_cond_init(&logging_thread_cond_wake_early, &attr)) != 0 ||
-            (pthreadErr = pthread_create(&logging_thread, NULL, p_scossl_keysinuse_logging_thread_start, NULL)) != 0)
-        {
-            p_scossl_keysinuse_log_error("Failed to start logging thread,SYS_%d", pthreadErr);
-            is_logging = FALSE;
-            goto cleanup;
-        }
-    
-        keysinuse_enabled = TRUE;
-        status = SCOSSL_SUCCESS;
-    }
-
-
-cleanup:
-    if (status != SCOSSL_SUCCESS)
-    {
-        p_scossl_keysinuse_teardown();
-    }
 }
 
 BOOL p_scossl_keysinuse_running()
@@ -384,11 +257,7 @@ void p_scossl_keysinuse_teardown()
     }
 
     CRYPTO_THREAD_lock_free(sk_keysinuse_info_lock);
-    sk_SCOSSL_PROV_KEYSINUSE_INFO_free(sk_keysinuse_info);
-    sk_SCOSSL_PROV_KEYSINUSE_INFO_free(sk_keysinuse_info_pending);
     sk_keysinuse_info_lock = NULL;
-    sk_keysinuse_info = NULL;
-    sk_keysinuse_info_pending = NULL;
 }
 
 //
@@ -816,8 +685,9 @@ static void *p_scossl_keysinuse_logging_thread_start(ossl_unused void *arg)
     int pthreadErr;
     int waitStatus;
 
-    // Every time the logging loop runs, all pending usage events are popped to sk_keysinuse_info_pending
+    // Every time the logging loop runs, all pending usage events are popped to this thread-local stack
     // to minimize the time sk_keysinuse_info_lock is held.
+    STACK_OF(SCOSSL_PROV_KEYSINUSE_INFO) *sk_keysinuse_info_pending = sk_SCOSSL_PROV_KEYSINUSE_INFO_new_null();
     SCOSSL_PROV_KEYSINUSE_INFO *pKeysinuseInfo;
     SCOSSL_PROV_KEYSINUSE_INFO keysinuseInfoTmp;
 
@@ -939,9 +809,10 @@ static void *p_scossl_keysinuse_logging_thread_start(ossl_unused void *arg)
     while (isLoggingThreadRunning);
 
 cleanup:
+    sk_SCOSSL_PROV_KEYSINUSE_INFO_free(sk_keysinuse_info_pending);
     logging_thread_exit_status = SCOSSL_SUCCESS;
     keysinuse_enabled = FALSE;
-    p_scossl_keysinuse_logging_thread_cleanup();
+    p_scossl_keysinuse_cleanup();
 
     return NULL;
 }


### PR DESCRIPTION
This reverts commit 1c2f0f08998bfb0900ca724878d449febb8d23d8.

Testing with development binaries revealed a potential regression. Reverting this commit for further testing.