### PR TITLE
use pthread_atfork handler for ngnix support

### DIFF
--- a/KeysInUse/keysinuse.c
+++ b/KeysInUse/keysinuse.c
@@ -270,7 +270,8 @@ static void keysinuse_init_internal()
 
     if ((pthreadErr = pthread_atfork(NULL, NULL, keysinuse_atfork_reinit)) != 0)
     {
-        keysinuse_log_error("Failed to register child process reinit. Child processes will not log events,SYS_%d", pthreadErr);
+        keysinuse_log_error("Failed to register logging fork handler,SYS_%d", pthreadErr);
+        goto cleanup;
     }
 
     keysinuse_running = TRUE;


### PR DESCRIPTION
When the main nginx process forks, only the thread calling fork is cloned in the child process, so the logging thread is no longer running and KeysInUse is not logged in the child. There was a fix related to this in scossl 1.9 #146.

Changes:

* Added `keysinuse_atfork_reinit` to reset global state, reinitialize locks, ctx and restart the logging thread in child processes after a fork.

**Test**
* Ran ngnix locally and saw logs in keysinuse_not_*.log instead of keyinuse_err_*.log 