### PR TITLE
Remove references to SymCrypt UINT type in 1.9 branch

### DIFF
--- a/ScosslCommon/inc/scossl_rsa.h
+++ b/ScosslCommon/inc/scossl_rsa.h
@@ -39,12 +39,12 @@ SCOSSL_STATUS scossl_rsapss_verify(_In_ PSYMCRYPT_RSAKEY key, int mdnid, int cbS
                                    _In_reads_bytes_(cbHashValue) PCBYTE pbHashValue, SIZE_T cbHashValue,
                                    _In_reads_bytes_(pcbSignature) PCBYTE pbSignature, SIZE_T pcbSignature);
 
-SCOSSL_STATUS scossl_rsa_encrypt(_In_ PSYMCRYPT_RSAKEY key, UINT padding,
+SCOSSL_STATUS scossl_rsa_encrypt(_In_ PSYMCRYPT_RSAKEY key, UINT8 padding,
                                  int mdnid, _In_reads_bytes_opt_(cbLabel) PCBYTE pbLabel, SIZE_T cbLabel,
                                  _In_reads_bytes_(cbSrc) PCBYTE pbSrc, SIZE_T cbSrc,
                                  _Out_writes_bytes_(*pcbDst) PBYTE pbDst, _Out_ INT32 *pcbDst, SIZE_T cbDst);
 
-SCOSSL_STATUS scossl_rsa_decrypt(_In_ PSYMCRYPT_RSAKEY key, UINT padding,
+SCOSSL_STATUS scossl_rsa_decrypt(_In_ PSYMCRYPT_RSAKEY key, UINT8 padding,
                                  int mdnid, _In_reads_bytes_opt_(cbLabel) PCBYTE pbLabel, SIZE_T cbLabel,
                                  _In_reads_bytes_(cbSrc) PCBYTE pbSrc, SIZE_T cbSrc,
                                  _Out_writes_bytes_(*pcbDst) PBYTE pbDst, _Out_ INT32 *pcbDst, SIZE_T cbDst);

--- a/ScosslCommon/src/scossl_rsa.c
+++ b/ScosslCommon/src/scossl_rsa.c
@@ -428,7 +428,7 @@ cleanup:
 }
 
 _Use_decl_annotations_
-SCOSSL_STATUS scossl_rsa_encrypt(PSYMCRYPT_RSAKEY key, UINT padding,
+SCOSSL_STATUS scossl_rsa_encrypt(PSYMCRYPT_RSAKEY key, UINT8 padding,
                                  int mdnid, PCBYTE pbLabel, SIZE_T cbLabel, // OAEP-only parameters
                                  PCBYTE pbSrc, SIZE_T cbSrc,
                                  PBYTE pbDst, INT32 *pcbDst, SIZE_T cbDst)
@@ -545,7 +545,7 @@ cleanup:
 }
 
 _Use_decl_annotations_
-SCOSSL_STATUS scossl_rsa_decrypt(PSYMCRYPT_RSAKEY key, UINT padding,
+SCOSSL_STATUS scossl_rsa_decrypt(PSYMCRYPT_RSAKEY key, UINT8 padding,
                                  int mdnid, PCBYTE pbLabel, SIZE_T cbLabel, // OAEP-only parameters
                                  PCBYTE pbSrc, SIZE_T cbSrc,
                                  PBYTE pbDst, INT32 *pcbDst, SIZE_T cbDst)

--- a/SymCryptProvider/src/asymcipher/p_scossl_rsa_cipher.c
+++ b/SymCryptProvider/src/asymcipher/p_scossl_rsa_cipher.c
@@ -20,7 +20,7 @@ typedef struct
     OSSL_LIB_CTX *libctx;
 
     SCOSSL_PROV_RSA_KEY_CTX *keyCtx;
-    UINT padding;
+    UINT8 padding;
     int operation;
 
     // OAEP Parameters
@@ -314,7 +314,7 @@ static SCOSSL_STATUS p_scossl_rsa_cipher_set_ctx_params(_Inout_ SCOSSL_RSA_CIPHE
         // Padding mode may be passed as legacy NID or string, and is
         // checked against the padding modes the ScOSSL provider supports
         int i = 0;
-        UINT padding;
+        unsigned int padding;
 
         switch (p->data_type)
         {

--- a/SymCryptProvider/src/ciphers/p_scossl_aes.c
+++ b/SymCryptProvider/src/ciphers/p_scossl_aes.c
@@ -56,7 +56,7 @@ typedef struct
     SIZE_T cbBuf;
 
     OSSL_LIB_CTX *libctx;
-    UINT tlsVersion;
+    UINT32 tlsVersion;
     PBYTE tlsMac;
     SIZE_T tlsMacSize;
 
@@ -157,7 +157,7 @@ static SCOSSL_STATUS p_scossl_aes_generic_decrypt_init(_Inout_ SCOSSL_AES_CTX *c
 // but the padding is still verified and removed.
 //
 // The MAC will later be fetched through p_scossl_aes_generic_get_ctx_params
-// This function is adapted from ssl3_cbc_copy_mac in ssl/record/tls_pad.c, and 
+// This function is adapted from ssl3_cbc_copy_mac in ssl/record/tls_pad.c, and
 // SymCryptTlsCbcHmacVerifyCore from SymCrypt, and runs in constant time w.r.t
 // the values in pbData. In case of bad padding, a random MAC is assigned instead
 static SCOSSL_STATUS p_scossl_aes_tls_remove_padding_and_copy_mac(
@@ -227,7 +227,7 @@ static SCOSSL_STATUS p_scossl_aes_tls_remove_padding_and_copy_mac(
     macStart = macEnd - ctx->tlsMacSize;
 
     rotatedMac = rotatedMacBuf + ((0 - (SIZE_T)rotatedMacBuf) & 0x3f);
-    
+
     // Find and extract MAC, and verify padding
     memset(rotatedMac, 0, ctx->tlsMacSize);
     for (i = 0, j = 0; i < cbTail-1; i++)
@@ -747,7 +747,7 @@ static SCOSSL_STATUS p_scossl_aes_generic_set_ctx_params(_Inout_ SCOSSL_AES_CTX 
 
     if ((p = OSSL_PARAM_locate_const(params, OSSL_CIPHER_PARAM_TLS_VERSION)) != NULL)
     {
-        UINT tlsVersion;
+        unsigned int tlsVersion;
         if (!OSSL_PARAM_get_uint(p, &tlsVersion))
         {
             ERR_raise(ERR_LIB_PROV, PROV_R_FAILED_TO_GET_PARAMETER);

--- a/SymCryptProvider/src/kdf/p_scossl_kbkdf.c
+++ b/SymCryptProvider/src/kdf/p_scossl_kbkdf.c
@@ -30,7 +30,7 @@ typedef struct
     SIZE_T cbLabel;
     PCSYMCRYPT_MAC pMac;
 
-    UINT macType;
+    UINT8 macType;
     SIZE_T cbCmacKey;
     const SCOSSL_KMAC_EXTENSIONS *pMacEx;
 } SCOSSL_PROV_KBKDF_CTX;

--- a/SymCryptProvider/src/keyexch/p_scossl_dh.c
+++ b/SymCryptProvider/src/keyexch/p_scossl_dh.c
@@ -28,7 +28,7 @@ typedef struct
     SCOSSL_PROV_DH_KEY_CTX *provKey;
     SCOSSL_PROV_DH_KEY_CTX *peerProvKey;
 
-    UINT pad;
+    BOOL pad;
 
     // X9.42 parameters
     enum scossl_kdf_type kdfType;
@@ -334,7 +334,7 @@ static SCOSSL_STATUS p_scossl_dh_set_ctx_params(_Inout_ SCOSSL_DH_CTX *ctx, _In_
             return SCOSSL_FAILURE;
         }
 
-        ctx->pad = pad ? 1 : 0;
+        ctx->pad = pad ? TRUE : FALSE;
     }
 
     if ((p = OSSL_PARAM_locate_const(params, OSSL_EXCHANGE_PARAM_KDF_TYPE)) != NULL)

--- a/SymCryptProvider/src/keymgmt/p_scossl_rsa_keymgmt.c
+++ b/SymCryptProvider/src/keymgmt/p_scossl_rsa_keymgmt.c
@@ -17,7 +17,7 @@ typedef struct
 {
     OSSL_LIB_CTX *libctx;
     // May be set for PSS
-    UINT keyType;
+    UINT32 keyType;
     SCOSSL_RSA_PSS_RESTRICTIONS *pssRestrictions;
 
     UINT32 nBitsOfModulus;
@@ -373,7 +373,7 @@ static void p_scossl_rsa_keygen_cleanup(_Inout_ SCOSSL_RSA_KEYGEN_CTX *genCtx)
 }
 
 static SCOSSL_RSA_KEYGEN_CTX *p_scossl_rsa_keygen_init_common(_In_ SCOSSL_PROVCTX *provctx, int selection,
-                                                              _In_ const OSSL_PARAM params[], UINT keyType)
+                                                              _In_ const OSSL_PARAM params[], UINT32 keyType)
 {
     // Sanity check
     if ((selection & OSSL_KEYMGMT_SELECT_KEYPAIR) == 0)

--- a/SymCryptProvider/src/p_scossl_rsa.c
+++ b/SymCryptProvider/src/p_scossl_rsa.c
@@ -35,7 +35,7 @@ static const OSSL_ITEM p_scossl_rsa_supported_mds[] = {
     {NID_sha3_512,      OSSL_DIGEST_NAME_SHA3_512}};
 
 _Use_decl_annotations_
-const OSSL_ITEM *p_scossl_rsa_get_supported_md(OSSL_LIB_CTX *libctx, UINT padding,
+const OSSL_ITEM *p_scossl_rsa_get_supported_md(OSSL_LIB_CTX *libctx, UINT8 padding,
                                                const char *mdname, const char *propq,
                                                EVP_MD **md)
 {

--- a/SymCryptProvider/src/p_scossl_rsa.h
+++ b/SymCryptProvider/src/p_scossl_rsa.h
@@ -23,7 +23,7 @@ typedef struct
     OSSL_LIB_CTX *libctx;
     BOOL initialized;
     PSYMCRYPT_RSAKEY key;
-    UINT keyType;
+    UINT32 keyType;
     SCOSSL_RSA_PSS_RESTRICTIONS *pssRestrictions;
 
 #ifdef KEYSINUSE_ENABLED
@@ -33,7 +33,7 @@ typedef struct
 #endif
 } SCOSSL_PROV_RSA_KEY_CTX;
 
-const OSSL_ITEM *p_scossl_rsa_get_supported_md(_In_ OSSL_LIB_CTX *libctx, UINT padding,
+const OSSL_ITEM *p_scossl_rsa_get_supported_md(_In_ OSSL_LIB_CTX *libctx, UINT8 padding,
                                                _In_ const char *mdname, _In_ const char *propq,
                                                _Out_opt_ EVP_MD **md);
 

--- a/SymCryptProvider/src/signature/p_scossl_ecdsa_signature.c
+++ b/SymCryptProvider/src/signature/p_scossl_ecdsa_signature.c
@@ -282,7 +282,7 @@ static SCOSSL_STATUS p_scossl_ecdsa_digest_sign_final(_In_ SCOSSL_ECDSA_CTX *ctx
                                                       _Out_writes_bytes_(*siglen) unsigned char *sig, _Out_ size_t *siglen, size_t sigsize)
 {
     BYTE digest[EVP_MAX_MD_SIZE];
-    UINT cbDigest = 0;
+    unsigned int cbDigest = 0;
 
     if (ctx->mdctx == NULL)
     {
@@ -307,7 +307,7 @@ static SCOSSL_STATUS p_scossl_ecdsa_digest_verify_final(_In_ SCOSSL_ECDSA_CTX *c
                                                         _In_reads_bytes_(siglen) unsigned char *sig, size_t siglen)
 {
     BYTE digest[EVP_MAX_MD_SIZE];
-    UINT cbDigest = 0;
+    unsigned int cbDigest = 0;
 
     if (ctx->mdctx == NULL)
     {
@@ -374,7 +374,7 @@ static SCOSSL_STATUS p_scossl_ecdsa_set_ctx_params(_Inout_ SCOSSL_ECDSA_CTX *ctx
             ERR_raise(ERR_LIB_PROV, PROV_R_FAILED_TO_GET_PARAMETER);
             return SCOSSL_FAILURE;
         }
-        
+
         if (nonce_type != 0)
         {
             ERR_raise(ERR_LIB_PROV, PROV_R_NOT_SUPPORTED);

--- a/SymCryptProvider/src/signature/p_scossl_rsa_signature.c
+++ b/SymCryptProvider/src/signature/p_scossl_rsa_signature.c
@@ -18,7 +18,7 @@ extern "C" {
 typedef struct
 {
     SCOSSL_PROV_RSA_KEY_CTX *keyCtx;
-    UINT padding;
+    UINT8 padding;
     int operation;
 
     // Needed for fetching md
@@ -394,7 +394,7 @@ static SCOSSL_STATUS p_scossl_rsa_digest_sign_final(_In_ SCOSSL_RSA_SIGN_CTX *ct
 {
     SCOSSL_STATUS ret = SCOSSL_FAILURE;
     BYTE digest[EVP_MAX_MD_SIZE];
-    UINT cbDigest = 0;
+    unsigned int cbDigest = 0;
 
     if (ctx->mdctx == NULL)
     {
@@ -415,7 +415,7 @@ static SCOSSL_STATUS p_scossl_rsa_digest_verify_final(_In_ SCOSSL_RSA_SIGN_CTX *
                                                       _In_reads_bytes_(siglen) unsigned char *sig, size_t siglen)
 {
     BYTE digest[EVP_MAX_MD_SIZE];
-    UINT cbDigest = 0;
+    unsigned int cbDigest = 0;
 
     if (ctx->mdctx == NULL)
     {
@@ -491,7 +491,7 @@ static SCOSSL_STATUS p_scossl_rsa_set_ctx_params(_Inout_ SCOSSL_RSA_SIGN_CTX *ct
         // Padding mode may be passed as legacy NID or string, and is
         // checked against the padding modes the ScOSSL provider supports
         int i = 0;
-        UINT padding;
+        unsigned int padding;
 
         switch (p->data_type)
         {


### PR DESCRIPTION
The SymCrypt provider previously used the `UINT` type defined in `symcrypt_internal.h`, which has been removed in recent versions of SymCrypt. This PR removes usage of the type to fix compatability with the SymCrypt provider 1.9.x and latest versions of SymCrypt.

This change is based on the change already made to the main branch.