### PR TITLE
Add generic and AES SKEY support

### DIFF
--- a/SymCryptProvider/CMakeLists.txt
+++ b/SymCryptProvider/CMakeLists.txt
@@ -11,7 +11,7 @@ configure_file(
     ${CMAKE_CURRENT_SOURCE_DIR}/inc/p_scossl_base.h.in
     ${CMAKE_CURRENT_SOURCE_DIR}/inc/p_scossl_base.h)
 
-find_package(OpenSSL REQUIRED)
+find_package(OpenSSL 3.5 REQUIRED)
 include_directories(${OPENSSL_INCLUDE_DIR})
 
 find_library(SYMCRYPT_LIBRARY symcrypt PATHS ${CMAKE_SOURCE_DIR})
@@ -52,18 +52,14 @@ set(SCOSSL_SOURCES
     ./src/mac/p_scossl_kmac.c
     ./src/signature/p_scossl_ecdsa_signature.c
     ./src/signature/p_scossl_rsa_signature.c
+    ./src/skeymgmt/p_scossl_aes_skeymgmt.c
+    ./src/skeymgmt/p_scossl_generic_skeymgmt.c
     ./src/p_scossl_bio.c
     ./src/p_scossl_ecc.c
     ./src/p_scossl_rand.c
     ./src/p_scossl_rsa.c
     ./src/p_scossl_base.c
 )
-
-if (${OPENSSL_VERSION} VERSION_GREATER_EQUAL 3.5)
-    list(APPEND SCOSSL_SOURCES
-        ./src/skeymgmt/p_scossl_generic_skeymgmt.c
-        ./src/skeymgmt/p_scossl_aes_skeymgmt.c)
-endif()
 
 if (KEYSINUSE_ENABLED)
     list(APPEND SCOSSL_SOURCES ../KeysInUse/keysinuse.c)

--- a/SymCryptProvider/CMakeLists.txt
+++ b/SymCryptProvider/CMakeLists.txt
@@ -59,6 +59,12 @@ set(SCOSSL_SOURCES
     ./src/p_scossl_base.c
 )
 
+if (${OPENSSL_VERSION} VERSION_GREATER_EQUAL 3.5)
+    list(APPEND SCOSSL_SOURCES
+        ./src/skeymgmt/p_scossl_generic_skeymgmt.c
+        ./src/skeymgmt/p_scossl_aes_skeymgmt.c)
+endif()
+
 if (KEYSINUSE_ENABLED)
     list(APPEND SCOSSL_SOURCES ../KeysInUse/keysinuse.c)
 endif()

--- a/SymCryptProvider/src/ciphers/p_scossl_aes.c
+++ b/SymCryptProvider/src/ciphers/p_scossl_aes.c
@@ -10,6 +10,7 @@
 #include "scossl_helpers.h"
 #include "p_scossl_base.h"
 #include "p_scossl_aes.h"
+#include "p_scossl_skey.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -148,12 +149,26 @@ static SCOSSL_STATUS p_scossl_aes_generic_decrypt_init(_Inout_ SCOSSL_AES_CTX *c
     return p_scossl_aes_generic_init_internal(ctx, FALSE, key, keylen, iv, ivlen, params);
 }
 
+static SCOSSL_STATUS p_scossl_aes_generic_skey_encrypt_init(_Inout_ SCOSSL_AES_CTX *ctx, _In_ SCOSSL_SKEY *skey,
+                                                            _In_reads_bytes_opt_(ivlen) const unsigned char *iv, size_t ivlen,
+                                                            _In_ const OSSL_PARAM params[])
+{
+    return p_scossl_aes_generic_init_internal(ctx, TRUE, skey->pbKey, skey->cbKey, iv, ivlen, params);
+}
+
+static SCOSSL_STATUS p_scossl_aes_generic_skey_decrypt_init(_Inout_ SCOSSL_AES_CTX *ctx, _In_ SCOSSL_SKEY *skey,
+                                                            _In_reads_bytes_opt_(ivlen) const unsigned char *iv, size_t ivlen,
+                                                            _In_ const OSSL_PARAM params[])
+{
+    return p_scossl_aes_generic_init_internal(ctx, FALSE, skey->pbKey, skey->cbKey, iv, ivlen, params);
+}
+
 #define SYMCRYPT_OPENSSL_MASK8_SELECT( _mask, _a, _b ) (SYMCRYPT_FORCE_READ8(&_mask) & _a) | (~(SYMCRYPT_FORCE_READ8(&_mask)) & _b)
 
 // Verifies the TLS padding from the end of record, extracts the MAC from the end of
-// the unpadded record, and saves the result to ctx->tlsMac. 
-// 
-// If ctx->tlsMacSize is 0 (in the case of encrypt-then-mac), no MAC is extracted, 
+// the unpadded record, and saves the result to ctx->tlsMac.
+//
+// If ctx->tlsMacSize is 0 (in the case of encrypt-then-mac), no MAC is extracted,
 // but the padding is still verified and removed.
 //
 // The MAC will later be fetched through p_scossl_aes_generic_get_ctx_params
@@ -1028,6 +1043,8 @@ static SCOSSL_STATUS scossl_aes_cfb8_cipher(_Inout_ SCOSSL_AES_CTX *ctx,
         {OSSL_FUNC_CIPHER_GETTABLE_PARAMS, (void (*)(void))p_scossl_aes_generic_gettable_params},         \
         {OSSL_FUNC_CIPHER_GETTABLE_CTX_PARAMS, (void (*)(void))p_scossl_aes_generic_gettable_ctx_params}, \
         {OSSL_FUNC_CIPHER_SETTABLE_CTX_PARAMS, (void (*)(void))p_scossl_aes_generic_settable_ctx_params}, \
+        {OSSL_FUNC_CIPHER_ENCRYPT_SKEY_INIT, (void (*)(void))p_scossl_aes_generic_skey_encrypt_init},     \
+        {OSSL_FUNC_CIPHER_DECRYPT_SKEY_INIT, (void (*)(void))p_scossl_aes_generic_skey_decrypt_init},     \
         {0, NULL}};
 
 IMPLEMENT_SCOSSL_AES_GENERIC_CIPHER(128, SYMCRYPT_AES_BLOCK_SIZE, cbc, CBC, block, SYMCRYPT_AES_BLOCK_SIZE)

--- a/SymCryptProvider/src/ciphers/p_scossl_aes_aead.c
+++ b/SymCryptProvider/src/ciphers/p_scossl_aes_aead.c
@@ -117,14 +117,14 @@ static SCOSSL_STATUS p_scossl_aes_gcm_decrypt_init(_Inout_ SCOSSL_CIPHER_GCM_CTX
 }
 
 static SCOSSL_STATUS p_scossl_aes_gcm_skey_encrypt_init(_Inout_ void *ctx, _In_ SCOSSL_SKEY *skey,
-                                                        _In_reads_bytes_opt_(keylen) const unsigned char *iv, size_t ivlen,
+                                                        _In_reads_bytes_opt_(ivlen) const unsigned char *iv, size_t ivlen,
                                                         _In_ const OSSL_PARAM params[])
 {
     return p_scossl_aes_gcm_init_internal(ctx, 1, skey->pbKey, skey->cbKey, iv, ivlen, params);
 }
 
 static SCOSSL_STATUS p_scossl_aes_gcm_skey_decrypt_init(_Inout_ void *ctx, _In_ SCOSSL_SKEY *skey,
-                                                        _In_reads_bytes_opt_(keylen) const unsigned char *iv, size_t ivlen,
+                                                        _In_reads_bytes_opt_(ivlen) const unsigned char *iv, size_t ivlen,
                                                         _In_ const OSSL_PARAM params[])
 {
     return p_scossl_aes_gcm_init_internal(ctx, 0, skey->pbKey, skey->cbKey, iv, ivlen, params);
@@ -388,14 +388,14 @@ static SCOSSL_STATUS p_scossl_aes_ccm_decrypt_init(_Inout_ SCOSSL_CIPHER_CCM_CTX
 }
 
 static SCOSSL_STATUS p_scossl_aes_ccm_skey_encrypt_init(_Inout_ void *ctx, _In_ SCOSSL_SKEY *skey,
-                                                        _In_reads_bytes_opt_(keylen) const unsigned char *iv, size_t ivlen,
+                                                        _In_reads_bytes_opt_(ivlen) const unsigned char *iv, size_t ivlen,
                                                         _In_ const OSSL_PARAM params[])
 {
     return p_scossl_aes_ccm_init_internal(ctx, 1, skey->pbKey, skey->cbKey, iv, ivlen, params);
 }
 
 static SCOSSL_STATUS p_scossl_aes_ccm_skey_decrypt_init(_Inout_ void *ctx, _In_ SCOSSL_SKEY *skey,
-                                                        _In_reads_bytes_opt_(keylen) const unsigned char *iv, size_t ivlen,
+                                                        _In_reads_bytes_opt_(ivlen) const unsigned char *iv, size_t ivlen,
                                                         _In_ const OSSL_PARAM params[])
 {
     return p_scossl_aes_ccm_init_internal(ctx, 0, skey->pbKey, skey->cbKey, iv, ivlen, params);

--- a/SymCryptProvider/src/ciphers/p_scossl_aes_aead.c
+++ b/SymCryptProvider/src/ciphers/p_scossl_aes_aead.c
@@ -8,6 +8,7 @@
 
 #include "scossl_aes_aead.h"
 #include "p_scossl_aes.h"
+#include "p_scossl_skey.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -113,6 +114,20 @@ static SCOSSL_STATUS p_scossl_aes_gcm_decrypt_init(_Inout_ SCOSSL_CIPHER_GCM_CTX
                                                    _In_ const OSSL_PARAM params[])
 {
     return p_scossl_aes_gcm_init_internal(ctx, 0, key, keylen, iv, ivlen, params);
+}
+
+static SCOSSL_STATUS p_scossl_aes_gcm_skey_encrypt_init(_Inout_ void *ctx, _In_ SCOSSL_SKEY *skey,
+                                                        _In_reads_bytes_opt_(keylen) const unsigned char *iv, size_t ivlen,
+                                                        _In_ const OSSL_PARAM params[])
+{
+    return p_scossl_aes_gcm_init_internal(ctx, 1, skey->pbKey, skey->cbKey, iv, ivlen, params);
+}
+
+static SCOSSL_STATUS p_scossl_aes_gcm_skey_decrypt_init(_Inout_ void *ctx, _In_ SCOSSL_SKEY *skey,
+                                                        _In_reads_bytes_opt_(keylen) const unsigned char *iv, size_t ivlen,
+                                                        _In_ const OSSL_PARAM params[])
+{
+    return p_scossl_aes_gcm_init_internal(ctx, 0, skey->pbKey, skey->cbKey, iv, ivlen, params);
 }
 
 static SCOSSL_STATUS p_scossl_aes_gcm_final(_Inout_ SCOSSL_CIPHER_GCM_CTX *ctx,
@@ -372,6 +387,20 @@ static SCOSSL_STATUS p_scossl_aes_ccm_decrypt_init(_Inout_ SCOSSL_CIPHER_CCM_CTX
     return p_scossl_aes_ccm_init_internal(ctx, 0, key, keylen, iv, ivlen, params);
 }
 
+static SCOSSL_STATUS p_scossl_aes_ccm_skey_encrypt_init(_Inout_ void *ctx, _In_ SCOSSL_SKEY *skey,
+                                                        _In_reads_bytes_opt_(keylen) const unsigned char *iv, size_t ivlen,
+                                                        _In_ const OSSL_PARAM params[])
+{
+    return p_scossl_aes_ccm_init_internal(ctx, 1, skey->pbKey, skey->cbKey, iv, ivlen, params);
+}
+
+static SCOSSL_STATUS p_scossl_aes_ccm_skey_decrypt_init(_Inout_ void *ctx, _In_ SCOSSL_SKEY *skey,
+                                                        _In_reads_bytes_opt_(keylen) const unsigned char *iv, size_t ivlen,
+                                                        _In_ const OSSL_PARAM params[])
+{
+    return p_scossl_aes_ccm_init_internal(ctx, 0, skey->pbKey, skey->cbKey, iv, ivlen, params);
+}
+
 static SCOSSL_STATUS p_scossl_aes_ccm_final(_Inout_ SCOSSL_CIPHER_CCM_CTX *ctx,
                                             _Out_writes_bytes_(*outl) unsigned char *out, _Out_ size_t *outl, ossl_unused size_t outsize)
 {
@@ -579,6 +608,8 @@ static SCOSSL_STATUS p_scossl_aes_ccm_set_ctx_params(_Inout_ SCOSSL_CIPHER_CCM_C
         {OSSL_FUNC_CIPHER_GETTABLE_PARAMS, (void (*)(void))p_scossl_aes_generic_gettable_params},            \
         {OSSL_FUNC_CIPHER_GETTABLE_CTX_PARAMS, (void (*)(void))p_scossl_aes_##lcmode##_gettable_ctx_params}, \
         {OSSL_FUNC_CIPHER_SETTABLE_CTX_PARAMS, (void (*)(void))p_scossl_aes_##lcmode##_settable_ctx_params}, \
+        {OSSL_FUNC_CIPHER_ENCRYPT_SKEY_INIT, (void (*)(void))p_scossl_aes_##lcmode##_skey_encrypt_init},     \
+        {OSSL_FUNC_CIPHER_DECRYPT_SKEY_INIT, (void (*)(void))p_scossl_aes_##lcmode##_skey_decrypt_init},     \
         {0, NULL}};
 
 IMPLEMENT_SCOSSL_AES_AEAD_CIPHER(128, SCOSSL_GCM_DEFAULT_IV_LENGTH, gcm, GCM)

--- a/SymCryptProvider/src/ciphers/p_scossl_aes_xts.c
+++ b/SymCryptProvider/src/ciphers/p_scossl_aes_xts.c
@@ -8,6 +8,7 @@
 
 #include "scossl_helpers.h"
 #include "p_scossl_aes.h"
+#include "p_scossl_skey.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -120,6 +121,19 @@ static SCOSSL_STATUS p_scossl_aes_xts_decrypt_init(_Inout_ SCOSSL_AES_XTS_CTX *c
     return p_scossl_aes_xts_init_internal(ctx, 0, key, keylen, iv, ivlen, params);
 }
 
+static SCOSSL_STATUS p_scossl_aes_xts_skey_encrypt_init(_Inout_ SCOSSL_AES_XTS_CTX *ctx, _In_ SCOSSL_SKEY *skey,
+                                                        _In_reads_bytes_opt_(keylen) const unsigned char *iv, size_t ivlen,
+                                                        _In_ const OSSL_PARAM params[])
+{
+    return p_scossl_aes_xts_init_internal((SCOSSL_AES_XTS_CTX *)ctx, 1, skey->pbKey, skey->cbKey, iv, ivlen, params);
+}
+
+static SCOSSL_STATUS p_scossl_aes_xts_skey_decrypt_init(_Inout_ SCOSSL_AES_XTS_CTX *ctx, _In_ SCOSSL_SKEY *skey,
+                                                        _In_reads_bytes_opt_(keylen) const unsigned char *iv, size_t ivlen,
+                                                        _In_ const OSSL_PARAM params[])
+{
+    return p_scossl_aes_xts_init_internal((SCOSSL_AES_XTS_CTX *)ctx, 0, skey->pbKey, skey->cbKey, iv, ivlen, params);
+}
 
 static SCOSSL_STATUS p_scossl_aes_xts_cipher(SCOSSL_AES_XTS_CTX *ctx,
                                              _Out_writes_bytes_(*outl) unsigned char *out, _Out_ size_t *outl, size_t outsize,
@@ -274,6 +288,8 @@ static SCOSSL_STATUS p_scossl_aes_xts_set_ctx_params(_Inout_ SCOSSL_AES_XTS_CTX 
         {OSSL_FUNC_CIPHER_GETTABLE_PARAMS, (void (*)(void))p_scossl_aes_generic_gettable_params},     \
         {OSSL_FUNC_CIPHER_GETTABLE_CTX_PARAMS, (void (*)(void))p_scossl_aes_xts_gettable_ctx_params}, \
         {OSSL_FUNC_CIPHER_SETTABLE_CTX_PARAMS, (void (*)(void))p_scossl_aes_xts_settable_ctx_params}, \
+        {OSSL_FUNC_CIPHER_ENCRYPT_SKEY_INIT, (void (*)(void))p_scossl_aes_xts_skey_encrypt_init},     \
+        {OSSL_FUNC_CIPHER_DECRYPT_SKEY_INIT, (void (*)(void))p_scossl_aes_xts_skey_decrypt_init},     \
         {0, NULL}};
 
 IMPLEMENT_SCOSSL_AES_XTS_CIPHER(128)

--- a/SymCryptProvider/src/ciphers/p_scossl_aes_xts.c
+++ b/SymCryptProvider/src/ciphers/p_scossl_aes_xts.c
@@ -125,14 +125,14 @@ static SCOSSL_STATUS p_scossl_aes_xts_skey_encrypt_init(_Inout_ SCOSSL_AES_XTS_C
                                                         _In_reads_bytes_opt_(ivlen) const unsigned char *iv, size_t ivlen,
                                                         _In_ const OSSL_PARAM params[])
 {
-    return p_scossl_aes_xts_init_internal((SCOSSL_AES_XTS_CTX *)ctx, 1, skey->pbKey, skey->cbKey, iv, ivlen, params);
+    return p_scossl_aes_xts_init_internal(ctx, 1, skey->pbKey, skey->cbKey, iv, ivlen, params);
 }
 
 static SCOSSL_STATUS p_scossl_aes_xts_skey_decrypt_init(_Inout_ SCOSSL_AES_XTS_CTX *ctx, _In_ SCOSSL_SKEY *skey,
                                                         _In_reads_bytes_opt_(ivlen) const unsigned char *iv, size_t ivlen,
                                                         _In_ const OSSL_PARAM params[])
 {
-    return p_scossl_aes_xts_init_internal((SCOSSL_AES_XTS_CTX *)ctx, 0, skey->pbKey, skey->cbKey, iv, ivlen, params);
+    return p_scossl_aes_xts_init_internal(ctx, 0, skey->pbKey, skey->cbKey, iv, ivlen, params);
 }
 
 static SCOSSL_STATUS p_scossl_aes_xts_cipher(SCOSSL_AES_XTS_CTX *ctx,

--- a/SymCryptProvider/src/ciphers/p_scossl_aes_xts.c
+++ b/SymCryptProvider/src/ciphers/p_scossl_aes_xts.c
@@ -122,14 +122,14 @@ static SCOSSL_STATUS p_scossl_aes_xts_decrypt_init(_Inout_ SCOSSL_AES_XTS_CTX *c
 }
 
 static SCOSSL_STATUS p_scossl_aes_xts_skey_encrypt_init(_Inout_ SCOSSL_AES_XTS_CTX *ctx, _In_ SCOSSL_SKEY *skey,
-                                                        _In_reads_bytes_opt_(keylen) const unsigned char *iv, size_t ivlen,
+                                                        _In_reads_bytes_opt_(ivlen) const unsigned char *iv, size_t ivlen,
                                                         _In_ const OSSL_PARAM params[])
 {
     return p_scossl_aes_xts_init_internal((SCOSSL_AES_XTS_CTX *)ctx, 1, skey->pbKey, skey->cbKey, iv, ivlen, params);
 }
 
 static SCOSSL_STATUS p_scossl_aes_xts_skey_decrypt_init(_Inout_ SCOSSL_AES_XTS_CTX *ctx, _In_ SCOSSL_SKEY *skey,
-                                                        _In_reads_bytes_opt_(keylen) const unsigned char *iv, size_t ivlen,
+                                                        _In_reads_bytes_opt_(ivlen) const unsigned char *iv, size_t ivlen,
                                                         _In_ const OSSL_PARAM params[])
 {
     return p_scossl_aes_xts_init_internal((SCOSSL_AES_XTS_CTX *)ctx, 0, skey->pbKey, skey->cbKey, iv, ivlen, params);

--- a/SymCryptProvider/src/mac/p_scossl_cmac.c
+++ b/SymCryptProvider/src/mac/p_scossl_cmac.c
@@ -4,6 +4,7 @@
 
 #include "scossl_mac.h"
 #include "p_scossl_base.h"
+#include "p_scossl_skey.h"
 
 #include <openssl/proverr.h>
 
@@ -42,6 +43,14 @@ static SCOSSL_STATUS p_scossl_cmac_init(_Inout_ SCOSSL_MAC_CTX *ctx,
     return p_scossl_cmac_set_ctx_params(ctx, params) &&
            scossl_mac_init(ctx, key, keylen);
 
+}
+
+static SCOSSL_STATUS p_scossl_cmac_init_skey(_Inout_ void *ctx,
+                                             _In_ SCOSSL_SKEY *skey,
+                                             _In_ const OSSL_PARAM params[])
+{
+    return p_scossl_cmac_set_ctx_params(ctx, params) &&
+           scossl_mac_init(ctx, skey->pbKey, skey->cbKey);
 }
 
 static const OSSL_PARAM *p_scossl_cmac_gettable_ctx_params(ossl_unused void *ctx, ossl_unused void *provctx)
@@ -130,6 +139,7 @@ const OSSL_DISPATCH p_scossl_cmac_functions[] = {
     {OSSL_FUNC_MAC_FREECTX, (void (*)(void))scossl_mac_freectx},
     {OSSL_FUNC_MAC_DUPCTX, (void (*)(void))scossl_mac_dupctx},
     {OSSL_FUNC_MAC_INIT, (void (*)(void))p_scossl_cmac_init},
+    {OSSL_FUNC_MAC_INIT_SKEY, (void (*)(void))p_scossl_cmac_init_skey},
     {OSSL_FUNC_MAC_UPDATE, (void (*)(void))scossl_mac_update},
     {OSSL_FUNC_MAC_FINAL, (void (*)(void))scossl_mac_final},
     {OSSL_FUNC_MAC_GETTABLE_CTX_PARAMS, (void (*)(void))p_scossl_cmac_gettable_ctx_params},

--- a/SymCryptProvider/src/p_scossl_base.c
+++ b/SymCryptProvider/src/p_scossl_base.c
@@ -519,7 +519,6 @@ static const OSSL_ALGORITHM p_scossl_encoder[] = {
     ALG_TABLE_END};
 
 // Symmetric key management
-#ifdef OSSL_OP_SKEYMGMT
 extern const OSSL_DISPATCH p_scossl_aes_skeymgmt_functions[];
 extern const OSSL_DISPATCH p_scossl_generic_skeymgmt_functions[];
 
@@ -527,7 +526,6 @@ static const OSSL_ALGORITHM p_scossl_skeymgmt[] = {
     ALG("AES", p_scossl_aes_skeymgmt_functions),
     ALG("GENERIC-SECRET", p_scossl_generic_skeymgmt_functions),
     ALG_TABLE_END};
-#endif // OSSL_OP_SKEYMGMT
 
 static SCOSSL_STATUS p_scossl_register_extended_algorithms()
 {
@@ -620,10 +618,8 @@ static const OSSL_ALGORITHM *p_scossl_query_operation(ossl_unused void *provctx,
         return p_scossl_decoder;
     case OSSL_OP_ENCODER:
         return p_scossl_encoder;
-#ifdef OSSL_OP_SKEYMGMT
     case OSSL_OP_SKEYMGMT:
         return p_scossl_skeymgmt;
-#endif
     }
 
     return NULL;

--- a/SymCryptProvider/src/p_scossl_base.c
+++ b/SymCryptProvider/src/p_scossl_base.c
@@ -518,6 +518,17 @@ static const OSSL_ALGORITHM p_scossl_encoder[] = {
     ENCODER_ENTRIES_ALL(SCOSSL_LN_MLKEM1024, mlkem1024)
     ALG_TABLE_END};
 
+// Symmetric key management
+#ifdef OSSL_OP_SKEYMGMT
+extern const OSSL_DISPATCH p_scossl_aes_skeymgmt_functions[];
+extern const OSSL_DISPATCH p_scossl_generic_skeymgmt_functions[];
+
+static const OSSL_ALGORITHM p_scossl_skeymgmt[] = {
+    ALG("AES", p_scossl_aes_skeymgmt_functions),
+    ALG("GENERIC-SECRET", p_scossl_kdf_keymgmt_functions),
+    ALG_TABLE_END};
+#endif // OSSL_OP_SKEYMGMT
+
 static SCOSSL_STATUS p_scossl_register_extended_algorithms()
 {
     return p_scossl_mlkem_register_algorithms();
@@ -609,6 +620,10 @@ static const OSSL_ALGORITHM *p_scossl_query_operation(ossl_unused void *provctx,
         return p_scossl_decoder;
     case OSSL_OP_ENCODER:
         return p_scossl_encoder;
+#ifdef OSSL_OP_SKEYMGMT
+    case OSSL_OP_SKEYMGMT:
+        return p_scossl_skeymgmt;
+#endif
     }
 
     return NULL;

--- a/SymCryptProvider/src/p_scossl_base.c
+++ b/SymCryptProvider/src/p_scossl_base.c
@@ -525,7 +525,7 @@ extern const OSSL_DISPATCH p_scossl_generic_skeymgmt_functions[];
 
 static const OSSL_ALGORITHM p_scossl_skeymgmt[] = {
     ALG("AES", p_scossl_aes_skeymgmt_functions),
-    ALG("GENERIC-SECRET", p_scossl_kdf_keymgmt_functions),
+    ALG("GENERIC-SECRET", p_scossl_generic_skeymgmt_functions),
     ALG_TABLE_END};
 #endif // OSSL_OP_SKEYMGMT
 

--- a/SymCryptProvider/src/p_scossl_skey.h
+++ b/SymCryptProvider/src/p_scossl_skey.h
@@ -1,0 +1,28 @@
+//
+// Copyright (c) Microsoft Corporation. Licensed under the MIT license.
+//
+
+#pragma once
+
+#include "scossl_helpers.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#define SCOSSL_SKEY_TYPE_GENERIC 1
+#define SCOSSL_SKEY_TYPE_AES 2
+
+typedef struct
+{
+    int type;
+
+    OSSL_LIB_CTX *libctx;
+
+    PBYTE pbKey;
+    SIZE_T cbKey;
+} SCOSSL_SKEY;
+
+#ifdef __cplusplus
+}
+#endif

--- a/SymCryptProvider/src/skeymgmt/p_scossl_aes_skeymgmt.c
+++ b/SymCryptProvider/src/skeymgmt/p_scossl_aes_skeymgmt.c
@@ -18,8 +18,7 @@ static const OSSL_PARAM p_scossl_aes_skeygen_settable_param_types[] = {
     OSSL_PARAM_size_t(OSSL_SKEY_PARAM_KEY_LENGTH, NULL),
     OSSL_PARAM_END};
 
-static void *p_scossl_aes_skeymgmt_import(_In_ SCOSSL_PROVCTX *provctx, int selection,
-                                          _In_ const OSSL_PARAM params[])
+static SCOSSL_SKEY *p_scossl_aes_skeymgmt_import(_In_ SCOSSL_PROVCTX *provctx, int selection, _In_ const OSSL_PARAM params[])
 {
     SCOSSL_SKEY *skey = p_scossl_generic_skeymgmt_import(provctx, selection, params);
 

--- a/SymCryptProvider/src/skeymgmt/p_scossl_aes_skeymgmt.c
+++ b/SymCryptProvider/src/skeymgmt/p_scossl_aes_skeymgmt.c
@@ -20,18 +20,61 @@ static const OSSL_PARAM p_scossl_aes_skeygen_settable_param_types[] = {
 
 static SCOSSL_SKEY *p_scossl_aes_skeymgmt_import(_In_ SCOSSL_PROVCTX *provctx, int selection, _In_ const OSSL_PARAM params[])
 {
-    SCOSSL_SKEY *skey = p_scossl_generic_skeymgmt_import(provctx, selection, params);
+    const OSSL_PARAM *p;
+    PCBYTE pcbKey = NULL;
+    SIZE_T cbKey = 0;
+    SCOSSL_SKEY *skey = NULL;
+    SCOSSL_STATUS status = SCOSSL_FAILURE;
 
-    if (skey != NULL)
+    if ((selection & OSSL_SKEYMGMT_SELECT_SECRET_KEY) == 0)
     {
-        skey->type = SCOSSL_SKEY_TYPE_AES;
+        goto cleanup;
+    }
 
-        if (skey->cbKey != 16 && skey->cbKey != 24 && skey->cbKey != 32)
-        {
-            ERR_raise(ERR_LIB_PROV, PROV_R_INVALID_KEY_LENGTH);
-            p_scossl_generic_skeymgmt_free(skey);
-            skey = NULL;
-        }
+    if ((p = OSSL_PARAM_locate_const(params, OSSL_SKEY_PARAM_RAW_BYTES)) == NULL)
+    {
+        ERR_raise(ERR_LIB_PROV, PROV_R_MISSING_KEY);
+        goto cleanup;
+    }
+
+    if (!OSSL_PARAM_get_octet_string_ptr(p, (const void **)&pcbKey, &cbKey))
+    {
+        ERR_raise(ERR_LIB_PROV, PROV_R_FAILED_TO_GET_PARAMETER);
+        goto cleanup;
+    }
+
+    if (pcbKey == NULL || cbKey == 0 ||
+        (cbKey != 16 && cbKey != 24 && cbKey != 32))
+    {
+        ERR_raise(ERR_LIB_PROV, PROV_R_INVALID_KEY_LENGTH);
+        goto cleanup;
+    }
+
+    skey = p_scossl_generic_skeymgmt_new(provctx->libctx);
+    if (skey == NULL)
+    {
+        ERR_raise(ERR_LIB_PROV, ERR_R_MALLOC_FAILURE);
+        goto cleanup;
+    }
+
+    skey->pbKey = OPENSSL_secure_malloc(cbKey);
+    if (skey->pbKey == NULL)
+    {
+        ERR_raise(ERR_LIB_PROV, ERR_R_MALLOC_FAILURE);
+        goto cleanup;
+    }
+
+    skey->type = SCOSSL_SKEY_TYPE_AES;
+    skey->cbKey = cbKey;
+    memcpy(skey->pbKey, pcbKey, cbKey);
+
+    status = SCOSSL_SUCCESS;
+
+cleanup:
+    if (status != SCOSSL_SUCCESS)
+    {
+        p_scossl_generic_skeymgmt_free(skey);
+        skey = NULL;
     }
 
     return skey;
@@ -50,18 +93,55 @@ static SCOSSL_STATUS p_scossl_aes_skeymgmt_export(_In_ SCOSSL_SKEY *skey, int se
 
 static SCOSSL_SKEY *p_scossl_aes_skeygen_generate(_In_ SCOSSL_PROVCTX *provctx, _In_ const OSSL_PARAM params[])
 {
-    SCOSSL_SKEY *skey = p_scossl_generic_skeygen_generate(provctx, params);
+   const OSSL_PARAM *p;
+    SIZE_T cbKey = 0;
+    SCOSSL_SKEY *skey = NULL;
+    SCOSSL_STATUS status = SCOSSL_FAILURE;
 
-    if (skey != NULL)
+    if ((p = OSSL_PARAM_locate_const(params, OSSL_SKEY_PARAM_KEY_LENGTH)) == NULL)
     {
-        skey->type = SCOSSL_SKEY_TYPE_AES;
+        ERR_raise(ERR_LIB_PROV, PROV_R_MISSING_KEY);
+        goto cleanup;
+    }
 
-        if (skey->cbKey != 16 && skey->cbKey != 24 && skey->cbKey != 32)
-        {
-            ERR_raise(ERR_LIB_PROV, PROV_R_INVALID_KEY_LENGTH);
-            p_scossl_generic_skeymgmt_free(skey);
-            skey = NULL;
-        }
+    if (!OSSL_PARAM_get_size_t(p, &cbKey))
+    {
+        ERR_raise(ERR_LIB_PROV, PROV_R_FAILED_TO_GET_PARAMETER);
+        goto cleanup;
+    }
+
+    if (cbKey == 0 ||
+        (cbKey != 16 && cbKey != 24 && cbKey != 32))
+    {
+        ERR_raise(ERR_LIB_PROV, PROV_R_INVALID_KEY_LENGTH);
+        goto cleanup;
+    }
+
+    skey = p_scossl_generic_skeymgmt_new(provctx->libctx);
+    if (skey == NULL)
+    {
+        ERR_raise(ERR_LIB_PROV, ERR_R_MALLOC_FAILURE);
+        goto cleanup;
+    }
+
+    skey->pbKey = OPENSSL_secure_malloc(cbKey);
+    if (skey->pbKey == NULL)
+    {
+        ERR_raise(ERR_LIB_PROV, ERR_R_MALLOC_FAILURE);
+        goto cleanup;
+    }
+
+    skey->type = SCOSSL_SKEY_TYPE_AES;
+    skey->cbKey = cbKey;
+    SymCryptRandom(skey->pbKey, cbKey);
+
+    status = SCOSSL_SUCCESS;
+
+cleanup:
+    if (status != SCOSSL_SUCCESS)
+    {
+        p_scossl_generic_skeymgmt_free(skey);
+        skey = NULL;
     }
 
     return skey;

--- a/SymCryptProvider/src/skeymgmt/p_scossl_aes_skeymgmt.c
+++ b/SymCryptProvider/src/skeymgmt/p_scossl_aes_skeymgmt.c
@@ -1,0 +1,92 @@
+//
+// Copyright (c) Microsoft Corporation. Licensed under the MIT license.
+//
+
+#include <openssl/proverr.h>
+
+#include "p_scossl_generic_skeymgmt.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+static const OSSL_PARAM p_scossl_aes_skeymgmt_settable_param_types[] = {
+    OSSL_PARAM_octet_string(OSSL_SKEY_PARAM_RAW_BYTES, NULL, 0),
+    OSSL_PARAM_END};
+
+static const OSSL_PARAM p_scossl_aes_skeygen_settable_param_types[] = {
+    OSSL_PARAM_size_t(OSSL_SKEY_PARAM_KEY_LENGTH, NULL),
+    OSSL_PARAM_END};
+
+static void *p_scossl_aes_skeymgmt_import(_In_ SCOSSL_PROVCTX *provctx, int selection,
+                                          _In_ const OSSL_PARAM params[])
+{
+    SCOSSL_SKEY *skey = p_scossl_generic_skeymgmt_import(provctx, selection, params);
+
+    if (skey != NULL)
+    {
+        skey->type = SCOSSL_SKEY_TYPE_AES;
+
+        if (skey->cbKey != 16 && skey->cbKey != 24 && skey->cbKey != 32)
+        {
+            ERR_raise(ERR_LIB_PROV, PROV_R_INVALID_KEY_LENGTH);
+            p_scossl_generic_skeymgmt_free(skey);
+            skey = NULL;
+        }
+    }
+
+    return skey;
+}
+
+static SCOSSL_STATUS p_scossl_aes_skeymgmt_export(_In_ SCOSSL_SKEY *skey, int selection,
+                                                  _In_ OSSL_CALLBACK *param_cb, _In_ void *cbarg)
+{
+    if (skey->type != SCOSSL_SKEY_TYPE_AES)
+    {
+        return SCOSSL_FAILURE;
+    }
+
+    return p_scossl_generic_skeymgmt_export(skey, selection, param_cb, cbarg);
+}
+
+static SCOSSL_SKEY *p_scossl_aes_skeygen_generate(_In_ SCOSSL_PROVCTX *provctx, _In_ const OSSL_PARAM params[])
+{
+    SCOSSL_SKEY *skey = p_scossl_generic_skeygen_generate(provctx, params);
+
+    if (skey != NULL)
+    {
+        skey->type = SCOSSL_SKEY_TYPE_AES;
+
+        if (skey->cbKey != 16 && skey->cbKey != 24 && skey->cbKey != 32)
+        {
+            ERR_raise(ERR_LIB_PROV, PROV_R_INVALID_KEY_LENGTH);
+            p_scossl_generic_skeymgmt_free(skey);
+            skey = NULL;
+        }
+    }
+
+    return skey;
+}
+
+static const OSSL_PARAM *p_scossl_aes_skeymgmt_imp_settable_params(ossl_unused void *provctx)
+{
+    return p_scossl_aes_skeymgmt_settable_param_types;
+}
+
+static const OSSL_PARAM *p_scossl_aes_skeygen_settable_params(ossl_unused void *provctx)
+{
+    return p_scossl_aes_skeygen_settable_param_types;
+}
+
+const OSSL_DISPATCH p_scossl_aes_skeymgmt_functions[] = {
+    {OSSL_FUNC_SKEYMGMT_FREE, (void (*)(void))p_scossl_generic_skeymgmt_free},
+    {OSSL_FUNC_SKEYMGMT_IMPORT, (void (*)(void))p_scossl_aes_skeymgmt_import},
+    {OSSL_FUNC_SKEYMGMT_EXPORT, (void (*)(void))p_scossl_aes_skeymgmt_export},
+    {OSSL_FUNC_SKEYMGMT_GENERATE, (void (*)(void))p_scossl_aes_skeygen_generate},
+    {OSSL_FUNC_SKEYMGMT_IMP_SETTABLE_PARAMS, (void (*)(void))p_scossl_aes_skeymgmt_imp_settable_params},
+    {OSSL_FUNC_SKEYMGMT_GEN_SETTABLE_PARAMS, (void (*)(void))p_scossl_aes_skeygen_settable_params},
+    {0, NULL}};
+
+#ifdef __cplusplus
+}
+#endif

--- a/SymCryptProvider/src/skeymgmt/p_scossl_generic_skeymgmt.c
+++ b/SymCryptProvider/src/skeymgmt/p_scossl_generic_skeymgmt.c
@@ -41,7 +41,7 @@ void p_scossl_generic_skeymgmt_free(SCOSSL_SKEY *skey)
 }
 
 _Use_decl_annotations_
-void *p_scossl_generic_skeymgmt_import(SCOSSL_PROVCTX *provctx, int selection, const OSSL_PARAM params[])
+SCOSSL_SKEY *p_scossl_generic_skeymgmt_import(SCOSSL_PROVCTX *provctx, int selection, const OSSL_PARAM params[])
 {
     const OSSL_PARAM *p;
     PCBYTE pcbKey = NULL;

--- a/SymCryptProvider/src/skeymgmt/p_scossl_generic_skeymgmt.c
+++ b/SymCryptProvider/src/skeymgmt/p_scossl_generic_skeymgmt.c
@@ -121,7 +121,7 @@ SCOSSL_STATUS p_scossl_generic_skeymgmt_export(SCOSSL_SKEY *skey, int selection,
 }
 
 _Use_decl_annotations_
-SCOSSL_SKEY *p_scossl_generic_skeymgmt_generate(SCOSSL_PROVCTX *provctx, const OSSL_PARAM params[])
+SCOSSL_SKEY *p_scossl_generic_skeygen_generate(SCOSSL_PROVCTX *provctx, const OSSL_PARAM params[])
 {
     const OSSL_PARAM *p;
     SIZE_T cbKey = 0;

--- a/SymCryptProvider/src/skeymgmt/p_scossl_generic_skeymgmt.c
+++ b/SymCryptProvider/src/skeymgmt/p_scossl_generic_skeymgmt.c
@@ -1,0 +1,196 @@
+//
+// Copyright (c) Microsoft Corporation. Licensed under the MIT license.
+//
+
+#include <openssl/proverr.h>
+
+#include "p_scossl_generic_skeymgmt.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+static const OSSL_PARAM p_scossl_generic_skeymgmt_settable_param_types[] = {
+    OSSL_PARAM_octet_string(OSSL_SKEY_PARAM_RAW_BYTES, NULL, 0),
+    OSSL_PARAM_END};
+
+static const OSSL_PARAM p_scossl_generic_skeygen_settable_param_types[] = {
+    OSSL_PARAM_size_t(OSSL_SKEY_PARAM_KEY_LENGTH, NULL),
+    OSSL_PARAM_END};
+
+SCOSSL_SKEY *p_scossl_generic_skeymgmt_new(_In_ OSSL_LIB_CTX *libctx)
+{
+    SCOSSL_SKEY *skey = OPENSSL_zalloc(sizeof(SCOSSL_SKEY));
+    if (skey != NULL)
+    {
+        skey->libctx = libctx;
+        skey->type = SCOSSL_SKEY_TYPE_GENERIC;
+    }
+
+    return skey;
+}
+
+_Use_decl_annotations_
+void p_scossl_generic_skeymgmt_free(SCOSSL_SKEY *skey)
+{
+    if (skey == NULL)
+        return;
+
+    OPENSSL_secure_clear_free(skey->pbKey, skey->cbKey);
+    OPENSSL_free(skey);
+}
+
+_Use_decl_annotations_
+void *p_scossl_generic_skeymgmt_import(SCOSSL_PROVCTX *provctx, int selection, const OSSL_PARAM params[])
+{
+    const OSSL_PARAM *p;
+    PCBYTE pcbKey = NULL;
+    SIZE_T cbKey = 0;
+    SCOSSL_SKEY *skey = NULL;
+    SCOSSL_STATUS status = SCOSSL_FAILURE;
+
+    if ((selection & OSSL_SKEYMGMT_SELECT_SECRET_KEY) == 0)
+    {
+        goto cleanup;
+    }
+
+    if ((p = OSSL_PARAM_locate_const(params, OSSL_SKEY_PARAM_RAW_BYTES)) != NULL)
+    {
+        if (!OSSL_PARAM_get_octet_string_ptr(p, (const void **)&pcbKey, &cbKey))
+        {
+            ERR_raise(ERR_LIB_PROV, PROV_R_FAILED_TO_GET_PARAMETER);
+            goto cleanup;
+        }
+
+        if (pcbKey == NULL)
+        {
+            goto cleanup;
+        }
+
+        skey = p_scossl_generic_skeymgmt_new(provctx->libctx);
+        if (skey == NULL)
+        {
+            ERR_raise(ERR_LIB_PROV, ERR_R_MALLOC_FAILURE);
+            goto cleanup;
+        }
+
+        skey->pbKey = OPENSSL_secure_malloc(cbKey);
+        if (skey->pbKey == NULL)
+        {
+            ERR_raise(ERR_LIB_PROV, ERR_R_MALLOC_FAILURE);
+            goto cleanup;
+        }
+
+        skey->cbKey = cbKey;
+        memcpy(skey->pbKey, pcbKey, cbKey);
+    }
+
+    status = SCOSSL_SUCCESS;
+
+cleanup:
+    if (status != SCOSSL_SUCCESS)
+    {
+        p_scossl_generic_skeymgmt_free(skey);
+        skey = NULL;
+    }
+
+    return skey;
+}
+
+_Use_decl_annotations_
+SCOSSL_STATUS p_scossl_generic_skeymgmt_export(SCOSSL_SKEY *skey, int selection,
+                                               OSSL_CALLBACK *param_cb, void *cbarg)
+{
+    OSSL_PARAM params[2];
+
+    if (skey == NULL)
+    {
+        ERR_raise(ERR_LIB_PROV, ERR_R_PASSED_NULL_PARAMETER);
+        return SCOSSL_FAILURE;
+    }
+
+    if ((selection & OSSL_SKEYMGMT_SELECT_SECRET_KEY) == 0)
+    {
+        return SCOSSL_FAILURE;
+    }
+
+    params[0] = OSSL_PARAM_construct_octet_string(OSSL_SKEY_PARAM_RAW_BYTES, skey->pbKey, skey->cbKey);
+    params[1] = OSSL_PARAM_construct_end();
+
+    return param_cb(params, cbarg);
+}
+
+_Use_decl_annotations_
+SCOSSL_SKEY *p_scossl_generic_skeymgmt_generate(SCOSSL_PROVCTX *provctx, const OSSL_PARAM params[])
+{
+    const OSSL_PARAM *p;
+    SIZE_T cbKey = 0;
+    SCOSSL_SKEY *skey = NULL;
+    SCOSSL_STATUS status = SCOSSL_FAILURE;
+
+    if ((p = OSSL_PARAM_locate_const(params, OSSL_SKEY_PARAM_KEY_LENGTH)) != NULL)
+    {
+        if (!OSSL_PARAM_get_size_t(p, &cbKey))
+        {
+            ERR_raise(ERR_LIB_PROV, PROV_R_FAILED_TO_GET_PARAMETER);
+            goto cleanup;
+        }
+
+        if (cbKey == 0)
+        {
+            goto cleanup;
+        }
+
+        skey = p_scossl_generic_skeymgmt_new(provctx->libctx);
+        if (skey == NULL)
+        {
+            ERR_raise(ERR_LIB_PROV, ERR_R_MALLOC_FAILURE);
+            goto cleanup;
+        }
+
+        skey->pbKey = OPENSSL_secure_malloc(cbKey);
+        if (skey->pbKey == NULL)
+        {
+            ERR_raise(ERR_LIB_PROV, ERR_R_MALLOC_FAILURE);
+            goto cleanup;
+        }
+
+        SymCryptRandom(skey->pbKey, cbKey);
+        skey->cbKey = cbKey;
+
+    }
+
+    status = SCOSSL_SUCCESS;
+
+cleanup:
+    if (status != SCOSSL_SUCCESS)
+    {
+        p_scossl_generic_skeymgmt_free(skey);
+        skey = NULL;
+    }
+
+    return skey;
+}
+
+static const OSSL_PARAM *p_scossl_generic_skeymgmt_settable_params(ossl_unused void *provctx)
+{
+    return p_scossl_generic_skeymgmt_settable_param_types;
+}
+
+static const OSSL_PARAM *p_scossl_generic_skeygen_settable_params(ossl_unused void *provctx)
+{
+    return p_scossl_generic_skeygen_settable_param_types;
+}
+
+const OSSL_DISPATCH p_scossl_generic_skeymgmt_functions[] = {
+    {OSSL_FUNC_SKEYMGMT_FREE, (void (*)(void))p_scossl_generic_skeymgmt_free},
+    {OSSL_FUNC_SKEYMGMT_IMPORT, (void (*)(void))p_scossl_generic_skeymgmt_import},
+    {OSSL_FUNC_SKEYMGMT_EXPORT, (void (*)(void))p_scossl_generic_skeymgmt_export},
+    {OSSL_FUNC_SKEYMGMT_GENERATE, (void (*)(void))p_scossl_generic_skeygen_generate},
+    {OSSL_FUNC_SKEYMGMT_IMP_SETTABLE_PARAMS, (void (*)(void))p_scossl_generic_skeymgmt_settable_params},
+    {OSSL_FUNC_SKEYMGMT_GEN_SETTABLE_PARAMS, (void (*)(void))p_scossl_generic_skeygen_settable_params},
+    {0, NULL}};
+
+#ifdef __cplusplus
+}
+#endif

--- a/SymCryptProvider/src/skeymgmt/p_scossl_generic_skeymgmt.c
+++ b/SymCryptProvider/src/skeymgmt/p_scossl_generic_skeymgmt.c
@@ -18,7 +18,8 @@ static const OSSL_PARAM p_scossl_generic_skeygen_settable_param_types[] = {
     OSSL_PARAM_size_t(OSSL_SKEY_PARAM_KEY_LENGTH, NULL),
     OSSL_PARAM_END};
 
-SCOSSL_SKEY *p_scossl_generic_skeymgmt_new(_In_ OSSL_LIB_CTX *libctx)
+_Use_decl_annotations_
+SCOSSL_SKEY *p_scossl_generic_skeymgmt_new(OSSL_LIB_CTX *libctx)
 {
     SCOSSL_SKEY *skey = OPENSSL_zalloc(sizeof(SCOSSL_SKEY));
     if (skey != NULL)
@@ -40,8 +41,7 @@ void p_scossl_generic_skeymgmt_free(SCOSSL_SKEY *skey)
     OPENSSL_free(skey);
 }
 
-_Use_decl_annotations_
-SCOSSL_SKEY *p_scossl_generic_skeymgmt_import(SCOSSL_PROVCTX *provctx, int selection, const OSSL_PARAM params[])
+SCOSSL_SKEY *p_scossl_generic_skeymgmt_import(_In_ SCOSSL_PROVCTX *provctx, int selection, _In_ const OSSL_PARAM params[])
 {
     const OSSL_PARAM *p;
     PCBYTE pcbKey = NULL;
@@ -54,36 +54,37 @@ SCOSSL_SKEY *p_scossl_generic_skeymgmt_import(SCOSSL_PROVCTX *provctx, int selec
         goto cleanup;
     }
 
-    if ((p = OSSL_PARAM_locate_const(params, OSSL_SKEY_PARAM_RAW_BYTES)) != NULL)
+    if ((p = OSSL_PARAM_locate_const(params, OSSL_SKEY_PARAM_RAW_BYTES)) == NULL)
     {
-        if (!OSSL_PARAM_get_octet_string_ptr(p, (const void **)&pcbKey, &cbKey))
-        {
-            ERR_raise(ERR_LIB_PROV, PROV_R_FAILED_TO_GET_PARAMETER);
-            goto cleanup;
-        }
+        ERR_raise(ERR_LIB_PROV, PROV_R_MISSING_KEY);
+        goto cleanup;
+    }
 
-        if (pcbKey == NULL)
-        {
-            goto cleanup;
-        }
+    if (!OSSL_PARAM_get_octet_string_ptr(p, (const void **)&pcbKey, &cbKey))
+    {
+        ERR_raise(ERR_LIB_PROV, PROV_R_FAILED_TO_GET_PARAMETER);
+        goto cleanup;
+    }
 
-        skey = p_scossl_generic_skeymgmt_new(provctx->libctx);
-        if (skey == NULL)
-        {
-            ERR_raise(ERR_LIB_PROV, ERR_R_MALLOC_FAILURE);
-            goto cleanup;
-        }
+    skey = p_scossl_generic_skeymgmt_new(provctx->libctx);
+    if (skey == NULL)
+    {
+        ERR_raise(ERR_LIB_PROV, ERR_R_MALLOC_FAILURE);
+        goto cleanup;
+    }
 
+    if (cbKey > 0)
+    {
         skey->pbKey = OPENSSL_secure_malloc(cbKey);
         if (skey->pbKey == NULL)
         {
             ERR_raise(ERR_LIB_PROV, ERR_R_MALLOC_FAILURE);
             goto cleanup;
         }
-
-        skey->cbKey = cbKey;
         memcpy(skey->pbKey, pcbKey, cbKey);
     }
+
+    skey->cbKey = cbKey;
 
     status = SCOSSL_SUCCESS;
 
@@ -114,51 +115,50 @@ SCOSSL_STATUS p_scossl_generic_skeymgmt_export(SCOSSL_SKEY *skey, int selection,
         return SCOSSL_FAILURE;
     }
 
-    params[0] = OSSL_PARAM_construct_octet_string(OSSL_SKEY_PARAM_RAW_BYTES, skey->pbKey, skey->cbKey);
+    params[0] = OSSL_PARAM_construct_octet_string(OSSL_SKEY_PARAM_RAW_BYTES, skey->cbKey > 0 ? skey->pbKey : "", skey->cbKey);
     params[1] = OSSL_PARAM_construct_end();
 
     return param_cb(params, cbarg);
 }
 
-_Use_decl_annotations_
-SCOSSL_SKEY *p_scossl_generic_skeygen_generate(SCOSSL_PROVCTX *provctx, const OSSL_PARAM params[])
+SCOSSL_SKEY *p_scossl_generic_skeygen_generate(_In_ SCOSSL_PROVCTX *provctx, _In_ const OSSL_PARAM params[])
 {
     const OSSL_PARAM *p;
     SIZE_T cbKey = 0;
     SCOSSL_SKEY *skey = NULL;
     SCOSSL_STATUS status = SCOSSL_FAILURE;
 
-    if ((p = OSSL_PARAM_locate_const(params, OSSL_SKEY_PARAM_KEY_LENGTH)) != NULL)
+    if ((p = OSSL_PARAM_locate_const(params, OSSL_SKEY_PARAM_KEY_LENGTH)) == NULL)
     {
-        if (!OSSL_PARAM_get_size_t(p, &cbKey))
-        {
-            ERR_raise(ERR_LIB_PROV, PROV_R_FAILED_TO_GET_PARAMETER);
-            goto cleanup;
-        }
+        ERR_raise(ERR_LIB_PROV, PROV_R_MISSING_KEY);
+        goto cleanup;
+    }
 
-        if (cbKey == 0)
-        {
-            goto cleanup;
-        }
+    if (!OSSL_PARAM_get_size_t(p, &cbKey))
+    {
+        ERR_raise(ERR_LIB_PROV, PROV_R_FAILED_TO_GET_PARAMETER);
+        goto cleanup;
+    }
 
-        skey = p_scossl_generic_skeymgmt_new(provctx->libctx);
-        if (skey == NULL)
-        {
-            ERR_raise(ERR_LIB_PROV, ERR_R_MALLOC_FAILURE);
-            goto cleanup;
-        }
+    skey = p_scossl_generic_skeymgmt_new(provctx->libctx);
+    if (skey == NULL)
+    {
+        ERR_raise(ERR_LIB_PROV, ERR_R_MALLOC_FAILURE);
+        goto cleanup;
+    }
 
+    if (cbKey > 0)
+    {
         skey->pbKey = OPENSSL_secure_malloc(cbKey);
         if (skey->pbKey == NULL)
         {
             ERR_raise(ERR_LIB_PROV, ERR_R_MALLOC_FAILURE);
             goto cleanup;
         }
-
         SymCryptRandom(skey->pbKey, cbKey);
-        skey->cbKey = cbKey;
-
     }
+
+    skey->cbKey = cbKey;
 
     status = SCOSSL_SUCCESS;
 

--- a/SymCryptProvider/src/skeymgmt/p_scossl_generic_skeymgmt.h
+++ b/SymCryptProvider/src/skeymgmt/p_scossl_generic_skeymgmt.h
@@ -13,7 +13,7 @@ extern "C" {
 
 void p_scossl_generic_skeymgmt_free(_Inout_ SCOSSL_SKEY *skey);
 
-void *p_scossl_generic_skeymgmt_import(_In_ SCOSSL_PROVCTX *provctx, int selection, _In_ const OSSL_PARAM params[]);
+SCOSSL_SKEY *p_scossl_generic_skeymgmt_import(_In_ SCOSSL_PROVCTX *provctx, int selection, _In_ const OSSL_PARAM params[]);
 SCOSSL_STATUS p_scossl_generic_skeymgmt_export(_In_ SCOSSL_SKEY *skey, int selection,
                                                _In_ OSSL_CALLBACK *param_cb, _In_ void *cbarg);
 

--- a/SymCryptProvider/src/skeymgmt/p_scossl_generic_skeymgmt.h
+++ b/SymCryptProvider/src/skeymgmt/p_scossl_generic_skeymgmt.h
@@ -1,0 +1,24 @@
+//
+// Copyright (c) Microsoft Corporation. Licensed under the MIT license.
+//
+
+#pragma once
+
+#include "p_scossl_base.h"
+#include "p_scossl_skey.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+void p_scossl_generic_skeymgmt_free(_Inout_ SCOSSL_SKEY *skey);
+
+void *p_scossl_generic_skeymgmt_import(_In_ SCOSSL_PROVCTX *provctx, int selection, _In_ const OSSL_PARAM params[]);
+SCOSSL_STATUS p_scossl_generic_skeymgmt_export(_In_ SCOSSL_SKEY *skey, int selection,
+                                               _In_ OSSL_CALLBACK *param_cb, _In_ void *cbarg);
+
+SCOSSL_SKEY *p_scossl_generic_skeygen_generate(_In_ SCOSSL_PROVCTX *provctx, _In_ const OSSL_PARAM params[]);
+
+#ifdef __cplusplus
+}
+#endif

--- a/SymCryptProvider/src/skeymgmt/p_scossl_generic_skeymgmt.h
+++ b/SymCryptProvider/src/skeymgmt/p_scossl_generic_skeymgmt.h
@@ -11,13 +11,11 @@
 extern "C" {
 #endif
 
+SCOSSL_SKEY *p_scossl_generic_skeymgmt_new(_In_ OSSL_LIB_CTX *libctx);
 void p_scossl_generic_skeymgmt_free(_Inout_ SCOSSL_SKEY *skey);
 
-SCOSSL_SKEY *p_scossl_generic_skeymgmt_import(_In_ SCOSSL_PROVCTX *provctx, int selection, _In_ const OSSL_PARAM params[]);
 SCOSSL_STATUS p_scossl_generic_skeymgmt_export(_In_ SCOSSL_SKEY *skey, int selection,
                                                _In_ OSSL_CALLBACK *param_cb, _In_ void *cbarg);
-
-SCOSSL_SKEY *p_scossl_generic_skeygen_generate(_In_ SCOSSL_PROVCTX *provctx, _In_ const OSSL_PARAM params[]);
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
OpenSSL 3.5 added [SKEYs](https://docs.openssl.org/3.5/man7/provider-skeymgmt) for opaque symmetric key management. This PR adds support for the new key types to the SymCrypt provider.

- Add generic and AES SKEY keymgmt interfaces
- Add support for AES SKEYs to AES cipher interfaces
- Add support for AES SKEYs to CMAC interface